### PR TITLE
[WIP] Add extension scopes.

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -216,6 +216,16 @@ module ActiveRecord
         }
       end
 
+      module Extention
+        extend ActiveSupport::Concern
+
+        included do
+          scope :histories_for, -> (id) {
+            ignore_valid_datetime.where(bitemporal_id: id)
+          }
+        end
+      end
+
       module Experimental
         extend ActiveSupport::Concern
 

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -223,12 +223,12 @@ module ActiveRecord
           scope :bitemporal_histories_by, -> (id) {
             ignore_valid_datetime.where(bitemporal_id: id)
           }
-          scope :bitemporal_latest_by, -> (id) {
+          def self.bitemporal_latest_by(id)
             bitemporal_histories_by(id).order(valid_from: :asc).last
-          }
-          scope :bitemporal_oldest_by, -> (id) {
+          end
+          def self.bitemporal_oldest_by(id)
             bitemporal_histories_by(id).order(valid_from: :asc).first
-          }
+          end
         end
       end
 

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -220,8 +220,14 @@ module ActiveRecord
         extend ActiveSupport::Concern
 
         included do
-          scope :histories_for, -> (id) {
+          scope :bitemporal_histories_by, -> (id) {
             ignore_valid_datetime.where(bitemporal_id: id)
+          }
+          scope :bitemporal_latest_by, -> (id) {
+            bitemporal_histories_by(id).order(valid_from: :asc).last
+          }
+          scope :bitemporal_oldest_by, -> (id) {
+            bitemporal_histories_by(id).order(valid_from: :asc).first
           }
         end
       end

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -216,7 +216,7 @@ module ActiveRecord
         }
       end
 
-      module Extention
+      module Extension
         extend ActiveSupport::Concern
 
         included do

--- a/spec/activerecord-bitemporal/scopes_spec.rb
+++ b/spec/activerecord-bitemporal/scopes_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         EmployeeWithScope.create!(name: "Kevin").update(name: "Jane")
       end
       subject { EmployeeWithScope.bitemporal_histories_by(employee.id) }
-      it { expect(subject.count).to eq 3 }
+      it { expect(subject.pluck(:name)).to contain_exactly("Jane", "Tom", "Jane") }
       it { expect(subject.where(name: "Jane").count).to eq 2 }
       it { expect(subject.ids).to eq [employee.id, employee.id, employee.id] }
     end
@@ -47,6 +47,7 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
       it { expect(subject).to be_kind_of EmployeeWithScope }
       it { expect(subject.id).to eq employee.id }
       it { expect(subject.name).to eq "Jane" }
+      it { expect(subject.deleted_at).to be_nil }
     end
 
     describe ".bitemporal_oldest_by" do
@@ -60,6 +61,7 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
       it { expect(subject).to be_kind_of EmployeeWithScope }
       it { expect(subject.id).to eq employee.id }
       it { expect(subject.name).to eq "Jane" }
+      it { expect(subject.deleted_at).to be_nil }
     end
   end
 

--- a/spec/activerecord-bitemporal/scopes_spec.rb
+++ b/spec/activerecord-bitemporal/scopes_spec.rb
@@ -1,75 +1,128 @@
 require 'spec_helper'
 
 class EmployeeWithScope < Employee
+  include ActiveRecord::Bitemporal::Scope::Extention
   include ActiveRecord::Bitemporal::Scope::Experimental
 end
 
-RSpec.describe ActiveRecord::Bitemporal::Scope::Experimental do
-  shared_examples "defined records" do
+RSpec.describe ActiveRecord::Bitemporal::Scope do
+  describe ".within_deleted" do
     before do
-      emp1 = nil
-      emp2 = nil
-      Timecop.freeze("2019/1/10") {
-        emp1 = EmployeeWithScope.create(name: "Jane")
-        emp2 = EmployeeWithScope.create(name: "Homu")
-      }
-
-      Timecop.freeze("2019/1/17") {
-        emp1.update!(name: "Tom")
-        emp2.update!(name: "Mami")
-      }
-
-      Timecop.freeze("2019/1/25") {
-        emp1.update!(name: "Kevin")
-        emp2.update!(name: "Mado")
-      }
+      EmployeeWithScope.create!(name: "Kevin").update(name: "Jane")
     end
-  end
-
-  describe ".valid_in" do
-    include_context "defined records"
-    subject { EmployeeWithScope.valid_in(from: from, to: to).pluck(:name).flatten }
-
-    context "2019/1/5 - 2019/1/8" do
-      let(:from) { "2019/1/5" }
-      let(:to) { "2019/1/8" }
-      it { is_expected.to be_empty }
-    end
-
-    context "2019/1/5 - 2019/1/10" do
-      let(:from) { "2019/1/5" }
-      let(:to) { "2019/1/10" }
-      it { is_expected.to contain_exactly("Jane", "Homu") }
-
-      context "with .within_deleted" do
-        subject { EmployeeWithScope.valid_in(from: from, to: to).within_deleted.count }
-        it { is_expected.to eq 4 }
-      end
-    end
-
-    context "2019/1/5 - 2019/1/20" do
-      let(:from) { "2019/1/5" }
-      let(:to) { "2019/1/20" }
-      it { is_expected.to contain_exactly("Jane", "Homu", "Tom", "Mami") }
-    end
-
-    context "2019/1/20 - 2019/1/30" do
-      let(:from) { "2019/1/20" }
-      let(:to) { "2019/1/30" }
-      it { is_expected.to contain_exactly("Tom", "Mami", "Kevin", "Mado") }
-    end
-
-    context "2019/1/27 - 2019/1/30" do
-      let(:from) { "2019/1/27" }
-      let(:to) { "2019/1/30" }
-      it { is_expected.to contain_exactly("Kevin", "Mado") }
-    end
+    subject { EmployeeWithScope.ignore_valid_datetime.within_deleted.count }
+    it { is_expected.to eq 3 }
   end
 
   describe ".without_deleted" do
-    include_context "defined records"
-    subject { EmployeeWithScope.ignore_valid_datetime.without_deleted.count }
+    before do
+      EmployeeWithScope.create!(name: "Kevin").update(name: "Jane")
+    end
+    subject { EmployeeWithScope.ignore_valid_datetime.within_deleted.without_deleted.count }
+    it { is_expected.to eq 2 }
+  end
 
-    it { is_expected.to eq 6 }
+  describe ActiveRecord::Bitemporal::Scope::Extention do
+    describe ".bitemporal_histories_by" do
+      let(:employee) { EmployeeWithScope.create!(name: "Jane") }
+      before do
+        employee.update(name: "Tom")
+        employee.update(name: "Jane")
+        EmployeeWithScope.create!(name: "Kevin").update(name: "Jane")
+      end
+      subject { EmployeeWithScope.bitemporal_histories_by(employee.id) }
+      it { expect(subject.count).to eq 3 }
+      it { expect(subject.where(name: "Jane").count).to eq 2 }
+      it { expect(subject.ids).to eq [employee.id, employee.id, employee.id] }
+    end
+
+    describe ".bitemporal_latest_by" do
+      let(:employee) { EmployeeWithScope.create!(name: "Jane") }
+      before do
+        employee.update(name: "Tom")
+        employee.update(name: "Jane")
+        EmployeeWithScope.create!(name: "Jane").update(name: "Kevin")
+      end
+      subject { EmployeeWithScope.bitemporal_latest_by(employee.id) }
+      it { expect(subject).to be_kind_of EmployeeWithScope }
+      it { expect(subject.id).to eq employee.id }
+      it { expect(subject.name).to eq "Jane" }
+    end
+
+    describe ".bitemporal_oldest_by" do
+      let(:employee) { EmployeeWithScope.create!(name: "Jane") }
+      before do
+        employee.update(name: "Tom")
+        employee.update(name: "Jane")
+        EmployeeWithScope.create!(name: "Jane").update(name: "Kevin")
+      end
+      subject { EmployeeWithScope.bitemporal_oldest_by(employee.id) }
+      it { expect(subject).to be_kind_of EmployeeWithScope }
+      it { expect(subject.id).to eq employee.id }
+      it { expect(subject.name).to eq "Jane" }
+    end
+  end
+
+  describe ActiveRecord::Bitemporal::Scope::Experimental do
+    shared_examples "defined records" do
+      before do
+        emp1 = nil
+        emp2 = nil
+        Timecop.freeze("2019/1/10") {
+          emp1 = EmployeeWithScope.create!(name: "Jane")
+          emp2 = EmployeeWithScope.create!(name: "Homu")
+        }
+
+        Timecop.freeze("2019/1/17") {
+          emp1.update!(name: "Tom")
+          emp2.update!(name: "Mami")
+        }
+
+        Timecop.freeze("2019/1/25") {
+          emp1.update!(name: "Kevin")
+          emp2.update!(name: "Mado")
+        }
+      end
+    end
+
+    describe ".valid_in" do
+      include_context "defined records"
+      subject { EmployeeWithScope.valid_in(from: from, to: to).pluck(:name).flatten }
+
+      context "2019/1/5 - 2019/1/8" do
+        let(:from) { "2019/1/5" }
+        let(:to) { "2019/1/8" }
+        it { is_expected.to be_empty }
+      end
+
+      context "2019/1/5 - 2019/1/10" do
+        let(:from) { "2019/1/5" }
+        let(:to) { "2019/1/10" }
+        it { is_expected.to contain_exactly("Jane", "Homu") }
+
+        context "with .within_deleted" do
+          subject { EmployeeWithScope.valid_in(from: from, to: to).within_deleted.count }
+          it { is_expected.to eq 4 }
+        end
+      end
+
+      context "2019/1/5 - 2019/1/20" do
+        let(:from) { "2019/1/5" }
+        let(:to) { "2019/1/20" }
+        it { is_expected.to contain_exactly("Jane", "Homu", "Tom", "Mami") }
+      end
+
+      context "2019/1/20 - 2019/1/30" do
+        let(:from) { "2019/1/20" }
+        let(:to) { "2019/1/30" }
+        it { is_expected.to contain_exactly("Tom", "Mami", "Kevin", "Mado") }
+      end
+
+      context "2019/1/27 - 2019/1/30" do
+        let(:from) { "2019/1/27" }
+        let(:to) { "2019/1/30" }
+        it { is_expected.to contain_exactly("Kevin", "Mado") }
+      end
+    end
   end
 end

--- a/spec/activerecord-bitemporal/scopes_spec.rb
+++ b/spec/activerecord-bitemporal/scopes_spec.rb
@@ -30,10 +30,19 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         employee.update(name: "Jane")
         EmployeeWithScope.create!(name: "Kevin").update(name: "Jane")
       end
-      subject { EmployeeWithScope.bitemporal_histories_by(employee.id) }
-      it { expect(subject.pluck(:name)).to contain_exactly("Jane", "Tom", "Jane") }
-      it { expect(subject.where(name: "Jane").count).to eq 2 }
-      it { expect(subject.ids).to eq [employee.id, employee.id, employee.id] }
+      subject { EmployeeWithScope.bitemporal_histories_by(id) }
+
+      context "valid `id`" do
+        let(:id) { employee.id }
+        it { expect(subject.pluck(:name)).to contain_exactly("Jane", "Tom", "Jane") }
+        it { expect(subject.where(name: "Jane").count).to eq 2 }
+        it { expect(subject.ids).to eq [employee.id, employee.id, employee.id] }
+      end
+
+      context "invalid `id`" do
+        let(:id) { -1 }
+        it { is_expected.to be_empty }
+      end
     end
 
     describe ".bitemporal_latest_by" do
@@ -43,11 +52,20 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         employee.update(name: "Jane")
         EmployeeWithScope.create!(name: "Jane").update(name: "Kevin")
       end
-      subject { EmployeeWithScope.bitemporal_latest_by(employee.id) }
-      it { expect(subject).to be_kind_of EmployeeWithScope }
-      it { expect(subject.id).to eq employee.id }
-      it { expect(subject.name).to eq "Jane" }
-      it { expect(subject.deleted_at).to be_nil }
+      subject { EmployeeWithScope.bitemporal_latest_by(id) }
+
+      context "valid `id`" do
+        let(:id) { employee.id }
+        it { expect(subject).to be_kind_of EmployeeWithScope }
+        it { expect(subject.id).to eq employee.id }
+        it { expect(subject.name).to eq "Jane" }
+        it { expect(subject.deleted_at).to be_nil }
+      end
+
+      context "invalid `id`" do
+        let(:id) { -1 }
+        it { is_expected.to be_nil }
+      end
     end
 
     describe ".bitemporal_oldest_by" do
@@ -57,11 +75,20 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         employee.update(name: "Jane")
         EmployeeWithScope.create!(name: "Jane").update(name: "Kevin")
       end
-      subject { EmployeeWithScope.bitemporal_oldest_by(employee.id) }
-      it { expect(subject).to be_kind_of EmployeeWithScope }
-      it { expect(subject.id).to eq employee.id }
-      it { expect(subject.name).to eq "Jane" }
-      it { expect(subject.deleted_at).to be_nil }
+      subject { EmployeeWithScope.bitemporal_oldest_by(id) }
+
+      context "valid `id`" do
+        let(:id) { employee.id }
+        it { expect(subject).to be_kind_of EmployeeWithScope }
+        it { expect(subject.id).to eq employee.id }
+        it { expect(subject.name).to eq "Jane" }
+        it { expect(subject.deleted_at).to be_nil }
+      end
+
+      context "invalid `id`" do
+        let(:id) { -1 }
+        it { is_expected.to be_nil }
+      end
     end
   end
 

--- a/spec/activerecord-bitemporal/scopes_spec.rb
+++ b/spec/activerecord-bitemporal/scopes_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 class EmployeeWithScope < Employee
-  include ActiveRecord::Bitemporal::Scope::Extention
+  include ActiveRecord::Bitemporal::Scope::Extension
   include ActiveRecord::Bitemporal::Scope::Experimental
 end
 
@@ -22,7 +22,7 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
     it { is_expected.to eq 2 }
   end
 
-  describe ActiveRecord::Bitemporal::Scope::Extention do
+  describe ActiveRecord::Bitemporal::Scope::Extension do
     describe ".bitemporal_histories_by" do
       let(:employee) { EmployeeWithScope.create!(name: "Jane") }
       before do

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -67,6 +67,7 @@ end
 
 class Company < ActiveRecord::Base
   include ActiveRecord::Bitemporal
+  include ActiveRecord::Bitemporal::Scope::Extention
 
   has_many :employees, foreign_key: :company_id
   has_many :employee_without_bitemporals, foreign_key: :company_id
@@ -80,6 +81,7 @@ end
 
 class Employee < ActiveRecord::Base
   include ActiveRecord::Bitemporal
+  include ActiveRecord::Bitemporal::Scope::Extention
 
   belongs_to :company, foreign_key: :company_id
 
@@ -121,6 +123,7 @@ end
 
 class Address < ActiveRecord::Base
   include ActiveRecord::Bitemporal
+  include ActiveRecord::Bitemporal::Scope::Extention
 
   belongs_to :employee, foreign_key: :employee_id
 end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -67,7 +67,7 @@ end
 
 class Company < ActiveRecord::Base
   include ActiveRecord::Bitemporal
-  include ActiveRecord::Bitemporal::Scope::Extention
+  include ActiveRecord::Bitemporal::Scope::Extension
 
   has_many :employees, foreign_key: :company_id
   has_many :employee_without_bitemporals, foreign_key: :company_id
@@ -81,7 +81,7 @@ end
 
 class Employee < ActiveRecord::Base
   include ActiveRecord::Bitemporal
-  include ActiveRecord::Bitemporal::Scope::Extention
+  include ActiveRecord::Bitemporal::Scope::Extension
 
   belongs_to :company, foreign_key: :company_id
 
@@ -123,7 +123,7 @@ end
 
 class Address < ActiveRecord::Base
   include ActiveRecord::Bitemporal
-  include ActiveRecord::Bitemporal::Scope::Extention
+  include ActiveRecord::Bitemporal::Scope::Extension
 
   belongs_to :employee, foreign_key: :employee_id
 end


### PR DESCRIPTION
Added an extension scope.
This scope is used `include ActiveRecord::Bitemporal::Scope::Extension` .


## Added scopes

| scope | result |
| --- | --- |
| `.bitemporal_histories_by(id)` | return histories relation with id |
| `.bitemporal_latest_by(id)` | return latest history with id |
| `.bitemporal_oldest_by(id)` | return oldest history with id |


## Usage

```ruby
class Company
  include ActiveRecord::Bitemporal
  # Need included ActiveRecord::Bitemporal::Scope::Extension
  include ActiveRecord::Bitemporal::Scope::Extension
end


company = Company.create(name: "Company1")
company.update(name: "Company2")
company.update(name: "Company3")

# return to relation
pp Company.bitemporal_histories_by(company.id).pluck(:name)
# => ["Company1", "Company2", "Company3"]

# return to record
pp Company.bitemporal_latest_by(company.id).name  # => "Company3"
pp Company.bitemporal_oldest_by(company.id).name  # => "Company1"


# Invalid id
pp Company.bitemporal_latest_by(-1)  # => nil
pp Company.bitemporal_oldest_by(-1)  # => nil
```

## NOTE

Are there any good scope names besides `bitemporal_histories_by`, `bitemporal_latest_by` and `bitemporal_oldest_by` ?
