### PR TITLE
Add support changing swapped_id, when called `# reload`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [#18](https://github.com/kufu/activerecord-bitemporal/pull/18) - `ignore_valid_datetime` is not applied in `ActiveRecord::Bitemporal.valid_at!`.
 - [#21](https://github.com/kufu/activerecord-bitemporal/pull/21) - Fixed bug in multi thread with `#update`.
 - [#24](https://github.com/kufu/activerecord-bitemporal/pull/24) [#25](https://github.com/kufu/activerecord-bitemporal/pull/25) - Fixed bug. Does not respect table alias on join clause.
+- [#27](https://github.com/kufu/activerecord-bitemporal/pull/27) - Fixed a bug that `swapped_id` doesn't change after `#reload`.
 
 ### Deprecated
 

--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -50,13 +50,15 @@ module ActiveRecord::Bitemporal::Bitemporalize
     include ActiveRecord::Bitemporal::Persistence
 
     def swap_id!
-      @_swapped_id = self.id
+      @_swapped_id = nil
+      tmp_id = self.id
       self.id = self.send(bitemporal_id_key)
       clear_changes_information
+      @attributes.instance_variable_set("@_loaded_swapped_id", tmp_id)
     end
 
     def swapped_id
-      @_swapped_id || self.id
+      @attributes.instance_variable_get("@_loaded_swapped_id") || @_swapped_id || self.id
     end
 
     def bitemporal_id_key

--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -50,15 +50,13 @@ module ActiveRecord::Bitemporal::Bitemporalize
     include ActiveRecord::Bitemporal::Persistence
 
     def swap_id!
-      @_swapped_id = nil
-      tmp_id = self.id
+      @_swapped_id = self.id
       self.id = self.send(bitemporal_id_key)
       clear_changes_information
-      @attributes.instance_variable_set("@_loaded_swapped_id", tmp_id)
     end
 
     def swapped_id
-      @attributes.instance_variable_get("@_loaded_swapped_id") || @_swapped_id || self.id
+      @_swapped_id || self.id
     end
 
     def bitemporal_id_key

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -413,6 +413,7 @@ module ActiveRecord
             after_instance.save!(validate: false)
           end
           # update 後に新しく生成したインスタンスのデータを移行する
+          @attributes.instance_variable_set("@_loaded_swapped_id", nil)
           @_swapped_id = after_instance.swapped_id
           self.valid_from = after_instance.valid_from
         end

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -413,7 +413,6 @@ module ActiveRecord
             after_instance.save!(validate: false)
           end
           # update 後に新しく生成したインスタンスのデータを移行する
-          @attributes.instance_variable_set("@_loaded_swapped_id", nil)
           @_swapped_id = after_instance.swapped_id
           self.valid_from = after_instance.valid_from
         end
@@ -442,6 +441,29 @@ module ActiveRecord
         rescue
           @destroyed = false
           false
+        end
+      end
+
+      module ::ActiveRecord::Persistence
+        # MEMO: Must be override ActiveRecord::Persistence#reload
+        alias_method :active_record_bitemporal_original_reload, :reload
+        def reload(options = nil)
+          return active_record_bitemporal_original_reload(options) unless self.class.bi_temporal_model?
+
+          self.class.connection.clear_query_cache
+
+          fresh_object =
+            if options && options[:lock]
+              self.class.unscoped { self.class.lock(options[:lock]).find(id) }
+            else
+              self.class.unscoped { self.class.find(id) }
+            end
+
+          @attributes = fresh_object.instance_variable_get("@attributes")
+          @new_record = false
+          # NOTE: Hook to copying swapped_id
+          @_swapped_id = fresh_object.swapped_id
+          self
         end
       end
     end

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -515,7 +515,7 @@ RSpec.describe ActiveRecord::Bitemporal do
     end
   end
 
-  describe ".reload" do
+  describe "#reload" do
     let(:employee) { Employee.create!(name: "Tom").tap { |emp| emp.update!(name: "Jane") } }
 
     context "call #update" do

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -159,9 +159,9 @@ RSpec.describe ActiveRecord::Bitemporal do
     subject { Employee.find_at_time(time, id) }
 
     before do
-      employee.update(name: "Tom")
-      employee.update(name: "Mami")
-      employee.update(name: "Homu")
+      employee.update!(name: "Tom")
+      employee.update!(name: "Mami")
+      employee.update!(name: "Homu")
     end
 
     # Tom:    |-----------|
@@ -512,6 +512,20 @@ RSpec.describe ActiveRecord::Bitemporal do
         let(:option) { { enable_strict_by_validates_bitemporal_id: false } }
         it { is_expected.to be_falsey }
       end
+    end
+  end
+
+  describe ".reload" do
+    let(:employee) { Employee.create!(name: "Tom").tap { |emp| emp.update!(name: "Jane") } }
+
+    context "call #update" do
+      subject { -> { employee.update!(name: "Kevin") } }
+      it { is_expected.to change { employee.reload.swapped_id } }
+    end
+
+    context "call .update" do
+      subject { -> { Employee.find(employee.id).update!(name: "Kevin") } }
+      it { is_expected.to change { employee.reload.swapped_id } }
     end
   end
 


### PR DESCRIPTION
Fixed a bug that `swapped_id` doesn't change after `#reload`.

### before

```ruby
class Company < ActiveRecord::Base
  include ActiveRecord::Bitemporal
end

company = Company.create(name: "Company")
Company.find(company.id).update(name: "NeoCompany")

pp company.name         # => "Company"
pp company.swapped_id   # => 1

company.reload

# Updated name
pp company.name         # => "NeoCompany"
# Not updated swapped_id
pp company.swapped_id   # => 1
```

### after

```ruby
class Company < ActiveRecord::Base
  include ActiveRecord::Bitemporal
end

company = Company.create(name: "Company")
Company.find(company.id).update(name: "NeoCompany")

pp company.name         # => "Company"
pp company.swapped_id   # => 1

company.reload

# Updated name
pp company.name         # => "NeoCompany"
# Updated swapped_id
pp company.swapped_id   # => 3
```