### PR TITLE
Add validation support with created_at and deleted_at

### DIFF
--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -76,6 +76,12 @@ module ActiveRecord::Bitemporal::Bitemporalize
         errors.add(:valid_from, "can't be greater equal than valid_to")
       end
     end
+
+    def created_at_cannot_be_greater_equal_than_deleted_at
+      if created_at && deleted_at && created_at >= deleted_at
+        errors.add(:created_at, "can't be greater equal than deleted_at")
+      end
+    end
   end
 
   def bitemporalize(enable_strict_by_validates_bitemporal_id: false)
@@ -104,6 +110,7 @@ module ActiveRecord::Bitemporal::Bitemporalize
     validates :valid_from, presence: true
     validates :valid_to, presence: true
     validate :valid_from_cannot_be_greater_equal_than_valid_to
+    validate :created_at_cannot_be_greater_equal_than_deleted_at
 
     validates bitemporal_id_key, uniqueness: true, allow_nil: true, strict: enable_strict_by_validates_bitemporal_id
 

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -423,7 +423,6 @@ module ActiveRecord
           end
           # update 後に新しく生成したインスタンスのデータを移行する
           @_swapped_id = after_instance.swapped_id
-          self.created_at = after_instance.created_at
           self.valid_from = after_instance.valid_from
 
           return 1

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -530,7 +530,9 @@ module ActiveRecord
               record.id && record.swapped_id ? scope.where.not(id: record.swapped_id) : scope
             }
 
-        created_at = record.created_at || Time.current
+        # MEMO: Must refer Time.current, when not new record
+        #       Because you don't want created_at to be rewritten
+        created_at = record.new_record? ? (record.created_at || Time.current) : Time.current
         deleted_at = record.deleted_at || ActiveRecord::Bitemporal::DEFAULT_VALID_TO
         transaction_at_scope = finder_class.unscoped
           .ignore_valid_datetime

--- a/spec/activerecord-bitemporal/transaction_at_spec.rb
+++ b/spec/activerecord-bitemporal/transaction_at_spec.rb
@@ -354,7 +354,7 @@ RSpec.describe "transaction_at" do
         end
       end
 
-      context "current time in created_at ~ deleted_at" do
+      context "current time greater than deleted_at" do
         it do
           Timecop.freeze(created_at + 1000.days) {
             emp = EmployeeWithUniquness.new(valid_from: valid_from, valid_to: valid_to, name: "Jane")

--- a/spec/activerecord-bitemporal/transaction_at_spec.rb
+++ b/spec/activerecord-bitemporal/transaction_at_spec.rb
@@ -224,6 +224,14 @@ RSpec.describe "transaction_at" do
         let(:new_to) { new_from + 5.days }
         let(:active_to) { nil }
       end
+
+      # active transaction time : |<-----------------------> Infinite
+      # new transaction time    :        |<-----------------------> Infinite
+      it_behaves_like "invalid uniqueness" do
+        let(:new_from) { active_from + 5.days }
+        let(:new_to) { nil }
+        let(:active_to) { nil }
+      end
     end
 
     context "have an active models" do

--- a/spec/activerecord-bitemporal/transaction_at_spec.rb
+++ b/spec/activerecord-bitemporal/transaction_at_spec.rb
@@ -33,4 +33,334 @@ RSpec.describe "transaction_at" do
       end
     end
   end
+
+  describe "validation `created_at` `deleted_at`" do
+    let(:time_current) { Time.current.round(6) }
+    subject { employee }
+    context "with `created_at` and `deleted_at`" do
+      let(:employee) { Employee.new(name: "Jane", created_at: created_at, deleted_at: deleted_at) }
+      context "`created_at` < `deleted_at`" do
+        let(:created_at) { time_current }
+        let(:deleted_at) { created_at + 10.days }
+        it { is_expected.to be_valid }
+      end
+
+      context "`created_at` > `deleted_at`" do
+        let(:created_at) { deleted_at + 10.days }
+        let(:deleted_at) { time_current }
+        it { is_expected.to be_invalid }
+      end
+
+      context "`created_at` == `deleted_at`" do
+        let(:created_at) { time_current }
+        let(:deleted_at) { created_at }
+        it { is_expected.to be_invalid }
+      end
+
+      context "`created_at` is `nil`" do
+        let(:created_at) { nil }
+        let(:deleted_at) { time_current }
+        it { is_expected.to be_valid }
+      end
+
+      context "`deleted_at` is `nil`" do
+        let(:created_at) { time_current }
+        let(:deleted_at) { nil }
+        it { is_expected.to be_valid }
+      end
+
+      context "`created_at` and `deleted_at` is `nil`" do
+        let(:created_at) { nil }
+        let(:deleted_at) { nil }
+        it { is_expected.to be_valid }
+      end
+    end
+
+    context "with `created_at`" do
+      let(:employee) { Employee.new(name: "Jane", created_at: created_at) }
+      let(:created_at) { time_current }
+      it { is_expected.to be_valid }
+    end
+
+    context "with `deleted_at`" do
+      let(:employee) { Employee.new(name: "Jane", deleted_at: deleted_at) }
+      let(:deleted_at) { time_current + 10.days }
+      it { is_expected.to be_valid }
+    end
+
+    context "blank `created_at` and `deleted_at`" do
+      let(:employee) { Employee.new(name: "Jane") }
+      it { is_expected.to be_valid }
+    end
+
+    context "with `bitemporal_id`" do
+      let!(:employee0) { Employee.create!(name: "Jane") }
+      subject { Employee.new(name: "Jane", bitemporal_id: employee0.bitemporal_id).save }
+      it { is_expected.to be_falsey }
+    end
+  end
+
+  describe "uniqueness" do
+    class EmployeeWithUniquness < Employee
+      validates :name, uniqueness: true
+    end
+
+    let(:time_current) { Time.current.round(6) }
+    context "have an active model" do
+      shared_context "define active model" do
+        let(:active_from) { time_current }
+        let(:active_to) { active_from + 10.days }
+        before do
+          EmployeeWithUniquness.create!(name: "Jane", created_at: active_from, deleted_at: active_to)
+        end
+      end
+
+      shared_examples "valid uniqueness" do
+        include_context "define active model"
+        subject { EmployeeWithUniquness.new(name: "Jane", created_at: new_from, deleted_at: new_to) }
+        it { is_expected.to be_valid }
+      end
+
+      shared_examples "invalid uniqueness" do
+        include_context "define active model"
+        subject { EmployeeWithUniquness.new(name: "Jane", created_at: new_from, deleted_at: new_to) }
+        it { is_expected.to be_invalid }
+      end
+
+      # active transaction time :                 |<---------->|
+      # new transaction time    : |<---------->|
+      it_behaves_like "valid uniqueness" do
+        let(:new_from) { active_from - 12.days }
+        let(:new_to) { active_to - 12.days }
+      end
+
+      # active transaction time :              |<---------->|
+      # new transaction time    : |<---------->|
+      it_behaves_like "valid uniqueness" do
+        let(:new_from) { new_to - 10.days }
+        let(:new_to) { active_from }
+      end
+
+      # active transaction time :        |<---------->|
+      # new transaction time    : |<---------->|
+      it_behaves_like "invalid uniqueness" do
+        let(:new_from) { active_from - 5.days }
+        let(:new_to) { active_to - 5.days }
+      end
+
+      # active transaction time :        |<---------->|
+      # new transaction time    : |<----------------->|
+      it_behaves_like "invalid uniqueness" do
+        let(:new_from) { active_from - 15.days }
+        let(:new_to) { active_to }
+      end
+
+      # active : |<---------->|
+      # new    : |<---------->|
+      it_behaves_like "invalid uniqueness" do
+        let(:new_from) { active_from }
+        let(:new_to) { active_to }
+      end
+
+      # active : |<---------->|
+      # new    :   |<------>|
+      it_behaves_like "invalid uniqueness" do
+        let(:new_from) { active_from + 2.days }
+        let(:new_to) { active_to - 2.days }
+      end
+
+      # active :   |<---------->|
+      # new    : |<-------------->|
+      it_behaves_like "invalid uniqueness" do
+        let(:new_from) { active_from - 2.days }
+        let(:new_to) { active_to + 2.days }
+      end
+
+      # active transaction time : |<---------->|
+      # new transaction time    : |<----------------->|
+      it_behaves_like "invalid uniqueness" do
+        let(:new_from) { active_from }
+        let(:new_to) { active_to + 15.days }
+      end
+
+      # active transaction time : |<---------->|
+      # new transaction time    :        |<---------->|
+      it_behaves_like "invalid uniqueness" do
+        let(:new_from) { active_from + 5.days }
+        let(:new_to) { active_to + 5.days }
+      end
+
+      # active transaction time : |<---------->|
+      # new transaction time    :              |<---------->|
+      it_behaves_like "valid uniqueness" do
+        let(:new_from) { active_to }
+        let(:new_to) { new_from + 10.days }
+      end
+
+      # active transaction time : |<---------->|
+      # new transaction time    :                 |<---------->|
+      it_behaves_like "valid uniqueness" do
+        let(:new_from) { active_from + 12.days }
+        let(:new_to) { active_to + 12.days }
+      end
+    end
+
+    context "have an active models" do
+      shared_context "define active models" do
+        let(:active1_from) { time_current }
+        let(:active1_to) { active1_from + 10.days }
+
+        let(:active2_from) { active1_from + 40.days }
+        let(:active2_to) { active2_from + 10.days }
+
+        before do
+          EmployeeWithUniquness.create!(name: "Jane", created_at: active1_from, deleted_at: active1_to)
+          EmployeeWithUniquness.create!(name: "Jane", created_at: active2_from, deleted_at: active2_to)
+        end
+      end
+
+      shared_examples "valid uniqueness" do
+        include_context "define active models"
+        subject { EmployeeWithUniquness.new(name: "Jane", created_at: new_from, deleted_at: new_to) }
+        it { is_expected.to be_valid }
+      end
+
+      shared_examples "invalid uniqueness" do
+        include_context "define active models"
+        subject { EmployeeWithUniquness.new(name: "Jane", created_at: new_from, deleted_at: new_to) }
+        it { is_expected.to be_invalid }
+      end
+
+      # active1 transaction time : |<---------->|
+      # active2 transaction time :                                 |<---------->|
+      # new transaction time     :                 |<---------->|
+      it_behaves_like "valid uniqueness" do
+        let(:new_from) { active1_to + 2.days }
+        let(:new_to) { new_from + 10.days }
+      end
+
+      # active1 transaction time :                 |<---------->|
+      # active2 transaction time :                                 |<---------->|
+      # new transaction time     : |<---------->|
+      it_behaves_like "valid uniqueness" do
+        let(:new_from) { new_to - 10.days }
+        let(:new_to) { active1_from - 2.days }
+      end
+
+      # active1 transaction time : |<---------->|
+      # active2 transaction time :                |<---------->|
+      # new transaction time     :                               |<---------->|
+      it_behaves_like "valid uniqueness" do
+        let(:new_from) { active2_to + 2.days }
+        let(:new_to) { new_from + 10.days }
+      end
+
+      # active1 transaction time : |<---------->|
+      # active2 transaction time :          |<---------->|
+      # new transaction time     :                    |<---------->|
+      it_behaves_like "invalid uniqueness" do
+        let(:new_from) { active1_to - 2.days }
+        let(:new_to) { active2_from + 2.days }
+      end
+
+      # active1 transaction time : |<---------->|
+      # active2 transaction time :              |<---------->|
+      # new transaction time     :                           |<---------->|
+      it_behaves_like "valid uniqueness" do
+        let(:new_from) { active2_to }
+        let(:new_to) { new_from + 10.days }
+      end
+    end
+
+    xdescribe "#update" do
+      let(:employee) { EmployeeWithUniquness.create!(name: "Jane", emp_code: "000") }
+      context "any update" do
+        it do
+          expect { employee.update(emp_code: "001") }.to change(employee, :swapped_id)
+          expect { employee.update(emp_code: "002") }.to change(employee, :swapped_id)
+          expect { employee.update(emp_code: "003") }.to change(employee, :swapped_id)
+        end
+      end
+
+      context "update to name" do
+        subject { -> { employee.update!(name: "Tom") } }
+
+        context "exitst other records" do
+          context "same name" do
+            let!(:other) { EmployeeWithUniquness.create!(name: "Jane").tap { |m| m.update!(name: "Tom") } }
+            it { is_expected.to raise_error ActiveRecord::RecordInvalid }
+          end
+          context "other name" do
+            let!(:other) { EmployeeWithUniquness.create!(name: "Mami").tap { |m| m.update!(name: "Homu") }  }
+            it { is_expected.not_to raise_error }
+            it { is_expected.to change { employee.reload.name }.from("Jane").to("Tom") }
+          end
+        end
+
+        context "after updating other record" do
+          let!(:other) { EmployeeWithUniquness.create!(name: "Jane").tap { |m| m.update!(name: "Tom") } }
+          before do
+            other.update!(name: "Homu")
+          end
+          it { is_expected.not_to raise_error }
+          it { is_expected.to change { employee.reload.name }.from("Jane").to("Tom") }
+
+          context "with `valid_at`" do
+            subject { -> { employee.valid_at(Time.current - 1.days) { |m| m.update!(name: "Tom") } } }
+            it { is_expected.to raise_error ActiveRecord::RecordInvalid }
+          end
+        end
+
+        context "after destroying other record" do
+          let!(:other) { EmployeeWithUniquness.create!(name: "Jane").tap { |m| m.update!(name: "Tom") } }
+          before do
+            other.destroy
+          end
+          it { is_expected.not_to raise_error }
+          it { is_expected.to change { employee.reload.name }.from("Jane").to("Tom") }
+
+          context "with `valid_at`" do
+            subject { -> { employee.valid_at(Time.current - 1.days) { |m| m.update!(name: "Tom") } } }
+            it { is_expected.to raise_error ActiveRecord::RecordInvalid }
+          end
+        end
+      end
+    end
+
+    xdescribe ".create" do
+      subject { -> { EmployeeWithUniquness.create!(name: "Tom") } }
+      context "exists destroyed model" do
+        let(:employee) { EmployeeWithUniquness.create!(name: "Jane").tap { |it| it.update(name: "Tom") } }
+        before do
+          employee.destroy!
+        end
+        it { is_expected.not_to raise_error }
+      end
+
+      context "exists past model" do
+        before do
+          EmployeeWithUniquness.create!(name: "Tom", valid_from: "1982/12/02", valid_to: "2001/03/24")
+        end
+        it { is_expected.not_to raise_error }
+      end
+    end
+
+    context "and `valid_from`" do
+      before do
+        EmployeeWithUniquness.create(name: "Jane", valid_from: "2019/1/10", valid_to: "2019/20")
+      end
+      subject { EmployeeWithUniquness.new(name: "Jane", valid_from: "2019/1/15").valid_at("2019/1/30", &:save) }
+    end
+
+    context "`valid_datetime` out of range `valid_from` ~ `valid_to`" do
+      it { is_expected.to be_truthy }
+
+      context "empty records" do
+        before { EmployeeWithUniquness.destroy_all }
+        subject { EmployeeWithUniquness.new(valid_from: "9999/1/10").valid_at("9999/1/1", &:save) }
+        it { is_expected.to be_truthy }
+      end
+    end
+  end
+
 end

--- a/spec/activerecord-bitemporal/transaction_at_spec.rb
+++ b/spec/activerecord-bitemporal/transaction_at_spec.rb
@@ -326,13 +326,6 @@ RSpec.describe "transaction_at" do
       end
     end
 
-    context "and `valid_from`" do
-      before do
-        EmployeeWithUniquness.create(name: "Jane", valid_from: "2019/1/10", valid_to: "2019/20")
-      end
-      subject { EmployeeWithUniquness.new(name: "Jane", valid_from: "2019/1/15").valid_at("2019/1/30", &:save) }
-    end
-
     context "`valid_datetime` out of range `valid_from` ~ `valid_to`" do
       it { is_expected.to be_truthy }
 

--- a/spec/activerecord-bitemporal/transaction_at_spec.rb
+++ b/spec/activerecord-bitemporal/transaction_at_spec.rb
@@ -370,5 +370,14 @@ RSpec.describe "transaction_at" do
         end
       end
     end
+
+    context "Update with duplicate name after update" do
+      it do
+        company1 = EmployeeWithUniquness.create!(name: "Jane")
+        company2 = EmployeeWithUniquness.create!(name: "Tom")
+        company1.update!(name: "Homu")
+        expect { company2.update!(name: "Jane") }.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/activerecord-bitemporal/transaction_at_spec.rb
+++ b/spec/activerecord-bitemporal/transaction_at_spec.rb
@@ -209,6 +209,21 @@ RSpec.describe "transaction_at" do
         let(:new_from) { active_from + 12.days }
         let(:new_to) { active_to + 12.days }
       end
+
+      # active transaction time :        |<---------->|
+      # new transaction time    : |<-----------------------> Infinite
+      it_behaves_like "invalid uniqueness" do
+        let(:new_from) { active_from - 5.days }
+        let(:new_to) { nil }
+      end
+
+      # active transaction time : |<-----------------------> Infinite
+      # new transaction time    :        |<---------->|
+      it_behaves_like "invalid uniqueness" do
+        let(:new_from) { active_from + 5.days }
+        let(:new_to) { new_from + 5.days }
+        let(:active_to) { nil }
+      end
     end
 
     context "have an active models" do

--- a/spec/activerecord-bitemporal/uniqueness_spec.rb
+++ b/spec/activerecord-bitemporal/uniqueness_spec.rb
@@ -308,9 +308,10 @@ RSpec.describe ActiveRecord::Bitemporal::Uniqueness do
 
     context "and `valid_from`" do
       before do
-        EmployeeWithUniquness.create(name: "Jane", valid_from: "2019/1/10", valid_to: "2019/20")
+        EmployeeWithUniquness.create(name: "Jane", valid_from: "2019/1/10", valid_to: "2019/1/20")
       end
       subject { EmployeeWithUniquness.new(name: "Jane", valid_from: "2019/1/15").valid_at("2019/1/30", &:save) }
+      it { is_expected.to be_falsey }
     end
 
     context "`valid_datetime` out of range `valid_from` ~ `valid_to`" do


### PR DESCRIPTION
## Overview

Don't duplicate in `created_at ~ deleted_at` .
Add validation support with `created_at ~ deleted_at` .


## Before

* Validation error, when is duplicated `valid_from ~ valid_to`

```ruby
# deleted_at is nil
company1 = Company.create!(created_at: "2019/04/01", valid_from: "2019/01/01", valid_to: "2019/06/01", name: "Company")

# Not duplicated for company1
company2 = Company.new(created_at: "2019/01/01", valid_from: "2019/07/01", valid_to: "2019/10/01", name: "Company")
pp company2.valid?
# => true

# Duplicated `valid_from ~ valid_to` only for company1
company2 = Company.new(created_at: "2019/01/01", deleted_at: "2019/03/01", valid_from: "2019/04/01", valid_to: "2019/07/01", name: "Company")
pp company2.valid?
# => false

# Duplicated `created_at ~ deleted_at` only for company1
company2 = Company.new(created_at: "2019/05/01", deleted_at: "2019/12/01", valid_from: "2019/07/01", valid_to: "2019/10/01", name: "Company")
pp company2.valid?
# => true

# Duplicated `created_at ~ deleted_at` and `valid_from ~ valid_to` only for company1
company2 = Company.new(created_at: "2019/03/01", deleted_at: "2019/09/01", valid_from: "2019/05/01", valid_to: "2019/06/01", name: "Company")
pp company2.valid?
# => false
```


## After

* Validation error, when is duplicated `created_at ~ deleted_at` and `valid_from ~ valid_to`

```ruby
# deleted_at is nil
company1 = Company.create!(created_at: "2019/04/01", valid_from: "2019/01/01", valid_to: "2019/06/01", name: "Company")

# Not duplicated for company1
company2 = Company.new(created_at: "2019/01/01", valid_from: "2019/07/01", valid_to: "2019/10/01", name: "Company")
pp company2.valid?
# => true

# Duplicated `valid_from ~ valid_to` only for company1
company2 = Company.new(created_at: "2019/01/01", deleted_at: "2019/03/01", valid_from: "2019/04/01", valid_to: "2019/07/01", name: "Company")
pp company2.valid?
# => true

# Duplicated `created_at ~ deleted_at` only for company1
company2 = Company.new(created_at: "2019/05/01", deleted_at: "2019/12/01", valid_from: "2019/07/01", valid_to: "2019/10/01", name: "Company")
pp company2.valid?
# => true

# Duplicated `created_at ~ deleted_at` and `valid_from ~ valid_to` only for company1
company2 = Company.new(created_at: "2019/03/01", deleted_at: "2019/09/01", valid_from: "2019/05/01", valid_to: "2019/06/01", name: "Company")
pp company2.valid?
# => false
```

* And invalid `created_at` and `deleted_at`

```ruby
# Error: `raise_validation_error': Validation failed: Created at can't be greater equal than deleted_at (ActiveRecord::RecordInvalid)
Company.create!(name: "Company1", created_at: "2019/04/01", deleted_at: "2019/04/01")
# Error: `raise_validation_error': Validation failed: Created at can't be greater equal than deleted_at (ActiveRecord::RecordInvalid)
Company.create!(name: "Company1", created_at: "2019/10/01", deleted_at: "2019/04/01")
```


### All code

```ruby
require "active_record"
require "activerecord-bitemporal"

class Company < ActiveRecord::Base
  include ActiveRecord::Bitemporal
  validates :name, uniqueness: true
end

ActiveRecord::Base.establish_connection(
  adapter: 'postgresql',
  database: 'postgres',
  username: 'postgres',
  host: 'localhost'
)

ActiveRecord::Base.transaction do
  ActiveRecord::Schema.define(version: 1) do
    enable_extension 'pgcrypto'

    create_table :companies, force: true do |t|
      t.integer :bitemporal_id

      t.string :name

      t.datetime :valid_from
      t.datetime :valid_to
      t.datetime :deleted_at

      t.timestamps
    end
  end


  # deleted_at is nil
  company1 = Company.create!(created_at: "2019/04/01", valid_from: "2019/01/01", valid_to: "2019/06/01", name: "Company")

  # Not duplicated for company1
  company2 = Company.new(created_at: "2019/01/01", valid_from: "2019/07/01", valid_to: "2019/10/01", name: "Company")
  pp company2.valid?
  # => true

  # Duplicated `valid_from ~ valid_to` only for company1
  company2 = Company.new(created_at: "2019/01/01", deleted_at: "2019/03/01", valid_from: "2019/04/01", valid_to: "2019/07/01", name: "Company")
  pp company2.valid?
  # => false

  # Duplicated `created_at ~ deleted_at` only for company1
  company2 = Company.new(created_at: "2019/05/01", deleted_at: "2019/12/01", valid_from: "2019/07/01", valid_to: "2019/10/01", name: "Company")
  pp company2.valid?
  # => true

  # Duplicated `created_at ~ deleted_at` and `valid_from ~ valid_to` only for company1
  company2 = Company.new(created_at: "2019/03/01", deleted_at: "2019/09/01", valid_from: "2019/05/01", valid_to: "2019/06/01", name: "Company")
  pp company2.valid?
  # => false

  raise ActiveRecord::Rollback
end
``
`

