### PR TITLE
Remove to `.merge`.

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -156,20 +156,6 @@ module ActiveRecord
         end
       end
 
-      def merge(*)
-        # このタイミングで先読みしているアソシエーションが読み込まれるので時間を固定
-        if valid_datetime
-          relations = ActiveRecord::Bitemporal.valid_at(valid_datetime) { super }
-        else
-          relations = super
-        end
-        relations
-        relations.each do |record|
-          record.bitemporal_option_merge! bitemporal_option.except(:ignore_valid_datetime)
-        end
-        relations
-      end
-
       def build_arel(args = nil)
         ActiveRecord::Bitemporal.with_bitemporal_option(bitemporal_option) {
           super.tap { |arel|

--- a/spec/activerecord-bitemporal/relation_spec.rb
+++ b/spec/activerecord-bitemporal/relation_spec.rb
@@ -144,6 +144,7 @@ RSpec.describe "Relation" do
     let(:relation) { Company.valid_at("2019/1/1").merge(Company.valid_at("2019/2/2")) }
     subject { relation.bitemporal_option }
     it { is_expected.to include(valid_datetime: "2019/2/2") }
+    it { expect(relation.loaded?).to be_falsey }
   end
 
   describe ".ignore_valid_datetime" do


### PR DESCRIPTION
Removed `.merge` hooked to ActiveRecord.

## Problem

Record loaded when call `.merge`.

```ruby
pp Company.merge(Company.where(name: "hoge")).loaded?
# => true
```

Using `.merge` may result in duplicate records being load.

## Fix

Removed `.merge` hooked to ActiveRecord.


## Before

```ruby
pp Company.merge(Company.where(name: "hoge")).loaded?
# => true
```

## After

```ruby
pp Company.merge(Company.where(name: "hoge")).loaded?
# => nil
```
