### PR TITLE
Remove block argument from `.valid_at` and `.ignore_valid_datetime`.

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -48,7 +48,7 @@ module ActiveRecord
     #   # in valid_datetime is "2018/4/1".
     # }
     module ::ActiveRecord::Bitemporal
-      class <<self
+      class << self
         include Optionable
 
         def valid_at(datetime, &block)

--- a/lib/activerecord-bitemporal/patches.rb
+++ b/lib/activerecord-bitemporal/patches.rb
@@ -57,7 +57,7 @@ module ActiveRecord::Bitemporal
         scope = super
         return scope unless scope.bi_temporal_model?
 
-        scope.merge!(klass.valid_at(klass.try(:valid_datetime) || owner.try(:valid_datetime))) if klass&.bi_temporal_model?
+        scope.merge!(klass.valid_at(owner.valid_datetime)) if owner.class&.bi_temporal_model? && owner.valid_datetime
         return scope
       end
 

--- a/spec/activerecord-bitemporal/association_spec.rb
+++ b/spec/activerecord-bitemporal/association_spec.rb
@@ -190,12 +190,12 @@ RSpec.describe "Association" do
       end
 
       describe ".valid_at" do
-        it { expect(Employee.valid_at(@time, &:count)).to eq 6 }
-        it { expect(company.employees.valid_at(@time, &:count)).to eq 3 }
-        it { expect(company2.employees.valid_at(@time, &:count)).to eq 0 }
-        it { expect(company.employees.valid_at(@time) { |m| m.where(name: "Jane").count }).to eq 1 }
-        it { expect(company.employees.valid_at(@time) { |m| m.where(name: "Tom").count }).to eq 1 }
-        it { expect(company.employees.valid_at(@time) { |m| m.where(name: "Homu").count }).to eq 0 }
+        it { expect(Employee.valid_at(@time).count).to eq 6 }
+        it { expect(company.employees.valid_at(@time).count).to eq 3 }
+        it { expect(company2.employees.valid_at(@time).count).to eq 0 }
+        it { expect(company.employees.valid_at(@time).where(name: "Jane").count).to eq 1 }
+        it { expect(company.employees.valid_at(@time).where(name: "Tom").count).to eq 1 }
+        it { expect(company.employees.valid_at(@time).where(name: "Homu").count).to eq 0 }
       end
 
       describe "preload" do

--- a/spec/activerecord-bitemporal/through_spec.rb
+++ b/spec/activerecord-bitemporal/through_spec.rb
@@ -126,8 +126,8 @@ RSpec.describe "has_xxx with through" do
 
     context "user.update" do
       before { Timecop.freeze(updated_at) { user.update(name: "Tom") } }
-      it { expect(blog.users.valid_at(created_at, &:all).first.name).to eq "Jane" }
-      it { expect(blog.users.valid_at(updated_at, &:all).first.name).to eq "Tom" }
+      it { expect(blog.users.valid_at(created_at).first.name).to eq "Jane" }
+      it { expect(blog.users.valid_at(updated_at).first.name).to eq "Tom" }
 
       it { expect(Blog.find_at_time(created_at, blog.id).users.first.name).to eq "Jane" }
       it { expect(Blog.find_at_time(updated_at, blog.id).users.first.name).to eq "Tom" }
@@ -138,11 +138,11 @@ RSpec.describe "has_xxx with through" do
 
     context "article.update" do
       before { Timecop.freeze(updated_at) { article.update(title: "sushi") } }
-      it { expect(blog.users.valid_at(created_at, &:all).first.articles.first.title).to eq "yakiniku" }
-      it { expect(blog.users.valid_at(updated_at, &:all).first.articles.first.title).to eq "sushi" }
+      it { expect(blog.users.valid_at(created_at).first.articles.first.title).to eq "yakiniku" }
+      it { expect(blog.users.valid_at(updated_at).first.articles.first.title).to eq "sushi" }
 
-      it { expect(blog.users.first.articles.valid_at(created_at, &:all).first.title).to eq "yakiniku" }
-      it { expect(blog.users.first.articles.valid_at(updated_at, &:all).first.title).to eq "sushi" }
+      it { expect(blog.users.first.articles.valid_at(created_at).first.title).to eq "yakiniku" }
+      it { expect(blog.users.first.articles.valid_at(updated_at).first.title).to eq "sushi" }
 
       it { expect(Blog.find_at_time(created_at, blog.id).users.first.articles.first.title).to eq "yakiniku" }
       it { expect(Blog.find_at_time(updated_at, blog.id).users.first.articles.first.title).to eq "sushi" }
@@ -152,8 +152,8 @@ RSpec.describe "has_xxx with through" do
       let(:user2) { User.create!(name: "Tom") }
       before { Timecop.freeze(updated_at) { article.update(user: user2) } }
 
-      it { expect(blog.users.valid_at(created_at, &:all).first.name).to eq "Jane" }
-      it { expect(blog.users.valid_at(updated_at, &:all).first.name).to eq "Tom" }
+      it { expect(blog.users.valid_at(created_at).first.name).to eq "Jane" }
+      it { expect(blog.users.valid_at(updated_at).first.name).to eq "Tom" }
 
       it { expect(Blog.find_at_time(created_at, blog.id).users.first.name).to eq "Jane" }
       it { expect(Blog.find_at_time(updated_at, blog.id).users.first.name).to eq "Tom" }


### PR DESCRIPTION
Removed block argument from `valid_at` and` ignore_valid_datetime` as they are no longer needed.
`.valid_at` and` .igore_valid_datetime` are used in a method chain.
Also `#valid_at` (and` #force_update`) continue to use blocks.

```ruby
company = nil
Timecop.freeze("2019/2/1") {
  company = Company.create(name: "Company")
}

Timecop.freeze("2019/3/1") {
  company.update(name: "Company2")
}

# NG : .valid_at is not have block argument. Block is not called.
company = Company.valid_at("2019/2/3") { |m| m.find_by(name "Company2") }

# OK : Chain after .valid_at
company = Company.valid_at("2019/2/3").find_by(name: "Company")

# OK : #valid_at is have block argument
company.valid_at("2019/2/10") { |m| m.update(name: "NeoCompany") }
```