### PR TITLE
Update `rails-6.0beta3` from CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,20 +21,20 @@ jobs:
       - run: bundle exec appraisal rails-master bundle install
       - run: bundle exec appraisal rails-master rake
 
-  rails-6.0beta2:
+  rails-6.0beta3:
     docker:
       - image: ruby:2.5.3
       - image: circleci/postgres:11-alpine
     steps:
       - checkout
       - run: bundle install
-      - run: bundle exec appraisal rails-6.0beta2 bundle install
-      - run: bundle exec appraisal rails-6.0beta2 rake
+      - run: bundle exec appraisal rails-6.0beta3 bundle install
+      - run: bundle exec appraisal rails-6.0beta3 rake
 
 workflows:
   version: 2
   test:
     jobs:
       - rails-5.2
-      - rails-6.0beta2
-      - rails-master
+      - rails-6.0beta3
+      # - rails-master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,4 +37,4 @@ workflows:
     jobs:
       - rails-5.2
       - rails-6.0beta3
-      # - rails-master
+      - rails-master

--- a/Appraisals
+++ b/Appraisals
@@ -6,6 +6,6 @@ appraise "rails-master" do
   gem "rails", git: 'https://github.com/rails/rails.git'
 end
 
-appraise "rails-6.0beta2" do
-  gem "rails", git: 'https://github.com/rails/rails.git', tag: "v6.0.0.beta2"
+appraise "rails-6.0beta3" do
+  gem "rails", git: 'https://github.com/rails/rails.git', tag: "v6.0.0.beta3"
 end

--- a/gemfiles/rails_6.0beta3.gemfile
+++ b/gemfiles/rails_6.0beta3.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "appraisal"
-gem "rails", git: "https://github.com/rails/rails.git", tag: "v6.0.0.beta2"
+gem "rails", git: "https://github.com/rails/rails.git", tag: "v6.0.0.beta3"
 
 gemspec path: "../"


### PR DESCRIPTION
<del>Remove `rails-master` (and update `rails-6.0beta3`) from CI.
Rails has [breaking changes](https://github.com/rails/rails/commit/1c6e508ade793b5f2676e9218ab2f4cc9474f9ce#diff-cc31fc1dd1e78db64638200f710b2f59L427).
As a result, [database_cleaner](https://github.com/DatabaseCleaner/database_cleaner/blob/1257e4c78a6fc0bd17cb3845a3f8b572c4aabc66/lib/database_cleaner/active_record/truncation.rb#L133) has an [error](https://circleci.com/gh/kufu/activerecord-bitemporal/71) :sob: </del>
Restored breaking change of Rails.
see: rails/rails@7618d08
Only update `rails-6.0beta3` :sob: