### PR TITLE
`force_update` does not refer to `valid_datetime` in validation

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -513,7 +513,7 @@ module ActiveRecord
           end
         }
 
-        # MEMO: `force_update` does not refer to` valid_datetime`
+        # MEMO: `force_update` does not refer to `valid_datetime`
         valid_from = record.valid_from if record.force_update?
 
         valid_to = record.valid_to.yield_self { |valid_to|

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -513,6 +513,9 @@ module ActiveRecord
           end
         }
 
+        # MEMO: `force_update` does not refer to` valid_datetime`
+        valid_from = record.valid_from if record.force_update?
+
         valid_to = record.valid_to.yield_self { |valid_to|
           # レコードを更新する時に valid_datetime が valid_from ~ valid_to の範囲外だった場合、
           #   一番近い未来の履歴レコードを参照して更新する

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -786,6 +786,22 @@ RSpec.describe ActiveRecord::Bitemporal do
         expect(Employee.ignore_valid_datetime.where(name: "Jane", deleted_at: nil).exists?).to be_falsey
       end
     end
+
+    context "within `valid_at`" do
+      class EmployeeWithUniquness < Employee
+        validates :name, uniqueness: true
+      end
+
+      it do
+        EmployeeWithUniquness.create!(name: "Company1", valid_from: "2019/04/01", valid_to: "2019/06/01")
+        company = EmployeeWithUniquness.create!(name: "Company0", valid_from: "2019/07/01")
+        expect {
+          ActiveRecord::Bitemporal.valid_at("2019/05/01") {
+            company.force_update { |it| it.update!(name: "Company1") }
+          }
+        }.to_not raise_error
+      end
+    end
   end
 
   describe "#force_update?" do


### PR DESCRIPTION
## Overview

* `#force_update` does not refer to `valid_datetime`
  * e.g. `model.force_update { |m| m.save! }`
* However, `valid_datetime` was referenced during validation
* Don't refer to `valid_datetime` in validation with `#force_update`


## Before

```ruby
class Company < ActiveRecord::Base
  include ActiveRecord::Bitemporal
  validates :name, uniqueness: true
end


company1 = Company.create!(name: "Company1", valid_from: "2019/04/01", valid_to: "2019/06/01")
company2 = Company.create!(name: "Company0", valid_from: "2019/07/01")

ActiveRecord::Bitemporal.valid_at("2019/05/01") {
  # Error: `raise_validation_error': Validation failed: Name has already been taken (ActiveRecord::RecordInvalid)
  # `valid_from` is "2019/05/01" in validation
  company2.force_update { |it| it.update!(name: "Company1") }
}
```

## After

```ruby
class Company < ActiveRecord::Base
  include ActiveRecord::Bitemporal
  validates :name, uniqueness: true
end


company1 = Company.create!(name: "Company1", valid_from: "2019/04/01", valid_to: "2019/06/01")
company2 = Company.create!(name: "Company0", valid_from: "2019/07/01")

ActiveRecord::Bitemporal.valid_at("2019/05/01") {
  # OK
  company2.force_update { |it| it.update!(name: "Company1") }
}
```

### All code

```ruby
require "active_record"
require "activerecord-bitemporal"

class Company < ActiveRecord::Base
  include ActiveRecord::Bitemporal
  validates :name, uniqueness: true
end

ActiveRecord::Base.establish_connection(
  adapter: 'postgresql',
  database: 'postgres',
  username: 'postgres',
  host: 'localhost'
)

ActiveRecord::Base.transaction do
  ActiveRecord::Schema.define(version: 1) do
    enable_extension 'pgcrypto'

    create_table :companies, force: true do |t|
      t.integer :bitemporal_id

      t.string :name

      t.datetime :valid_from
      t.datetime :valid_to
      t.datetime :deleted_at

      t.timestamps
    end
  end

  company1 = Company.create!(name: "Company1", valid_from: "2019/04/01", valid_to: "2019/06/01")
  company2 = Company.create!(name: "Company0", valid_from: "2019/07/01")

  ActiveRecord::Bitemporal.valid_at("2019/05/01") {
    # OK
    company2.force_update { |it| it.update!(name: "Company1") }
  }

  raise ActiveRecord::Rollback
end
```

