### PR TITLE
Does not respect table alias on join clause

### DIFF
--- a/spec/activerecord-bitemporal/association_spec.rb
+++ b/spec/activerecord-bitemporal/association_spec.rb
@@ -207,6 +207,15 @@ RSpec.describe "Association" do
         it { expect(CompanyWithoutBitemporal.includes(:employees).where(employees: { name: "Jane" }).count).to eq 2 }
         it { expect(CompanyWithoutBitemporal.joins(:employees).where(employees: { name: "Jane" }).count).to eq 3 }
       end
+
+      xdescribe "using table name alias for multiple join" do
+        let!(:company) { CompanyWithoutBitemporal.create(name: "Company") }
+        let!(:employee) { company.employees.create(name: "Jane").tap { |m| m.update(name: "Tom") } }
+
+        it 'returns a record' do
+          expect(CompanyWithoutBitemporal.joins(:employees).left_joins(:employees).where(employees: { bitemporal_id: employee.id }).count).to eq(1)
+        end
+      end
     end
 
     describe "nested_attributes" do


### PR DESCRIPTION
## Expected behavior

Use table alias on join clause.

## Actual behavior

Does not use table alias.

## Steps to reproduce

`CompanyWithoutBitemporal.joins(:employees).left_joins(:employees).where(employees: { bitemporal_id: employee.id }).count`
executes the following sql.

```sql
SELECT "company_without_bitemporals".*
FROM "company_without_bitemporals"
       INNER JOIN "employees" ON "employees"."company_id" = "company_without_bitemporals"."id" AND
                                 "employees"."valid_from" <= '2019-05-10 09:36:13.081016' AND
                                 "employees"."valid_to" > '2019-05-10 09:36:13.081016' AND
                                 "employees"."deleted_at" IS NULL
       LEFT OUTER JOIN "employees" "employees_company_without_bitemporals"
                       ON "employees_company_without_bitemporals"."company_id" = "company_without_bitemporals"."id" AND

                          -- **THIS MUST BE `employees_company_without_bitemporals`**
                          "employees"."valid_from" <= '2019-05-10 09:36:13.081225' AND 
                          -- **SAME AS ABOVE**
                          "employees"."valid_to" > '2019-05-10 09:36:13.081225' AND "employees"."deleted_at" IS NULL

WHERE "company_without_bitemporals"."bitemporal_id" = 2
  AND "employees"."bitemporal_id" = 18
```