### PR TITLE
Supported by multi thread

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -362,7 +362,6 @@ module ActiveRecord
       end
 
       def _update_row(attribute_names, attempted_action = 'update')
-        pp __method__
         target_datetime = valid_datetime || Time.current
         # NOTE: force_update の場合は自身のレコードを取得するような時間を指定しておく
         target_datetime = valid_from if force_update?

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -346,7 +346,6 @@ module ActiveRecord
       end
 
       def update(*)
-        lock!
         ActiveRecord::Base.transaction do
           self.class.where(bitemporal_id: self.id).lock!.pluck(:id)
           super
@@ -354,7 +353,6 @@ module ActiveRecord
       end
 
       def update!(*)
-        lock!
         ActiveRecord::Base.transaction do
           self.class.where(bitemporal_id: self.id).lock!.pluck(:id)
           super

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -345,7 +345,24 @@ module ActiveRecord
         super()
       end
 
+      def update(*)
+        lock!
+        ActiveRecord::Base.transaction do
+          self.class.where(bitemporal_id: self.id).lock!.pluck(:id)
+          super
+        end
+      end
+
+      def update!(*)
+        lock!
+        ActiveRecord::Base.transaction do
+          self.class.where(bitemporal_id: self.id).lock!.pluck(:id)
+          super
+        end
+      end
+
       def _update_row(attribute_names, attempted_action = 'update')
+        pp __method__
         target_datetime = valid_datetime || Time.current
         # NOTE: force_update の場合は自身のレコードを取得するような時間を指定しておく
         target_datetime = valid_from if force_update?

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -345,14 +345,14 @@ module ActiveRecord
         super()
       end
 
-      def update(*)
+      def save(*)
         ActiveRecord::Base.transaction do
           self.class.where(bitemporal_id: self.id).lock!.pluck(:id)
           super
         end
       end
 
-      def update!(*)
+      def save!(*)
         ActiveRecord::Base.transaction do
           self.class.where(bitemporal_id: self.id).lock!.pluck(:id)
           super

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,10 +29,20 @@ RSpec.configure do |config|
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
   end
-  config.around(:each) do |example|
-    DatabaseCleaner.cleaning do
-      example.run
-    end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+  config.before(:each, use_truncation: true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.append_after(:each) do
+    DatabaseCleaner.clean
   end
 end
 


### PR DESCRIPTION
Add supported by multi thread `update`.

## Before

```ruby
company = Company.create!(name: "Company")

threads = []
threads << Thread.new(company) { |company|
  ActiveRecord::Base.connection_pool.with_connection do
    com = Company.find(company.id)
    com.update(name: "Company2")
  end
}

threads << Thread.new(company) { |company|
  ActiveRecord::Base.connection_pool.with_connection do
    com = Company.find(company.id)
    com.update(name: "Company3")
  end
}
threads.each { |t| t.join(3) }

# Oops duplication `valid_to = "9999-12-31"` records
pp Company.ignore_valid_datetime.bitemporal_for(company.id).order(:valid_from).pluck(:name, :valid_from, :valid_to, :deleted_at)
# => [["Company", 2019-04-24 04:04:13 UTC, 2019-04-24 04:04:13 UTC, nil],
#     ["Company", 2019-04-24 04:04:13 UTC, 2019-04-24 04:04:13 UTC, nil],
#     ["Company2", 2019-04-24 04:04:13 UTC, 9999-12-31 00:00:00 UTC, nil],
#     ["Company3", 2019-04-24 04:04:13 UTC, 9999-12-31 00:00:00 UTC, nil]]
```

## After

```ruby
company = Company.create!(name: "Company")

threads = []
threads << Thread.new(company) { |company|
  ActiveRecord::Base.connection_pool.with_connection do
    com = Company.find(company.id)
    if !com.update(name: "Company2")
      puts %{Error: update(name: "Company2")}
    end
  end
}

threads << Thread.new(company) { |company|
  ActiveRecord::Base.connection_pool.with_connection do
    com = Company.find(company.id)
    if !com.update(name: "Company3")
      puts %{Error: update(name: "Company3")}
    end
  end
}

# OK : Error `update(name: "Company2")` or `update(name: "Company3")`
threads.each { |t| t.join(3) }

# OK : Not duplication records
pp Company.ignore_valid_datetime.bitemporal_for(company.id).order(:valid_from).pluck(:name, :valid_from, :valid_to, :deleted_at)
# => [["Company", 2019-04-24 04:08:54 UTC, 2019-04-24 04:08:54 UTC, nil],
#     ["Company2", 2019-04-24 04:08:54 UTC, 9999-12-31 00:00:00 UTC, nil]]
```