### PR TITLE
Add scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@
 
 ### Added
 
-- None
+- [#12](https://github.com/kufu/activerecord-bitemporal/pull/12) - Added utility (and extension) scopes.
+  - `.bitemporl_for(id)`
+  - `.valid_in(from: from, to: to)`
+  - `.valid_allin(from: from, to: to)`
+  - `.bitemporal_histories_by(id)`
+  - `.bitemporal_most_future(id)`
+  - `.bitemporal_most_past(id)`
 
 ### Fixed
 

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -236,12 +236,12 @@ module ActiveRecord
           scope :bitemporal_histories_by, -> (id) {
             ignore_valid_datetime.where(bitemporal_id: id)
           }
-          scope :bitemporal_latest_by, -> (id) {
+          def self.bitemporal_latest_by(id)
             bitemporal_histories_by(id).order(valid_from: :asc).last
-          }
-          scope :bitemporal_oldest_by, -> (id) {
+          end
+          def self.bitemporal_oldest_by(id)
             bitemporal_histories_by(id).order(valid_from: :asc).first
-          }
+          end
         end
       end
 

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -251,10 +251,10 @@ module ActiveRecord
           scope :bitemporal_histories, -> (*ids) {
             ignore_valid_datetime.bitemporal_for(*ids)
           }
-          def self.bitemporal_more_future(id)
+          def self.bitemporal_most_future(id)
             bitemporal_histories(id).order(valid_from: :asc).last
           end
-          def self.bitemporal_more_past(id)
+          def self.bitemporal_most_past(id)
             bitemporal_histories(id).order(valid_from: :asc).first
           end
         end

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -229,6 +229,16 @@ module ActiveRecord
         }
       end
 
+      module Extention
+        extend ActiveSupport::Concern
+
+        included do
+          scope :histories_for, -> (id) {
+            ignore_valid_datetime.where(bitemporal_id: id)
+          }
+        end
+      end
+
       module Experimental
         extend ActiveSupport::Concern
 

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -230,23 +230,21 @@ module ActiveRecord
         scope :bitemporal_for, -> (id) {
           where(bitemporal_id: id)
         }
-        scope :valid_in, -> (from: nil, to: nil, exclude_to: false) {
+        scope :valid_in, -> (from: nil, to: nil) {
           table_name = klass.table_name
           column_valid_to = "#{table_name}.valid_to"
           column_valid_from = "#{table_name}.valid_from"
           ignore_valid_datetime
             .tap { |relation| break relation.where("? <= #{column_valid_to}", from.in_time_zone.to_datetime) if from }
-            .tap { |relation| break relation.where("#{column_valid_from} <= ?", to.in_time_zone.to_datetime) if to && exclude_to }
-            .tap { |relation| break relation.where("#{column_valid_from} < ?", to.in_time_zone.to_datetime) if to && !exclude_to }
+            .tap { |relation| break relation.where("#{column_valid_from} <= ?", to.in_time_zone.to_datetime) if to }
         }
-        scope :valid_allin, -> (from: nil, to: nil, exclude_to: false) {
+        scope :valid_allin, -> (from: nil, to: nil) {
           table_name = klass.table_name
           column_valid_to = "#{table_name}.valid_to"
           column_valid_from = "#{table_name}.valid_from"
           ignore_valid_datetime
             .tap { |relation| break relation.where("? <= #{column_valid_from}", from.in_time_zone.to_datetime) if from }
-            .tap { |relation| break relation.where("#{column_valid_to} <= ?", to.in_time_zone.to_datetime) if to && exclude_to }
-            .tap { |relation| break relation.where("#{column_valid_to} < ?", to.in_time_zone.to_datetime) if to && !exclude_to }
+            .tap { |relation| break relation.where("#{column_valid_to} <= ?", to.in_time_zone.to_datetime) if to }
         }
       end
 

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -233,8 +233,14 @@ module ActiveRecord
         extend ActiveSupport::Concern
 
         included do
-          scope :histories_for, -> (id) {
+          scope :bitemporal_histories_by, -> (id) {
             ignore_valid_datetime.where(bitemporal_id: id)
+          }
+          scope :bitemporal_latest_by, -> (id) {
+            bitemporal_histories_by(id).order(valid_from: :asc).last
+          }
+          scope :bitemporal_oldest_by, -> (id) {
+            bitemporal_histories_by(id).order(valid_from: :asc).first
           }
         end
       end

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -231,16 +231,22 @@ module ActiveRecord
           where(bitemporal_id: id)
         }
         scope :valid_in, -> (from: nil, to: nil, exclude_to: false) {
+          table_name = klass.table_name
+          column_valid_to = "#{table_name}.valid_to"
+          column_valid_from = "#{table_name}.valid_from"
           ignore_valid_datetime
-            .tap { |relation| break relation.where("? <= valid_to", from.in_time_zone.to_datetime) if from }
-            .tap { |relation| break relation.where("valid_from <= ?", to.in_time_zone.to_datetime) if to && exclude_to }
-            .tap { |relation| break relation.where("valid_from < ?", to.in_time_zone.to_datetime) if to && !exclude_to }
+            .tap { |relation| break relation.where("? <= #{column_valid_to}", from.in_time_zone.to_datetime) if from }
+            .tap { |relation| break relation.where("#{column_valid_from} <= ?", to.in_time_zone.to_datetime) if to && exclude_to }
+            .tap { |relation| break relation.where("#{column_valid_from} < ?", to.in_time_zone.to_datetime) if to && !exclude_to }
         }
         scope :valid_allin, -> (from: nil, to: nil, exclude_to: false) {
+          table_name = klass.table_name
+          column_valid_to = "#{table_name}.valid_to"
+          column_valid_from = "#{table_name}.valid_from"
           ignore_valid_datetime
-            .tap { |relation| break relation.where("? <= valid_from", from.in_time_zone.to_datetime) if from }
-            .tap { |relation| break relation.where("valid_to <= ?", to.in_time_zone.to_datetime) if to && exclude_to }
-            .tap { |relation| break relation.where("valid_to < ?", to.in_time_zone.to_datetime) if to && !exclude_to }
+            .tap { |relation| break relation.where("? <= #{column_valid_from}", from.in_time_zone.to_datetime) if from }
+            .tap { |relation| break relation.where("#{column_valid_to} <= ?", to.in_time_zone.to_datetime) if to && exclude_to }
+            .tap { |relation| break relation.where("#{column_valid_to} < ?", to.in_time_zone.to_datetime) if to && !exclude_to }
         }
       end
 

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -229,7 +229,7 @@ module ActiveRecord
         }
       end
 
-      module Extention
+      module Extension
         extend ActiveSupport::Concern
 
         included do

--- a/spec/activerecord-bitemporal/scopes_spec.rb
+++ b/spec/activerecord-bitemporal/scopes_spec.rb
@@ -72,14 +72,7 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
     context "2019/1/20 - 2019/1/30" do
       let(:from) { "2019/1/20" }
       let(:to) { "2019/1/30" }
-      it { is_expected.to contain_exactly("Homu", "Jane", "Mami", "Tom") }
-    end
-
-    context "with `exclude_to: true`" do
-      let(:from) { "2019/1/20" }
-      let(:to) { "2019/1/30" }
-      subject { Employee.valid_in(from: from, to: to, exclude_to: true).pluck(:name).flatten }
-      it { is_expected.to contain_exactly("Homu", "Jane", "Kevin", "Mado", "Mami", "Tom") }
+      it { is_expected.to contain_exactly("Homu", "Jane", "Mami", "Tom", "Kevin", "Mado") }
     end
 
     describe ".to_sql" do
@@ -92,7 +85,7 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
       let(:to) { "2019/1/30" }
       subject { Employee.valid_in(from: from, to: to).to_sql }
       it { is_expected.to match /'2019-01-19 15:00:00' <= employees.valid_to/ }
-      it { is_expected.to match /employees.valid_from < '2019-01-29 15:00:00'/ }
+      it { is_expected.to match /employees.valid_from <= '2019-01-29 15:00:00'/ }
     end
   end
 
@@ -133,7 +126,7 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
     context "2019/1/10 - 2019/1/20" do
       let(:from) { "2019/1/10" }
       let(:to) { "2019/1/20" }
-      it { is_expected.to be_empty }
+      it { is_expected.to contain_exactly("Jane", "Homu") }
     end
 
     context "2019/1/10 - 2019/1/21" do
@@ -148,13 +141,6 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
       it { is_expected.to contain_exactly("Tom", "Mami") }
     end
 
-    context "with `exclude_to: true`" do
-      subject { Employee.valid_allin(from: from, to: to, exclude_to: true).pluck(:name).flatten }
-      let(:from) { "2019/1/10" }
-      let(:to) { "2019/1/20" }
-      it { is_expected.to contain_exactly("Jane", "Homu") }
-    end
-
     describe ".to_sql" do
       before do
         @old_time_zone = Time.zone
@@ -165,7 +151,7 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
       let(:to) { "2019/1/30" }
       subject { Employee.valid_allin(from: from, to: to).to_sql }
       it { is_expected.to match /'2019-01-19 15:00:00' <= employees.valid_from/ }
-      it { is_expected.to match /employees.valid_to < '2019-01-29 15:00:00'/ }
+      it { is_expected.to match /employees.valid_to <= '2019-01-29 15:00:00'/ }
     end
   end
 

--- a/spec/activerecord-bitemporal/scopes_spec.rb
+++ b/spec/activerecord-bitemporal/scopes_spec.rb
@@ -76,10 +76,23 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
     end
 
     context "with `exclude_to: true`" do
-      subject { Employee.valid_in(from: from, to: to, exclude_to: true).pluck(:name).flatten }
       let(:from) { "2019/1/20" }
       let(:to) { "2019/1/30" }
+      subject { Employee.valid_in(from: from, to: to, exclude_to: true).pluck(:name).flatten }
       it { is_expected.to contain_exactly("Homu", "Jane", "Kevin", "Mado", "Mami", "Tom") }
+    end
+
+    describe ".to_sql" do
+      before do
+        @old_time_zone = Time.zone
+        Time.zone = "Tokyo"
+      end
+      after { Time.zone = @old_time_zone }
+      let(:from) { "2019/1/20" }
+      let(:to) { "2019/1/30" }
+      subject { Employee.valid_in(from: from, to: to).to_sql }
+      it { is_expected.to match /'2019-01-19 15:00:00' <= employees.valid_to/ }
+      it { is_expected.to match /employees.valid_from < '2019-01-29 15:00:00'/ }
     end
   end
 
@@ -140,6 +153,19 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
       let(:from) { "2019/1/10" }
       let(:to) { "2019/1/20" }
       it { is_expected.to contain_exactly("Jane", "Homu") }
+    end
+
+    describe ".to_sql" do
+      before do
+        @old_time_zone = Time.zone
+        Time.zone = "Tokyo"
+      end
+      after { Time.zone = @old_time_zone }
+      let(:from) { "2019/1/20" }
+      let(:to) { "2019/1/30" }
+      subject { Employee.valid_allin(from: from, to: to).to_sql }
+      it { is_expected.to match /'2019-01-19 15:00:00' <= employees.valid_from/ }
+      it { is_expected.to match /employees.valid_to < '2019-01-29 15:00:00'/ }
     end
   end
 

--- a/spec/activerecord-bitemporal/scopes_spec.rb
+++ b/spec/activerecord-bitemporal/scopes_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         EmployeeWithScope.create!(name: "Kevin").update(name: "Jane")
       end
       subject { EmployeeWithScope.bitemporal_histories_by(employee.id) }
-      it { expect(subject.count).to eq 3 }
+      it { expect(subject.pluck(:name)).to contain_exactly("Jane", "Tom", "Jane") }
       it { expect(subject.where(name: "Jane").count).to eq 2 }
       it { expect(subject.ids).to eq [employee.id, employee.id, employee.id] }
     end
@@ -47,6 +47,7 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
       it { expect(subject).to be_kind_of EmployeeWithScope }
       it { expect(subject.id).to eq employee.id }
       it { expect(subject.name).to eq "Jane" }
+      it { expect(subject.deleted_at).to be_nil }
     end
 
     describe ".bitemporal_oldest_by" do
@@ -60,6 +61,7 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
       it { expect(subject).to be_kind_of EmployeeWithScope }
       it { expect(subject.id).to eq employee.id }
       it { expect(subject.name).to eq "Jane" }
+      it { expect(subject.deleted_at).to be_nil }
     end
   end
 

--- a/spec/activerecord-bitemporal/scopes_spec.rb
+++ b/spec/activerecord-bitemporal/scopes_spec.rb
@@ -1,75 +1,128 @@
 require 'spec_helper'
 
 class EmployeeWithScope < Employee
+  include ActiveRecord::Bitemporal::Scope::Extention
   include ActiveRecord::Bitemporal::Scope::Experimental
 end
 
-RSpec.describe ActiveRecord::Bitemporal::Scope::Experimental do
-  shared_examples "defined records" do
+RSpec.describe ActiveRecord::Bitemporal::Scope do
+  describe ".within_deleted" do
     before do
-      emp1 = nil
-      emp2 = nil
-      Timecop.freeze("2019/1/10") {
-        emp1 = EmployeeWithScope.create(name: "Jane")
-        emp2 = EmployeeWithScope.create(name: "Homu")
-      }
-
-      Timecop.freeze("2019/1/17") {
-        emp1.update!(name: "Tom")
-        emp2.update!(name: "Mami")
-      }
-
-      Timecop.freeze("2019/1/25") {
-        emp1.update!(name: "Kevin")
-        emp2.update!(name: "Mado")
-      }
+      EmployeeWithScope.create!(name: "Kevin").update(name: "Jane")
     end
-  end
-
-  describe ".valid_in" do
-    include_context "defined records"
-    subject { EmployeeWithScope.valid_in(from: from, to: to).pluck(:name).flatten }
-
-    context "2019/1/5 - 2019/1/8" do
-      let(:from) { "2019/1/5" }
-      let(:to) { "2019/1/8" }
-      it { is_expected.to be_empty }
-    end
-
-    context "2019/1/5 - 2019/1/10" do
-      let(:from) { "2019/1/5" }
-      let(:to) { "2019/1/10" }
-      it { is_expected.to contain_exactly("Jane", "Homu") }
-
-      context "with .within_deleted" do
-        subject { EmployeeWithScope.valid_in(from: from, to: to).within_deleted.count }
-        it { is_expected.to eq 4 }
-      end
-    end
-
-    context "2019/1/5 - 2019/1/20" do
-      let(:from) { "2019/1/5" }
-      let(:to) { "2019/1/20" }
-      it { is_expected.to contain_exactly("Jane", "Homu", "Tom", "Mami") }
-    end
-
-    context "2019/1/20 - 2019/1/30" do
-      let(:from) { "2019/1/20" }
-      let(:to) { "2019/1/30" }
-      it { is_expected.to contain_exactly("Tom", "Mami", "Kevin", "Mado") }
-    end
-
-    context "2019/1/27 - 2019/1/30" do
-      let(:from) { "2019/1/27" }
-      let(:to) { "2019/1/30" }
-      it { is_expected.to contain_exactly("Kevin", "Mado") }
-    end
+    subject { EmployeeWithScope.ignore_valid_datetime.within_deleted.count }
+    it { is_expected.to eq 3 }
   end
 
   describe ".without_deleted" do
-    include_context "defined records"
-    subject { EmployeeWithScope.ignore_valid_datetime.without_deleted.count }
+    before do
+      EmployeeWithScope.create!(name: "Kevin").update(name: "Jane")
+    end
+    subject { EmployeeWithScope.ignore_valid_datetime.within_deleted.without_deleted.count }
+    it { is_expected.to eq 2 }
+  end
 
-    it { is_expected.to eq 6 }
+  describe ActiveRecord::Bitemporal::Scope::Extention do
+    describe ".bitemporal_histories_by" do
+      let(:employee) { EmployeeWithScope.create!(name: "Jane") }
+      before do
+        employee.update(name: "Tom")
+        employee.update(name: "Jane")
+        EmployeeWithScope.create!(name: "Kevin").update(name: "Jane")
+      end
+      subject { EmployeeWithScope.bitemporal_histories_by(employee.id) }
+      it { expect(subject.count).to eq 3 }
+      it { expect(subject.where(name: "Jane").count).to eq 2 }
+      it { expect(subject.ids).to eq [employee.id, employee.id, employee.id] }
+    end
+
+    describe ".bitemporal_latest_by" do
+      let(:employee) { EmployeeWithScope.create!(name: "Jane") }
+      before do
+        employee.update(name: "Tom")
+        employee.update(name: "Jane")
+        EmployeeWithScope.create!(name: "Jane").update(name: "Kevin")
+      end
+      subject { EmployeeWithScope.bitemporal_latest_by(employee.id) }
+      it { expect(subject).to be_kind_of EmployeeWithScope }
+      it { expect(subject.id).to eq employee.id }
+      it { expect(subject.name).to eq "Jane" }
+    end
+
+    describe ".bitemporal_oldest_by" do
+      let(:employee) { EmployeeWithScope.create!(name: "Jane") }
+      before do
+        employee.update(name: "Tom")
+        employee.update(name: "Jane")
+        EmployeeWithScope.create!(name: "Jane").update(name: "Kevin")
+      end
+      subject { EmployeeWithScope.bitemporal_oldest_by(employee.id) }
+      it { expect(subject).to be_kind_of EmployeeWithScope }
+      it { expect(subject.id).to eq employee.id }
+      it { expect(subject.name).to eq "Jane" }
+    end
+  end
+
+  describe ActiveRecord::Bitemporal::Scope::Experimental do
+    shared_examples "defined records" do
+      before do
+        emp1 = nil
+        emp2 = nil
+        Timecop.freeze("2019/1/10") {
+          emp1 = EmployeeWithScope.create!(name: "Jane")
+          emp2 = EmployeeWithScope.create!(name: "Homu")
+        }
+
+        Timecop.freeze("2019/1/17") {
+          emp1.update!(name: "Tom")
+          emp2.update!(name: "Mami")
+        }
+
+        Timecop.freeze("2019/1/25") {
+          emp1.update!(name: "Kevin")
+          emp2.update!(name: "Mado")
+        }
+      end
+    end
+
+    describe ".valid_in" do
+      include_context "defined records"
+      subject { EmployeeWithScope.valid_in(from: from, to: to).pluck(:name).flatten }
+
+      context "2019/1/5 - 2019/1/8" do
+        let(:from) { "2019/1/5" }
+        let(:to) { "2019/1/8" }
+        it { is_expected.to be_empty }
+      end
+
+      context "2019/1/5 - 2019/1/10" do
+        let(:from) { "2019/1/5" }
+        let(:to) { "2019/1/10" }
+        it { is_expected.to contain_exactly("Jane", "Homu") }
+
+        context "with .within_deleted" do
+          subject { EmployeeWithScope.valid_in(from: from, to: to).within_deleted.count }
+          it { is_expected.to eq 4 }
+        end
+      end
+
+      context "2019/1/5 - 2019/1/20" do
+        let(:from) { "2019/1/5" }
+        let(:to) { "2019/1/20" }
+        it { is_expected.to contain_exactly("Jane", "Homu", "Tom", "Mami") }
+      end
+
+      context "2019/1/20 - 2019/1/30" do
+        let(:from) { "2019/1/20" }
+        let(:to) { "2019/1/30" }
+        it { is_expected.to contain_exactly("Tom", "Mami", "Kevin", "Mado") }
+      end
+
+      context "2019/1/27 - 2019/1/30" do
+        let(:from) { "2019/1/27" }
+        let(:to) { "2019/1/30" }
+        it { is_expected.to contain_exactly("Kevin", "Mado") }
+      end
+    end
   end
 end

--- a/spec/activerecord-bitemporal/scopes_spec.rb
+++ b/spec/activerecord-bitemporal/scopes_spec.rb
@@ -30,10 +30,19 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         employee.update(name: "Jane")
         EmployeeWithScope.create!(name: "Kevin").update(name: "Jane")
       end
-      subject { EmployeeWithScope.bitemporal_histories_by(employee.id) }
-      it { expect(subject.pluck(:name)).to contain_exactly("Jane", "Tom", "Jane") }
-      it { expect(subject.where(name: "Jane").count).to eq 2 }
-      it { expect(subject.ids).to eq [employee.id, employee.id, employee.id] }
+      subject { EmployeeWithScope.bitemporal_histories_by(id) }
+
+      context "valid `id`" do
+        let(:id) { employee.id }
+        it { expect(subject.pluck(:name)).to contain_exactly("Jane", "Tom", "Jane") }
+        it { expect(subject.where(name: "Jane").count).to eq 2 }
+        it { expect(subject.ids).to eq [employee.id, employee.id, employee.id] }
+      end
+
+      context "invalid `id`" do
+        let(:id) { -1 }
+        it { is_expected.to be_empty }
+      end
     end
 
     describe ".bitemporal_latest_by" do
@@ -43,11 +52,20 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         employee.update(name: "Jane")
         EmployeeWithScope.create!(name: "Jane").update(name: "Kevin")
       end
-      subject { EmployeeWithScope.bitemporal_latest_by(employee.id) }
-      it { expect(subject).to be_kind_of EmployeeWithScope }
-      it { expect(subject.id).to eq employee.id }
-      it { expect(subject.name).to eq "Jane" }
-      it { expect(subject.deleted_at).to be_nil }
+      subject { EmployeeWithScope.bitemporal_latest_by(id) }
+
+      context "valid `id`" do
+        let(:id) { employee.id }
+        it { expect(subject).to be_kind_of EmployeeWithScope }
+        it { expect(subject.id).to eq employee.id }
+        it { expect(subject.name).to eq "Jane" }
+        it { expect(subject.deleted_at).to be_nil }
+      end
+
+      context "invalid `id`" do
+        let(:id) { -1 }
+        it { is_expected.to be_nil }
+      end
     end
 
     describe ".bitemporal_oldest_by" do
@@ -57,11 +75,20 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         employee.update(name: "Jane")
         EmployeeWithScope.create!(name: "Jane").update(name: "Kevin")
       end
-      subject { EmployeeWithScope.bitemporal_oldest_by(employee.id) }
-      it { expect(subject).to be_kind_of EmployeeWithScope }
-      it { expect(subject.id).to eq employee.id }
-      it { expect(subject.name).to eq "Jane" }
-      it { expect(subject.deleted_at).to be_nil }
+      subject { EmployeeWithScope.bitemporal_oldest_by(id) }
+
+      context "valid `id`" do
+        let(:id) { employee.id }
+        it { expect(subject).to be_kind_of EmployeeWithScope }
+        it { expect(subject.id).to eq employee.id }
+        it { expect(subject.name).to eq "Jane" }
+        it { expect(subject.deleted_at).to be_nil }
+      end
+
+      context "invalid `id`" do
+        let(:id) { -1 }
+        it { is_expected.to be_nil }
+      end
     end
   end
 

--- a/spec/activerecord-bitemporal/scopes_spec.rb
+++ b/spec/activerecord-bitemporal/scopes_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 class EmployeeWithScope < Employee
-  include ActiveRecord::Bitemporal::Scope::Extention
+  include ActiveRecord::Bitemporal::Scope::Extension
   include ActiveRecord::Bitemporal::Scope::Experimental
 end
 
@@ -22,7 +22,7 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
     it { is_expected.to eq 2 }
   end
 
-  describe ActiveRecord::Bitemporal::Scope::Extention do
+  describe ActiveRecord::Bitemporal::Scope::Extension do
     describe ".bitemporal_histories_by" do
       let(:employee) { EmployeeWithScope.create!(name: "Jane") }
       before do

--- a/spec/activerecord-bitemporal/scopes_spec.rb
+++ b/spec/activerecord-bitemporal/scopes_spec.rb
@@ -166,14 +166,14 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
       end
     end
 
-    describe ".bitemporal_more_future" do
+    describe ".bitemporal_most_future" do
       let(:employee) { EmployeeWithScope.create!(name: "Jane") }
       before do
         employee.update(name: "Tom")
         employee.update(name: "Jane")
         EmployeeWithScope.create!(name: "Jane").update(name: "Kevin")
       end
-      subject { EmployeeWithScope.bitemporal_more_future(id) }
+      subject { EmployeeWithScope.bitemporal_most_future(id) }
 
       context "valid `id`" do
         let(:id) { employee.id }
@@ -189,14 +189,14 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
       end
     end
 
-    describe ".bitemporal_more_past" do
+    describe ".bitemporal_most_past" do
       let(:employee) { EmployeeWithScope.create!(name: "Jane") }
       before do
         employee.update(name: "Tom")
         employee.update(name: "Jane")
         EmployeeWithScope.create!(name: "Jane").update(name: "Kevin")
       end
-      subject { EmployeeWithScope.bitemporal_more_past(id) }
+      subject { EmployeeWithScope.bitemporal_most_past(id) }
 
       context "valid `id`" do
         let(:id) { employee.id }

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -67,6 +67,7 @@ end
 
 class Company < ActiveRecord::Base
   include ActiveRecord::Bitemporal
+  include ActiveRecord::Bitemporal::Scope::Extention
 
   has_many :employees, foreign_key: :company_id
   has_many :employee_without_bitemporals, foreign_key: :company_id
@@ -80,6 +81,7 @@ end
 
 class Employee < ActiveRecord::Base
   include ActiveRecord::Bitemporal
+  include ActiveRecord::Bitemporal::Scope::Extention
 
   belongs_to :company, foreign_key: :company_id
 
@@ -121,6 +123,7 @@ end
 
 class Address < ActiveRecord::Base
   include ActiveRecord::Bitemporal
+  include ActiveRecord::Bitemporal::Scope::Extention
 
   belongs_to :employee, foreign_key: :employee_id
 end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -67,7 +67,7 @@ end
 
 class Company < ActiveRecord::Base
   include ActiveRecord::Bitemporal
-  include ActiveRecord::Bitemporal::Scope::Extention
+  include ActiveRecord::Bitemporal::Scope::Extension
 
   has_many :employees, foreign_key: :company_id
   has_many :employee_without_bitemporals, foreign_key: :company_id
@@ -81,7 +81,7 @@ end
 
 class Employee < ActiveRecord::Base
   include ActiveRecord::Bitemporal
-  include ActiveRecord::Bitemporal::Scope::Extention
+  include ActiveRecord::Bitemporal::Scope::Extension
 
   belongs_to :company, foreign_key: :company_id
 
@@ -123,7 +123,7 @@ end
 
 class Address < ActiveRecord::Base
   include ActiveRecord::Bitemporal
-  include ActiveRecord::Bitemporal::Scope::Extention
+  include ActiveRecord::Bitemporal::Scope::Extension
 
   belongs_to :employee, foreign_key: :employee_id
 end


### PR DESCRIPTION
Fork from https://github.com/kufu/activerecord-bitemporal/pull/10.
Added default defined scope and expandable scope.
Extensible scope is used as `include ActiveRecord::Bitemporal::Scope::Extension`.

## Add scopes

### defined default scopes

| scope | result |
| --- | --- |
| `.bitemporl_for(id)` | `where(bitemporal_id: id)` |
| `.valid_in(from: from, to: to)` | `where("? <= valid_to AND ? <= valid_from", from, to)` |
| `.valid_allin(from: from, to: to)` | `where("? <= valid_from AND ? <= valid_to", from, to)` |

```ruby
class Company
  include ActiveRecord::Bitemporal
end


company = nil
company2 = nil
Timecop.freeze("2019/1/1") {
  company = Company.create(name: "Company1")
  company2 = Company.create(name: "NeoCompany")
}

Timecop.freeze("2019/1/10") {
  company.update(name: "Company2")
}

Timecop.freeze("2019/1/20") {
  company.update(name: "Company3")
  company2.update(name: "NeoCpmpany2")
}

# Only company records
pp Company.ignore_valid_datetime.bitemporal_for(company.id).pluck(:name)
# => ["Company1", "Company2", "Company3"]


# "2019/1/5" ~ "2019/1/15"
# `valid_in` is in `valid_from` or `valid_in`
pp Company.valid_in(from: "2019/1/5", to: "2019/1/15").pluck(:name)
# => ["Company1", "Company2", "NeoCompany"]

# "2019/1/15" ~
pp Company.valid_in(from: "2019/1/15").pluck(:name)
# => ["Company2", "Company3", "NeoCompany", "NeoCpmpany2"]

# ~ "2019/1/15"
pp Company.valid_in(to: "2019/1/15").pluck(:name)
# => ["Company1", "Company2", "NeoCompany"]


# "2019/1/5" ~ "2019/1/25"
# `valid_allin` is in `valid_from` and `valid_in`
pp Company.valid_allin(from: "2019/1/5", to: "2019/1/25").pluck(:name)
# => ["Company2"]

# "2019/1/15" ~
pp Company.valid_allin(from: "2019/1/15").pluck(:name)
# => ["Company3", "NeoCpmpany2"]

# ~ "2019/1/15"
pp Company.valid_allin(to: "2019/1/15").pluck(:name)
# => ["Company1"]
```


### undefined default scopes

NOTE: need using `include ActiveRecord::Bitemporal::Scope::Extension`

| scope | result |
| --- | --- |
| `.bitemporal_histories_by(id)` | histories relation with id |
| `.bitemporal_most_future(id)` | return most future history with id |
| `.bitemporal_most_past(id)` | return most past history with id |

```ruby
class Company
  include ActiveRecord::Bitemporal
  # Need include ActiveRecord::Bitemporal::Scope::Extension
  include ActiveRecord::Bitemporal::Scope::Extension
end


company = nil
company2 = nil
Timecop.freeze("2019/1/1") {
  company = Company.create(name: "Company1")
  company2 = Company.create(name: "NeoCompany")
}

Timecop.freeze("2019/1/10") {
  company.update(name: "Company2")
}

Timecop.freeze("2019/1/20") {
  company.update(name: "Company3")
  company2.update(name: "NeoCpmpany2")
}

# To equal `Company.ignore_valid_datetime.bitemporal_for(company.id).pluck(:name)`
pp Company.bitemporal_histories(company.id).pluck(:name)
# => ["Company1", "Company2", "Company3"]

# Most future bitemporal record
pp Company.bitemporal_most_future(company.id).name
# => "Company3"

# Most past bitemporal record
pp Company.bitemporal_most_past(company.id).name
# => "Company1"
```

## NOTE

Are there any good scope names besides `bitemporal_most_future`, `bitemporal_most_past` and other.
