### PR TITLE
Fixed by `Does not respect table alias on join clause`

### DIFF
--- a/spec/activerecord-bitemporal/association_spec.rb
+++ b/spec/activerecord-bitemporal/association_spec.rb
@@ -207,15 +207,6 @@ RSpec.describe "Association" do
         it { expect(CompanyWithoutBitemporal.includes(:employees).where(employees: { name: "Jane" }).count).to eq 2 }
         it { expect(CompanyWithoutBitemporal.joins(:employees).where(employees: { name: "Jane" }).count).to eq 3 }
       end
-
-      xdescribe "using table name alias for multiple join" do
-        let!(:company) { CompanyWithoutBitemporal.create(name: "Company") }
-        let!(:employee) { company.employees.create(name: "Jane").tap { |m| m.update(name: "Tom") } }
-
-        it 'returns a record' do
-          expect(CompanyWithoutBitemporal.joins(:employees).left_joins(:employees).where(employees: { bitemporal_id: employee.id }).count).to eq(1)
-        end
-      end
     end
 
     describe "nested_attributes" do

--- a/spec/activerecord-bitemporal/relation_spec.rb
+++ b/spec/activerecord-bitemporal/relation_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe "Relation" do
     end
 
     context ".includes" do
-      let(:company)  { company_relation.includes(*associations).first }
+      let(:company) { company_relation.includes(*associations).first }
       context "associations is `:employees`" do
         let(:associations) { [:employees] }
         it { expect(employee).to have_attributes(name: "Employee1") }
@@ -191,27 +191,43 @@ RSpec.describe "Relation" do
     end
 
     context ".includes.includes" do
-      let(:company)  { company_relation.includes(:employees).includes(employees: :address).first }
+      let(:company) { company_relation.includes(:employees).includes(employees: :address).first }
       it { expect(employee).to have_attributes(name: "Employee1") }
       it { expect(address).to have_attributes(name: "Address1") }
     end
 
     context ".eager_load" do
-      let(:company)  { company_relation.eager_load(:employees, employees: :address).first }
+      let(:company) { company_relation.eager_load(:employees, employees: :address).first }
       it { expect(employee).to have_attributes(name: "Employee1") }
       it { expect(address).to have_attributes(name: "Address1") }
     end
 
     context ".joins" do
-      let(:company)  { company_relation.joins(:employees, employees: :address).first }
+      let(:company) { company_relation.joins(:employees, employees: :address).first }
       it { expect(employee).to have_attributes(name: "Employee1") }
       it { expect(address).to have_attributes(name: "Address1") }
     end
 
     context ".preload" do
-      let(:company)  { company_relation.preload(:employees, employees: :address).first }
+      let(:company) { company_relation.preload(:employees, employees: :address).first }
       it { expect(employee).to have_attributes(name: "Employee1") }
       it { expect(address).to have_attributes(name: "Address1") }
+    end
+
+    context ".joins.left_joins" do
+      let(:company) { company_relation.joins(:employees).left_joins(:employees) }
+      it { expect(company.count).to eq(1) }
+    end
+  end
+
+  context ".left_joins" do
+    describe "using table name alias for multiple join" do
+      let!(:company) { Company.create(name: "Company") }
+      let!(:employee) { company.employees.create(name: "Jane").tap { |m| m.update(name: "Tom") } }
+
+      it 'returns a record' do
+        expect(Company.joins(:employees).left_joins(:employees).where(employees: { bitemporal_id: employee.id }).count).to eq(1)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixed by `Does not respect table alias on join clause` #24 

### before

```ruby
class Company < ActiveRecord::Base
  include ActiveRecord::Bitemporal
  has_many  :employees,  foreign_key: :company_id, autosave: true
end

class Employee < ActiveRecord::Base
  include ActiveRecord::Bitemporal
  belongs_to :company
end

p Company.joins(:employees).left_joins(:employees).where(employees: { bitemporal_id: employee.id }).count
# => 3

puts Company.joins(:employees).left_joins(:employees).where(employees: { bitemporal_id: employee.id }).to_sql
# => SELECT "companies".*
#      FROM "companies"
#     INNER JOIN "employees"
#        ON "employees"."company_id"           =  "companies"."bitemporal_id"
#       AND "employees"."valid_from"           <= '2019-05-13 08:40:40.496312'
#       AND "employees"."valid_to"             >  '2019-05-13 08:40:40.496312'
#       AND "employees"."deleted_at" IS NULL
#      LEFT OUTER JOIN "employees" "employees_companies"
#        ON "employees_companies"."company_id" =  "companies"."bitemporal_id"
#       AND "employees"."valid_from"           <= '2019-05-13 08:40:40.496426'
#       AND "employees"."valid_to"             >  '2019-05-13 08:40:40.496426'
#       AND "employees"."deleted_at" IS NULL
#     WHERE "companies"."valid_from"           <= '2019-05-13 08:40:40.496468'
#       AND "companies"."valid_to"             >  '2019-05-13 08:40:40.496468'
#       AND "companies"."deleted_at" IS NULL
#       AND "employees"."bitemporal_id"        =  1
```

### after

```ruby
class Company < ActiveRecord::Base
  include ActiveRecord::Bitemporal
  has_many  :employees,  foreign_key: :company_id, autosave: true
end

class Employee < ActiveRecord::Base
  include ActiveRecord::Bitemporal
  belongs_to :company
end

p Company.joins(:employees).left_joins(:employees).where(employees: { bitemporal_id: employee.id }).count
# => 1

puts Company.joins(:employees).left_joins(:employees).where(employees: { bitemporal_id: employee.id }).to_sql
# => SELECT "companies".*
#      FROM "companies"
#     INNER JOIN "employees"
#        ON "employees"."company_id"           =  "companies"."bitemporal_id"
#       AND "employees"."valid_from"           <= '2019-05-13 08:39:50.504885'
#       AND "employees"."valid_to"             >  '2019-05-13 08:39:50.504885'
#       AND "employees"."deleted_at" IS NULL
#      LEFT OUTER JOIN "employees" "employees_companies"
#        ON "employees_companies"."company_id" =  "companies"."bitemporal_id"
#       AND "employees_companies"."valid_from" <= '2019-05-13 08:39:50.504984'
#       AND "employees_companies"."valid_to"   >  '2019-05-13 08:39:50.504984'
#       AND "employees_companies"."deleted_at" IS NULL
#     WHERE "companies"."valid_from"           <= '2019-05-13 08:39:50.505018'
#       AND "companies"."valid_to"             >  '2019-05-13 08:39:50.505018'
#       AND "companies"."deleted_at" IS NULL
#       AND "employees"."bitemporal_id"        =  1
```