### PR TITLE
Add validation in update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [#21](https://github.com/kufu/activerecord-bitemporal/pull/21) - Fixed bug in multi thread with `#update`.
 - [#24](https://github.com/kufu/activerecord-bitemporal/pull/24) [#25](https://github.com/kufu/activerecord-bitemporal/pull/25) - Fixed bug. Does not respect table alias on join clause.
 - [#27](https://github.com/kufu/activerecord-bitemporal/pull/27) - Fixed a bug that `swapped_id` doesn't change after `#reload`.
+- [#28](https://github.com/kufu/activerecord-bitemporal/pull/28) - Fix the bug that `valid_from == valid_to` record is generated.
 
 ### Deprecated
 

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -378,7 +378,7 @@ module ActiveRecord
           # 履歴データとして保存する新しいインスタンス
           # NOTE: 以前の履歴データ(現時点で有効なレコードを元にする)
           before_instance = current_valid_record.dup
-          # NOTE: 以降の履歴ところで Ruby 2.6 なので `yield_self` よりも `then` のほうがいいのではデータ(自身のインスタンスを元にする)
+          # NOTE: 以降の履歴データ(自身のインスタンスを元にする)
           after_instance = build_new_instance
 
           # force_update の場合は既存のレコードを論理削除した上で新しいレコードを生成する
@@ -401,7 +401,6 @@ module ActiveRecord
             # 以降の履歴データは valid_from と valid_to を調整して保存する
             after_instance.valid_from = target_datetime
             after_instance.valid_to = current_valid_record.valid_to
-
             raise ActiveRecord::Rollback if after_instance.valid_from_cannot_be_greater_equal_than_valid_to
             after_instance.save!(validate: false)
 

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -632,18 +632,6 @@ RSpec.describe ActiveRecord::Bitemporal do
           let(:valid_to) { finish }
         end
       end
-
-      xcontext "any updated" do
-        let(:now) { from }
-        it do
-          expect { employee.update!(name: "Tom") }.to \
-            change(employee, :swapped_id).and(change(employee, :name).from("Jone").to("Tom"))
-          expect { employee.update!(name: "Mami") }.to \
-            change(employee, :swapped_id).and(change(employee, :name).from("Tom").to("Mami"))
-          expect { employee.update!(name: "Mado") }.to \
-            change(employee, :swapped_id) .and(change(employee, :name).from("Mami").to("Mado"))
-        end
-      end
     end
 
     context "wrapper method with the same name as the column name" do

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -762,11 +762,6 @@ RSpec.describe ActiveRecord::Bitemporal do
           it { is_expected.to raise_error(ActiveRecord::RecordNotSaved) }
         end
       end
-
-      xcontext "`valid_datetime` is `company.valid_to`" do
-        let(:valid_datetime) { company.valid_to }
-        it { is_expected.not_to change(&company_count) }
-      end
     end
   end
 

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -633,15 +633,15 @@ RSpec.describe ActiveRecord::Bitemporal do
         end
       end
 
-      context "any updated" do
+      xcontext "any updated" do
         let(:now) { from }
         it do
-          expect { employee.update(name: "Tom") }.to change(employee, :swapped_id)
-            .and(change(employee, :name).from("Jone").to("Tom"))
-          expect { employee.update(name: "Mami") }.to change(employee, :swapped_id)
-            .and(change(employee, :name).from("Tom").to("Mami"))
-          expect { employee.update(name: "Mado") }.to change(employee, :swapped_id)
-            .and(change(employee, :name).from("Mami").to("Mado"))
+          expect { employee.update!(name: "Tom") }.to \
+            change(employee, :swapped_id).and(change(employee, :name).from("Jone").to("Tom"))
+          expect { employee.update!(name: "Mami") }.to \
+            change(employee, :swapped_id).and(change(employee, :name).from("Tom").to("Mami"))
+          expect { employee.update!(name: "Mado") }.to \
+            change(employee, :swapped_id) .and(change(employee, :name).from("Mami").to("Mado"))
         end
       end
     end
@@ -718,7 +718,7 @@ RSpec.describe ActiveRecord::Bitemporal do
       it { is_expected.not_to change(employee, :emp_code) }
     end
 
-    context "with `#valid_at`" do
+    context "in `#valid_at`" do
       describe "set deleted_at" do
         let(:employee) { Timecop.freeze("2019/1/1") { Employee.create!(name: "Jane") } }
         let(:time_current) { employee.updated_at + 10.days }
@@ -741,6 +741,31 @@ RSpec.describe ActiveRecord::Bitemporal do
         it do
           is_expected.to change { latest_employee.call.valid_to }.from(employee.valid_to).to(employee.valid_from)
         end
+      end
+    end
+
+    context "failure" do
+      let(:company) { Company.create!(valid_from: "2019/2/1") }
+      let(:company_count) { -> { Company.ignore_valid_datetime.bitemporal_for(company.id).count } }
+      let(:company_deleted_at) { -> { Company.ignore_valid_datetime.within_deleted.bitemporal_for(company.id).first.deleted_at } }
+      subject { -> { company.valid_at(valid_datetime) { |c| c.update(name: "Company") } } }
+
+      context "`valid_datetime` is `company.valid_from`" do
+        let(:valid_datetime) { company.valid_from }
+
+        it { expect(subject.call).to be_falsey }
+        it { is_expected.not_to change(&company_count) }
+        it { is_expected.not_to change(&company_deleted_at) }
+
+        context "call `update!`" do
+          subject { -> { company.valid_at(valid_datetime) { |c| c.update!(name: "Company") } } }
+          it { is_expected.to raise_error(ActiveRecord::RecordNotSaved) }
+        end
+      end
+
+      xcontext "`valid_datetime` is `company.valid_to`" do
+        let(:valid_datetime) { company.valid_to }
+        it { is_expected.not_to change(&company_count) }
       end
     end
   end
@@ -940,12 +965,14 @@ RSpec.describe ActiveRecord::Bitemporal do
   end
 
   describe "#touch" do
-    let(:employee) { Employee.create(name: "Jane").tap { |it| it.update(name: "Tom") } }
+    let!(:employee) { Employee.create(name: "Jane").tap { |it| it.update!(name: "Tom") } }
+    let(:employee_count) { -> { Employee.ignore_valid_datetime.bitemporal_for(employee.id).count } }
     subject { -> { employee.touch(:archived_at) } }
-    around { |e| Timecop.freeze(time_current) { e.run } }
 
+    it { expect(employee).to have_attributes(name: "Tom", id: employee.id) }
     it { expect(subject.call).to eq true }
-    it { is_expected.to change { employee.reload.archived_at }.from(nil).to(time_current) }
+    it { is_expected.to change(&employee_count).by(1) }
+    it { is_expected.to change { employee.reload.archived_at }.from(nil) }
   end
 
   describe "validation" do
@@ -1395,36 +1422,38 @@ RSpec.describe ActiveRecord::Bitemporal do
     end
 
     describe "#save" do
-      let!(:company) { Company.create!(name: "Company") }
-      let!(:company2) { Company.create!(name: "Company") }
-      subject do
-        thread_new = proc { |id|
-          Thread.new(id) { |id|
-            ActiveRecord::Base.connection_pool.with_connection do
-              company = Company.find(id)
-              company.name = "Company2"
-              if !company.save
-                expect(company.errors[:bitemporal_id]).to include("has already been taken")
+      context "multi threading" do
+        let!(:company) { Company.create!(name: "Company") }
+        let!(:company2) { Company.create!(name: "Company") }
+        subject do
+          thread_new = proc { |id|
+            Thread.new(id) { |id|
+              ActiveRecord::Base.connection_pool.with_connection do
+                company = Company.find(id)
+                company.name = "Company2"
+                if !company.save
+                  expect(company.errors[:bitemporal_id]).to include("has already been taken")
+                end
               end
-            end
+            }
           }
-        }
-        proc do
-          [
-            thread_new.call(company.id),
-            thread_new.call(company.id),
-            thread_new.call(company.id),
-            thread_new.call(company2.id),
-            thread_new.call(company2.id),
-            thread_new.call(company2.id),
-          ].each { |t| t.join(3) }
+          proc do
+            [
+              thread_new.call(company.id),
+              thread_new.call(company.id),
+              thread_new.call(company.id),
+              thread_new.call(company2.id),
+              thread_new.call(company2.id),
+              thread_new.call(company2.id),
+            ].each { |t| t.join(3) }
+          end
         end
-      end
-      it { is_expected.to change { Company.ignore_valid_datetime.count }.by(2) }
-      it do
-        subject.call
-        com1, com2 = Company.ignore_valid_datetime.bitemporal_for(company.id).order(:valid_from).last(2)
-        expect(com1.valid_to).not_to eq com2.valid_to
+        it { is_expected.to change { Company.ignore_valid_datetime.count }.by(2) }
+        it do
+          subject.call
+          com1, com2 = Company.ignore_valid_datetime.bitemporal_for(company.id).order(:valid_from).last(2)
+          expect(com1.valid_to).not_to eq com2.valid_to
+        end
       end
     end
 

--- a/spec/activerecord-bitemporal/relation_spec.rb
+++ b/spec/activerecord-bitemporal/relation_spec.rb
@@ -158,10 +158,11 @@ RSpec.describe "Relation" do
     let(:address)  { employee.address }
     before do
       @company = nil
+      address = Timecop.freeze("2018/5/1") { Address.create(name: "Address1") }
       Timecop.freeze("2019/1/1") do
         @company = Company.create(name: "Company1")
         @company.employees.create(name: "Employee1")
-        @company.employees.first.address = Address.create(name: "Address1")
+        @company.employees.first.address = address
       end
 
       Timecop.freeze("2019/1/10") do


### PR DESCRIPTION
## Progrem

There was a case where a record `valid_from == valid_to` was created.

```ruby
employee = Employee.create(name: "Tom")

ActiveRecord::Bitemporal.valid_at("2019/5/1") {
  employee.address = Address.create(name: "Tokyo")
}

pp Address.ignore_valid_datetime.bitemporal_for(employee.address.id).map { |it|
  [it.name, it.valid_from.iso8601(10), it.valid_to.iso8601(10) ]
}
# => [["Tokyo",
#      "2019-05-01T00:00:00.0000000000Z",
#      "2019-05-01T00:00:00.0000000000Z"],
#     ["Tokyo",
#      "2019-05-01T00:00:00.0000000000Z",
#      "9999-12-31T00:00:00.0000000000Z"]]
```

```ruby
employee = Employee.create(name: "Homu", valid_from: "2019/1/1")
employee.name = "Jane"

employee.valid_at("2019/1/1", &:save!)

pp Employee.ignore_valid_datetime.bitemporal_for(employee.id).order(:valid_from).map { |it|
  [it.name, it.valid_from.iso8601(10), it.valid_to.iso8601(10) ]
}
# => [["Homu",
#      "2019-01-01T00:00:00.0000000000Z",
#      "2019-01-01T00:00:00.0000000000Z"],
#     ["Jane",
#      "2019-01-01T00:00:00.0000000000Z",
#      "9999-12-31T00:00:00.0000000000Z"]]
```


## Improvement

Added `valid_from / valid_to` validation when creating records in `#update`.
`#update` will fail, if `valid_from / valid_to` is invalid.


### After fixed

```ruby
employee = Employee.create(name: "Tom")

# Error in `block in replace': Failed to save the new associated address. (ActiveRecord::RecordNotSaved)
ActiveRecord::Bitemporal.valid_at("2019/5/1") {
  employee.address = Address.create(name: "Tokyo")
}
```

```ruby
employee = Employee.create(name: "Homu", valid_from: "2019/1/1")
employee.name = "Jane"

# Error: in `save!': Failed to save the record (ActiveRecord::RecordNotSaved)
employee.valid_at("2019/1/1", &:save!)
```
