### PR TITLE
Fix id equal bitemporal_id

### DIFF
--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -92,6 +92,7 @@ module ActiveRecord::Bitemporal::Bitemporalize
     after_create do
       # MEMO: #update_columns is not call #_update_row (and validations, callbacks)
       update_columns(bitemporal_id_key => swapped_id) unless send(bitemporal_id_key)
+      swap_id!
     end
 
     after_find do

--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -49,10 +49,10 @@ module ActiveRecord::Bitemporal::Bitemporalize
   module InstanceMethods
     include ActiveRecord::Bitemporal::Persistence
 
-    def swap_id!
+    def swap_id!(without_clear_changes_information: false)
       @_swapped_id = self.id
       self.id = self.send(bitemporal_id_key)
-      clear_changes_information
+      clear_changes_information unless without_clear_changes_information
     end
 
     def swapped_id
@@ -92,7 +92,7 @@ module ActiveRecord::Bitemporal::Bitemporalize
     after_create do
       # MEMO: #update_columns is not call #_update_row (and validations, callbacks)
       update_columns(bitemporal_id_key => swapped_id) unless send(bitemporal_id_key)
-      swap_id!
+      swap_id!(without_clear_changes_information: true)
     end
 
     after_find do

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe ActiveRecord::Bitemporal do
             previous_changes: include(
               "id" => [nil, subject.swapped_id],
               "valid_from" => [nil, be_present],
-              "valid_to" => [nil, ActiveRecord::Bitemporal::DEFAULT_VALID_TO],
+              "valid_to" => [nil, "2019/10/01".in_time_zone],
               "name" => [nil, "Tom"]
             )
           )

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -20,8 +20,10 @@ RSpec.describe ActiveRecord::Bitemporal do
       subject { Employee.create!(name: "Tom", **attributes) }
 
       context "with `bitemporal_id`" do
-        let(:attributes) { { bitemporal_id: 3 } }
-        it { is_expected.to have_attributes bitemporal_id: 3 }
+        let(:other_record) { Employee.create!(name: "Jane", valid_from: "2019/01/01", valid_to: "2019/04/01") }
+        let(:attributes) { { bitemporal_id: other_record.id, valid_from: "2019/04/01", valid_to: "2019/10/01" } }
+        it { is_expected.to have_attributes bitemporal_id: other_record.id }
+        it { is_expected.to have_attributes bitemporal_id: subject.id }
       end
 
       context "blank `bitemporal_id`" do

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -22,12 +22,32 @@ RSpec.describe ActiveRecord::Bitemporal do
       context "with `bitemporal_id`" do
         let(:other_record) { Employee.create!(name: "Jane", valid_from: "2019/01/01", valid_to: "2019/04/01") }
         let(:attributes) { { bitemporal_id: other_record.id, valid_from: "2019/04/01", valid_to: "2019/10/01" } }
+        it {
+          is_expected.to have_attributes(
+            bitemporal_id: subject.id,
+            previous_changes: include(
+              "id" => [nil, subject.swapped_id],
+              "valid_from" => [nil, be_present],
+              "valid_to" => [nil, ActiveRecord::Bitemporal::DEFAULT_VALID_TO],
+              "name" => [nil, "Tom"]
+            )
+          )
+        }
         it { is_expected.to have_attributes bitemporal_id: other_record.id }
-        it { is_expected.to have_attributes bitemporal_id: subject.id }
       end
 
-      context "blank `bitemporal_id`" do
-        it { is_expected.to have_attributes bitemporal_id: subject.id }
+      context "without `bitemporal_id`" do
+        it {
+          is_expected.to have_attributes(
+            bitemporal_id: subject.id,
+            previous_changes: include(
+              "id" => [nil, subject.id],
+              "valid_from" => [nil, be_present],
+              "valid_to" => [nil, ActiveRecord::Bitemporal::DEFAULT_VALID_TO],
+              "name" => [nil, "Tom"]
+            )
+          )
+        }
       end
 
       context "blank `valid_from` and `valid_to`" do


### PR DESCRIPTION
## Summry

Fixed id and bitemporal_id may not be equal.


## Steps to reproduce

1. create record
2. create other record with `bitemporal_id`
3. `2.` record is not `id` equal `bitemporal_id`, `id` is original `id`



## Expected behavior

```ruby
company = Company.create(valid_from: "2019/01/01", valid_to: "2019/04/01")
company2 = Company.create(valid_from: "2019/04/01", valid_to: "2019/10/01", bitemporal_id: company.id)

# return company.bitemporal_id
company2.bitemporal_id          # => 1

# return company2.bitemporal_id
company2.id                     # => 1

# return company2 original id
company2.swapped_id             # => 2
```


## Actual behavior

```ruby
company = Company.create(valid_from: "2019/01/01", valid_to: "2019/04/01")
company2 = Company.create(valid_from: "2019/04/01", valid_to: "2019/10/01", bitemporal_id: company.id)

# return company.bitemporal_id
company2.bitemporal_id          # => 1

# return company2.bitemporal_id(wrong)
company2.id                     # => 2

# return company2 original id
company2.swapped_id             # => 2
```

