### PR TITLE
Adjusted `created_at` and `deleted_at` in `update` and `destroy`

### DIFF
--- a/spec/activerecord-bitemporal/transaction_at_spec.rb
+++ b/spec/activerecord-bitemporal/transaction_at_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe "transaction_at" do
+  describe "fix `created_at` and `deleted_at`" do
+    let(:company) { Company.create(name: "Company1") }
+    define_method(:company_all) { Company.ignore_valid_datetime.within_deleted.bitemporal_for(company.id).order(:created_at) }
+
+    before do
+      # Created any records
+      company.update!(name: "Company2")
+      company.force_update { |it| it.update!(name: "Company3") }
+    end
+
+    context "updated" do
+      it "prev.deleted_at to equal next.created_at" do
+        company.update!(name: "NewCompany")
+        expect(company_all[-3].deleted_at).to eq(company_all[-2].created_at)
+                                         .and(eq(company_all[-1].created_at))
+      end
+
+      context "with `#force_update`" do
+        it do
+          company.force_update { |it| it.update!(name: "NewCompany") }
+          expect(company_all[-2].deleted_at).to eq(company_all[-1].created_at)
+        end
+      end
+    end
+
+    context "deleted" do
+      it do
+        company.reload.destroy
+        expect(company_all[-2].deleted_at).to eq(company_all[-1].created_at)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adjusted `created_at` and` deleted_at` values of records created when `update` / `destroy` .


## Example

```ruby
require "active_record"
require "activerecord-bitemporal"

class Company < ActiveRecord::Base
  include ActiveRecord::Bitemporal
end

ActiveRecord::Base.establish_connection(
  adapter: 'postgresql',
  database: 'postgres',
  username: 'postgres',
  host: 'localhost'
)

ActiveRecord::Base.transaction do
  ActiveRecord::Schema.define(version: 1) do
    enable_extension 'pgcrypto'

    create_table :companies, force: true do |t|
      t.integer :bitemporal_id

      t.string :name

      t.datetime :valid_from
      t.datetime :valid_to
      t.datetime :deleted_at

      t.timestamps
    end
  end

  company = nil
  ActiveRecord::Bitemporal.valid_at("2019/04/01") {
    company = Company.create(name: "Company1")
  }

  ActiveRecord::Bitemporal.valid_at("2019/04/02") {
    company.update!(name: "Company2")
  }

  ActiveRecord::Bitemporal.valid_at("2019/04/03") {
    company.destroy!
  }

  puts "| id      | name       | created_at ~ deleted_at |"
  puts Company.ignore_valid_datetime.within_deleted.bitemporal_for(company.id).sort_by(&:valid_from).map { |it|
    "| id = #{"%2d" % it.swapped_id} | #{"%-10s" % it.name} | #{it.created_at.iso8601(10)} ~ #{ "%-10s" % it.deleted_at&.iso8601(10)} |"
  }.join("\n")

  raise ActiveRecord::Rollback
end
```


## Before

* `deleted_at` and `created_at` when `update` or `destroy` are not the same

| id      | name       | created_at ~ deleted_at |
| --- | --- | --- |
| id =  1 | Company1   | 2019-09-20T08:18:39.6500500000Z ~ 2019-09-20T08:18:39.6564920000Z |
| id =  2 | Company1   | 2019-09-20T08:18:39.6578010000Z ~            |
| id =  3 | Company2   | 2019-09-20T08:18:39.6596440000Z ~ 2019-09-20T08:18:39.6618600000Z |
| id =  4 | Company2   | 2019-09-20T08:18:39.6629920000Z ~            |

## After

* prev recored `deleted_at` and next record `created_at` are the same

| id      | name       | created_at ~ deleted_at |
| --- | --- | --- |
| id =  1 | Company1   | 2019-09-20T08:25:23.8348470000Z ~ 2019-09-20T08:25:23.8384700000Z |
| id =  2 | Company1   | 2019-09-20T08:25:23.8384700000Z ~            |
| id =  3 | Company2   | 2019-09-20T08:25:23.8384700000Z ~ 2019-09-20T08:25:23.8433730000Z |
| id =  4 | Company2   | 2019-09-20T08:25:23.8433730000Z ~            |
