### PR TITLE
Support thread safe to `ActiveRecord :: Bitemporal.with_bitemporal_option`

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -48,6 +48,10 @@ module ActiveRecord
     #   # in valid_datetime is "2018/4/1".
     # }
     module ::ActiveRecord::Bitemporal
+      class Current < ActiveSupport::CurrentAttributes
+        attribute :option
+      end
+
       class << self
         include Optionable
 
@@ -73,6 +77,15 @@ module ActiveRecord
           else
             bitemporal_option_strage.merge(option)
           end
+        end
+
+      private
+        def bitemporal_option_strage
+          Current.option ||= {}
+        end
+
+        def bitemporal_option_strage=(value)
+          Current.option = value
         end
       end
     end

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -17,28 +17,28 @@ module ActiveRecord
 
     module Optionable
       def bitemporal_option
-        ::ActiveRecord::Bitemporal.merge_by(bitemporal_option_strage)
+        ::ActiveRecord::Bitemporal.merge_by(bitemporal_option_storage)
       end
 
       def bitemporal_option_merge!(other)
-        self.bitemporal_option_strage = bitemporal_option.merge other
+        self.bitemporal_option_storage = bitemporal_option.merge other
       end
 
       def with_bitemporal_option(**opt)
-        tmp_opt = bitemporal_option_strage
-        self.bitemporal_option_strage = tmp_opt.merge(opt)
+        tmp_opt = bitemporal_option_storage
+        self.bitemporal_option_storage = tmp_opt.merge(opt)
         yield self
       ensure
-        self.bitemporal_option_strage = tmp_opt
+        self.bitemporal_option_storage = tmp_opt
       end
 
     private
-      def bitemporal_option_strage
-        @bitemporal_option_strage ||= {}
+      def bitemporal_option_storage
+        @bitemporal_option_storage ||= {}
       end
 
-      def bitemporal_option_strage=(value)
-        @bitemporal_option_strage = value
+      def bitemporal_option_storage=(value)
+        @bitemporal_option_storage = value
       end
     end
 
@@ -72,19 +72,19 @@ module ActiveRecord
         end
 
         def merge_by(option)
-          if bitemporal_option_strage[:force]
-            option.merge(bitemporal_option_strage)
+          if bitemporal_option_storage[:force]
+            option.merge(bitemporal_option_storage)
           else
-            bitemporal_option_strage.merge(option)
+            bitemporal_option_storage.merge(option)
           end
         end
 
       private
-        def bitemporal_option_strage
+        def bitemporal_option_storage
           Current.option ||= {}
         end
 
-        def bitemporal_option_strage=(value)
+        def bitemporal_option_storage=(value)
           Current.option = value
         end
       end
@@ -201,11 +201,11 @@ module ActiveRecord
 
       private
 
-      def bitemporal_option_strage(klass_ = self.klass)
+      def bitemporal_option_storage(klass_ = self.klass)
         bitemporal_clause[klass_]
       end
 
-      def bitemporal_option_strage=(value)
+      def bitemporal_option_storage=(value)
         bitemporal_clause[klass] = value
       end
     end

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -1125,6 +1125,31 @@ RSpec.describe ActiveRecord::Bitemporal do
           }
         end
       end
+
+      context "thread" do
+        it do
+          t1 = Thread.new {
+            ActiveRecord::Bitemporal.with_bitemporal_option(value: 42) { |it|
+              value = it.bitemporal_option[:value]
+              sleep 0.1
+              expect(value).to eq it.bitemporal_option[:value]
+            }
+          }
+
+          t2 = Thread.new {
+            ActiveRecord::Bitemporal.with_bitemporal_option(value: "homu") { |it|
+              value = it.bitemporal_option[:value]
+              sleep 0.3
+              expect(value).to eq it.bitemporal_option[:value]
+            }
+          }
+
+          t1.join
+          t2.join
+
+          expect(ActiveRecord::Bitemporal.bitemporal_option).to be_empty
+        end
+      end
     end
 
     describe ".ignore_valid_datetime" do


### PR DESCRIPTION
`ActiveRecord :: Bitemporal.with_bitemporal_option` was not thread safe.
Support thread safe.

### Problem

`ActiveRecord :: Bitemporal.with_bitemporal_option` was not thread safe.

```ruby
t1 = Thread.new {
  ActiveRecord::Bitemporal.with_bitemporal_option(value: 42) { |it|
    value = it.bitemporal_option[:value]
    sleep 0.1
    pp "therad1 : #{it.bitemporal_option[:value]} == #{value}"
    # => "therad1 : homu == 42"
  }
}

t2 = Thread.new {
  ActiveRecord::Bitemporal.with_bitemporal_option(value: "homu") { |it|
    value = it.bitemporal_option[:value]
    sleep 0.3
    pp "therad2 : #{it.bitemporal_option[:value]} == #{value}"
    # => "therad2 :  == homu"
  }
}

t1.join
t2.join

pp ActiveRecord::Bitemporal.bitemporal_option
# => {:value=>42}
```

## Fixed

```ruby
t1 = Thread.new {
  ActiveRecord::Bitemporal.with_bitemporal_option(value: 42) { |it|
    value = it.bitemporal_option[:value]
    sleep 0.1
    pp "therad1 : #{it.bitemporal_option[:value]} == #{value}"
    # => "therad1 : 42 == 42"
  }
}

t2 = Thread.new {
  ActiveRecord::Bitemporal.with_bitemporal_option(value: "homu") { |it|
    value = it.bitemporal_option[:value]
    sleep 0.3
    pp "therad2 : #{it.bitemporal_option[:value]} == #{value}"
    # => "therad2 : homu == homu"
  }
}

t1.join
t2.join

pp ActiveRecord::Bitemporal.bitemporal_option
# => {}
```
