### PR TITLE
[Bugfix] Create record with `valid_datetime` out of the range `valid_from` to `valid_to`

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -460,7 +460,7 @@ module ActiveRecord
           # レコードを更新する時に valid_datetime が valid_from ~ valid_to の範囲外だった場合、
           #   一番近い未来の履歴レコードを参照して更新する
           # という仕様があるため、それを考慮して valid_to を設定する
-          if (record.valid_datetime && (record.valid_from..record.valid_to).include?(record.valid_datetime)) == false && (not record.new_record?)
+          if (record.valid_datetime && (record.valid_from..record.valid_to).include?(record.valid_datetime)) == false && (record.persisted?)
             finder_class.where(bitemporal_id: record.bitemporal_id).where('? < valid_from', target_datetime).ignore_valid_datetime.order(valid_from: :asc).first.valid_from
           else
             valid_to

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -457,10 +457,10 @@ module ActiveRecord
         }
 
         valid_to = record.valid_to.yield_self { |valid_to|
-          # valid_datetime が valid_from ~ valid_to の範囲外だった場合、
+          # レコードを更新する時に valid_datetime が valid_from ~ valid_to の範囲外だった場合、
           #   一番近い未来の履歴レコードを参照して更新する
           # という仕様があるため、それを考慮して valid_to を設定する
-          if (record.valid_datetime && (record.valid_from..record.valid_to).include?(record.valid_datetime)) == false
+          if (record.valid_datetime && (record.valid_from..record.valid_to).include?(record.valid_datetime)) == false && (not record.new_record?)
             finder_class.where(bitemporal_id: record.bitemporal_id).where('? < valid_from', target_datetime).ignore_valid_datetime.order(valid_from: :asc).first.valid_from
           else
             valid_to

--- a/spec/activerecord-bitemporal/uniqueness_spec.rb
+++ b/spec/activerecord-bitemporal/uniqueness_spec.rb
@@ -305,6 +305,23 @@ RSpec.describe ActiveRecord::Bitemporal::Uniqueness do
         end
       end
     end
+
+    context "and `valid_from`" do
+      before do
+        EmployeeWithUniquness.create(name: "Jane", valid_from: "2019/1/10", valid_to: "2019/20")
+      end
+      subject { EmployeeWithUniquness.new(name: "Jane", valid_from: "2019/1/15").valid_at("2019/1/30", &:save) }
+    end
+
+    context "`valid_datetime` out of range `valid_from` ~ `valid_to`" do
+      it { is_expected.to be_truthy }
+
+      context "empty records" do
+        before { EmployeeWithUniquness.destroy_all }
+        subject { EmployeeWithUniquness.new(valid_from: "9999/1/10").valid_at("9999/1/1", &:save) }
+        it { is_expected.to be_truthy }
+      end
+    end
   end
 
   describe EmployeeWithUniqunessAndScope do


### PR DESCRIPTION
Fixed bug in create record with `valid_datetime` out of the range `valid_from` to `valid_to`.

## before

```ruby
Company.new(name: "Tom", valid_from: "2019/2/2").valid_at("2019/1/1", &:save!)
# => undefined method `valid_from' for nil:NilClass (NoMethodError)
```

## after 

```ruby
Company.new(name: "Tom", valid_from: "2019/2/2").valid_at("2019/1/1", &:save!)
# => true
```