### PR TITLE
Add `.bitemporalize` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 | option | describe | default |
 | --- | --- | --- |
-| `enable_strict_by_validates_bitemporal_id` | raised with `validates :bitemporal_id, uniqueness: true` if true | true |
+| `enable_strict_by_validates_bitemporal_id` | raised with `validates :bitemporal_id, uniqueness: true` if `true` | false |
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@
 
 ### Added
 
-- None
+- [#15](https://github.com/kufu/activerecord-bitemporal/pull/15) - Added `.bitemporalize`. Use `.bitemporalize` instead of `include ActiveRecord::Bitemporal`.
+- [#15](https://github.com/kufu/activerecord-bitemporal/pull/15) - Added `.bitemporalize` options.
+
+| option | describe | default |
+| --- | --- | --- |
+| `enable_strict_by_validates_bitemporal_id` | raised with `validates :bitemporal_id, uniqueness: true` if true | true |
+
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
-- None
+- [#15](https://github.com/kufu/activerecord-bitemporal/pull/15) - `validates :bitemporal_id, uniqueness: true` is no raise by default.
 
 ### Added
 

--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -78,7 +78,7 @@ module ActiveRecord::Bitemporal::Bitemporalize
     end
   end
 
-  def bitemporalize(enable_raise_validation_bitemporal_id: true)
+  def bitemporalize(enable_strict_by_validates_bitemporal_id: true)
     extend ClassMethods
     include InstanceMethods
     include ActiveRecord::Bitemporal::Scope
@@ -105,11 +105,7 @@ module ActiveRecord::Bitemporal::Bitemporalize
     validates :valid_to, presence: true
     validate :valid_from_cannot_be_greater_equal_than_valid_to
 
-    if enable_raise_validation_bitemporal_id
-      validates! bitemporal_id_key, uniqueness: true, allow_nil: true
-    else
-      validates bitemporal_id_key, uniqueness: true, allow_nil: true
-    end
+    validates bitemporal_id_key, uniqueness: true, allow_nil: true, strict: enable_strict_by_validates_bitemporal_id
 
     prepend_relation_delegate_class ActiveRecord::Bitemporal::Relation
   end

--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -78,7 +78,7 @@ module ActiveRecord::Bitemporal::Bitemporalize
     end
   end
 
-  def bitemporalize(enable_strict_by_validates_bitemporal_id: true)
+  def bitemporalize(enable_strict_by_validates_bitemporal_id: false)
     extend ClassMethods
     include InstanceMethods
     include ActiveRecord::Bitemporal::Scope

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -316,7 +316,6 @@ module ActiveRecord
         each_association(deep: true, only_cached: true)
           .select { |asso| asso.class.bi_temporal_model? && asso.valid_from == ActiveRecord::Bitemporal::DEFAULT_VALID_FROM && asso.new_record? }
           .each   { |asso| asso.valid_from = self.valid_from }
-#         ActiveRecord::Bitemporal.valid_at(valid_from) { super() }
         super()
       end
 

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -316,6 +316,7 @@ module ActiveRecord
         each_association(deep: true, only_cached: true)
           .select { |asso| asso.class.bi_temporal_model? && asso.valid_from == ActiveRecord::Bitemporal::DEFAULT_VALID_FROM && asso.new_record? }
           .each   { |asso| asso.valid_from = self.valid_from }
+#         ActiveRecord::Bitemporal.valid_at(valid_from) { super() }
         super()
       end
 

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -502,7 +502,7 @@ RSpec.describe ActiveRecord::Bitemporal do
       subject { model_class.validators_on(:bitemporal_id).first.options[:strict] }
       context "empty" do
         let(:option) { {} }
-        it { is_expected.to be_truthy }
+        it { is_expected.to be_falsey }
       end
       context "`true`" do
         let(:option) { { enable_strict_by_validates_bitemporal_id: true } }
@@ -985,8 +985,8 @@ RSpec.describe ActiveRecord::Bitemporal do
 
     context "with `bitemporal_id`" do
       let!(:employee0) { Employee.create!(name: "Jane") }
-      subject { -> { Employee.create(name: "Jane", bitemporal_id: employee0.bitemporal_id) } }
-      it { expect(&subject).to raise_error(ActiveModel::StrictValidationFailed) }
+      subject { Employee.create(name: "Jane", bitemporal_id: employee0.bitemporal_id) }
+      it { is_expected.to raise_error(ActiveModel::StrictValidationFailed) }
     end
   end
 

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -490,6 +490,31 @@ RSpec.describe ActiveRecord::Bitemporal do
     end
   end
 
+  describe ".bitemporalize" do
+    let(:option) { {} }
+    let(:model_class) {
+      opt = option
+      Class.new(ActiveRecord::Base) {
+        bitemporalize **opt
+      }
+    }
+    describe "with `enable_strict_by_validates_bitemporal_id`" do
+      subject { model_class.validators_on(:bitemporal_id).first.options[:strict] }
+      context "empty" do
+        let(:option) { {} }
+        it { is_expected.to be_truthy }
+      end
+      context "`true`" do
+        let(:option) { { enable_strict_by_validates_bitemporal_id: true } }
+        it { is_expected.to be_truthy }
+      end
+      context "`false`" do
+        let(:option) { { enable_strict_by_validates_bitemporal_id: false } }
+        it { is_expected.to be_falsey }
+      end
+    end
+  end
+
   describe "#ignore_valid_datetime" do
     let!(:employee) { Employee.create!(name: "Jone") }
     let(:update) { -> { Employee.find(employee).update(name: "Tom"); Time.current } }

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -985,8 +985,8 @@ RSpec.describe ActiveRecord::Bitemporal do
 
     context "with `bitemporal_id`" do
       let!(:employee0) { Employee.create!(name: "Jane") }
-      subject { Employee.create(name: "Jane", bitemporal_id: employee0.bitemporal_id) }
-      it { is_expected.to raise_error(ActiveModel::StrictValidationFailed) }
+      subject { Employee.new(name: "Jane", bitemporal_id: employee0.bitemporal_id).save }
+      it { is_expected.to be_falsey }
     end
   end
 

--- a/spec/activerecord-bitemporal/uniqueness_spec.rb
+++ b/spec/activerecord-bitemporal/uniqueness_spec.rb
@@ -254,8 +254,8 @@ RSpec.describe ActiveRecord::Bitemporal::Uniqueness do
 
     describe "#dup" do
       let(:employee) { EmployeeWithUniquness.create!(name: "Jane").tap { |it| it.update(name: "Tom") } }
-      subject { -> { employee.dup.save } }
-      it { is_expected.to raise_error(ActiveModel::StrictValidationFailed) }
+      subject { employee.dup.save  }
+      it { is_expected.to be_falsey }
     end
 
     describe ".create" do


### PR DESCRIPTION
Add `.bitemporalize` method.
Use `.bitemporalize` instead of `include ActiveRecord::Bitemporal`.
Can called `.bitemporalize` with options.

:memo: `include ActiveRecord::Bitemporal` can be used as it is.

## before

```ruby
class User < ActiveRecord::Base
  # included ActiveRecord::Bitemporal
  include ActiveRecord::Bitemporal
end
```

## after

```ruby
class User < ActiveRecord::Base
  # call to .bitemporalize
  bitemporalize

  # `include ActiveRecord::Bitemporal` equal to call `bitemporalize`
  # include ActiveRecord::Bitemporal
end
```


## `.bitemporalize` with `enable_strict_by_validates_bitemporal_id`

Called `.bitemporalize` with `enable_strict_by_validates_bitemporal_id` options
Raise an exception with not null validation of `bitemporal_id`, if `enable_strict_by_validates_bitemporal_id` `true`.
Default value for `enable_strict_by_validates_bitemporal_id` is `false`.

### Raise

```ruby
class User < ApplicationRecord
  bitemporalize
  # or
  # bitemporalize enable_strict_by_validates_bitemporal_id: false
end

user = User.create(valid_from: "2019/1/1")

# Not exception
pp User.new(valid_from: "2019/1/1", bitemporal_id: user.bitemporal_id).valid?
# => false
```

### Not raise

```ruby
class User < ApplicationRecord
  bitemporalize enable_strict_by_validates_bitemporal_id: true
end

user = User.create(valid_from: "2019/1/1")

# Be exception
pp User.new(valid_from: "2019/1/1", bitemporal_id: user.bitemporal_id).valid?
# => Bitemporal has already been taken (ActiveModel::StrictValidationFailed)
```

## NOTE

`validates :bitemporal_id, uniqueness: true`  is no raise by default.
If you want to raise, please use `enable_strict_by_validates_bitemporal_id: true`