### PR TITLE
`.valid_at` with `ignore_valid_datetime: false`

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -52,11 +52,11 @@ module ActiveRecord
         include Optionable
 
         def valid_at(datetime, &block)
-          with_bitemporal_option(valid_datetime: datetime, &block)
+          with_bitemporal_option(ignore_valid_datetime: false, valid_datetime: datetime, &block)
         end
 
         def valid_at!(datetime, &block)
-          with_bitemporal_option(valid_datetime: datetime, force: true, &block)
+          with_bitemporal_option(ignore_valid_datetime: false, valid_datetime: datetime, force: true, &block)
         end
 
         def valid_datetime
@@ -203,7 +203,7 @@ module ActiveRecord
 
       included do
         scope :valid_at, -> (datetime) {
-          with_bitemporal_option(valid_datetime: datetime)
+          with_bitemporal_option(ignore_valid_datetime: false, valid_datetime: datetime)
         }
         scope :ignore_valid_datetime, -> {
           with_bitemporal_option(ignore_valid_datetime: true)

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -1127,9 +1127,31 @@ RSpec.describe ActiveRecord::Bitemporal do
       end
     end
 
+    describe "ActiveRecord::Bitemporal.ignore_valid_datetime" do
+      it do
+        ActiveRecord::Bitemporal.ignore_valid_datetime {
+          expect(Employee.all.bitemporal_option).to include(ignore_valid_datetime: true)
+        }
+      end
+
+      context "nexted call `.valid_at`" do
+        it do
+          ActiveRecord::Bitemporal.ignore_valid_datetime {
+            ActiveRecord::Bitemporal.valid_at("2019/1/1") {
+              expect(Employee.all.bitemporal_option).to include(ignore_valid_datetime: false)
+            }
+          }
+        end
+      end
+    end
+
     describe ".ignore_valid_datetime" do
       it { expect(Employee.ignore_valid_datetime.bitemporal_option).to include(ignore_valid_datetime: true) }
       it { expect(Employee.ignore_valid_datetime.first.bitemporal_option.keys).not_to include(:ignore_valid_datetime) }
+
+      context "call `.valid_at` later" do
+        it { expect(Employee.ignore_valid_datetime.valid_at("2019/1/1").bitemporal_option).to include(ignore_valid_datetime: false) }
+      end
     end
   end
 


### PR DESCRIPTION
Calling `valid_at` after `ignore_valid_datetime` has no effect.
Set the `ignore_valid_datetime` option to false when called `.valid_at`.


## before

```ruby
# ignore valid_at
puts Company.ignore_valid_datetime.valid_at("2019/1/1").to_sql
# => SELECT "companies".* FROM "companies" WHERE "companies"."deleted_at" IS NULL
```


## after

```ruby
# within valid_form and valid_to
puts Company.ignore_valid_datetime.valid_at("2019/1/1").to_sql
# => SELECT "companies".* FROM "companies" WHERE "companies"."valid_from" <= '2019-01-01 00:00:00' AND "companies"."valid_to" > '2019-01-01 00:00:00' AND "companies"."deleted_at" IS NULL
```
