### PR TITLE
Improve bitemporal scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Timecop.freeze("2019/1/10") {
 
 以下のようなレコードが生成されます。
 
-| id | bitemporal_id | emp_code | name | valid_from | valid_to | deleted_at |
+| id | bitemporal_id | emp_code | name | valid_from | valid_to | transaction_from | transaction_to |
 |  --- | --- | --- | --- | --- | --- | --- |
-| 1 | 1 | 001 | Jane | 2019-01-10 00:00:00 UTC | 9999-12-31 00:00:00 UTC | NULL |
+| 1 | 1 | 001 | Jane | 2019-01-10 | 9999-12-31 | 2019-01-10 | 2019-01-15 |
 
 そのモデルに対して更新を行うと
 
@@ -58,11 +58,11 @@ Timecop.freeze("2019/1/15") {
 
 次のような履歴レコードが暗黙的に生成されます。
 
-| id | bitemporal_id | emp_code | name | valid_from | valid_to | deleted_at |
+| id | bitemporal_id | emp_code | name | valid_from | valid_to | transaction_from | transaction_to |
 |  --- | --- | --- | --- | --- | --- | --- |
-| 1 | 1 | 001 | Jane | 2019-01-10 00:00:00 UTC | 9999-12-31 00:00:00 UTC | 2019-01-15 00:00:00 UTC |
-| 2 | 1 | 001 | Jane | 2019-01-10 00:00:00 UTC | 2019-01-15 00:00:00 UTC | NULL |
-| 3 | 1 | 001 | Tom | 2019-01-15 00:00:00 UTC | 9999-12-31 00:00:00 UTC | NULL |
+| 1 | 1 | 001 | Jane | 2019-01-10 | 9999-12-31 | 2019-01-10 | 2019-01-15 |
+| 2 | 1 | 001 | Jane | 2019-01-10 | 2019-01-15 | 2019-01-15 | 9999-12-31 |
+| 3 | 1 | 001 | Tom | 2019-01-15 | 9999-12-31 | 2019-01-15 | 9999-12-31 |
 
 更に更新すると
 
@@ -84,13 +84,13 @@ Timecop.freeze("2019/1/20") {
 
 更新する度にどんどん履歴レコードが増えていきます。
 
-| id | bitemporal_id | emp_code | name | valid_from | valid_to | deleted_at |
-|  --- | --- | --- | --- | --- | --- | --- |
-| 1 | 1 | 001 | Jane | 2019-01-10 00:00:00 UTC | 9999-12-31 00:00:00 UTC | 2019-01-15 00:00:00 UTC |
-| 2 | 1 | 001 | Jane | 2019-01-10 00:00:00 UTC | 2019-01-15 00:00:00 UTC | NULL |
-| 3 | 1 | 001 | Tom | 2019-01-15 00:00:00 UTC | 9999-12-31 00:00:00 UTC | 2019-01-20 00:00:00 UTC |
-| 4 | 1 | 001 | Tom | 2019-01-15 00:00:00 UTC | 2019-01-20 00:00:00 UTC | NULL |
-| 5 | 1 | 001 | Kevin | 2019-01-20 00:00:00 UTC | 9999-12-31 00:00:00 UTC | NULL |
+| id | bitemporal_id | emp_code | name | valid_from | valid_to | transaction_from | transaction_to |
+|  --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | 1 | 001 | Jane | 2019-01-10 | 9999-12-31 | 2019-01-10 | 2019-01-15 |
+| 2 | 1 | 001 | Jane | 2019-01-10 | 2019-01-15 | 2019-01-15 | 9999-12-31 |
+| 3 | 1 | 001 | Tom | 2019-01-15 | 9999-12-31 | 2019-01-15 | 2019-01-20 |
+| 4 | 1 | 001 | Tom | 2019-01-15 | 2019-01-20 | 2019-01-20 | 9999-12-31 |
+| 5 | 1 | 001 | Kevin | 2019-01-20 | 9999-12-31 | 2019-01-20 | 9999-12-31 |
 
 また、レコードを読み込む場合は暗黙的に『一番最新のレコード』を参照します。
 
@@ -119,14 +119,15 @@ Timecop.freeze("2019/1/25") {
 
   # 最新のみ参照する
   pp Employee.all
-  # => #<Employee:0x000055ee191468a8
-  #     id: 1,
-  #     bitemporal_id: 1,
-  #     emp_code: "001",
-  #     name: "Kevin",
-  #     valid_from: 2019-01-20 00:00:00 UTC,
-  #     valid_to: 9999-12-31 00:00:00 UTC,
-  #     deleted_at: nil>
+  # [#<Employee:0x0000559b1b37eb08
+  #   id: 1,
+  #   bitemporal_id: 1,
+  #   emp_code: "001",
+  #   name: "Kevin",
+  #   valid_from: 2019-01-20,
+  #   valid_to: 9999-12-31,
+  #   transaction_from: 2019-01-20,
+  #   transaction_to: 9999-12-31>]
 }
 ```
 
@@ -180,7 +181,8 @@ ActiveRecord::Schema.define(version: 1) do
     t.integer :bitemporal_id
     t.datetime :valid_from
     t.datetime :valid_to
-    t.datetime :deleted_at
+    t.datetime :transaction_from
+    t.datetime :transaction_to
   end
 end
 ```
@@ -189,10 +191,11 @@ end
 
 | カラム名 | 型 | 値 |
 | --- | --- | --- |
-| `bitemporal_id` | `id` と同じ型 |  履歴データが共通で持つ `id` |
-| `valid_from` | `datetime` | 履歴の有効な開始時間 |
-| `valid_to` | `datetime` | 履歴の有効な終了時間 |
-| `deleted_at` | `datetime` | 論理削除された時間 |
+| `bitemporal_id` | `id` と同じ型 |  BTDM が共通で持つ `id` |
+| `valid_from` | `datetime` | 有効時間の開始時刻 |
+| `valid_to` | `datetime` | 有効時間の終了時刻 |
+| `transaction_from` | `datetime` | システム時間の開始時刻 |
+| `transaction_to` | `datetime` | システム時間の終了終了 |
 
 また、モデルクラスでは `ActiveRecord::Bitemporal` を `include` をする必要があります。
 
@@ -226,9 +229,9 @@ Timecop.freeze("2019/1/10") {
 
 以下のようなレコードが生成されます。
 
-| id | bitemporal_id | emp_code | name | valid_from | valid_to | deleted_at |
-|  --- | --- | --- | --- | --- | --- | --- |
-| 1 | 1 | 001 | Jane | 2019-01-10 00:00:00 UTC | 9999-12-31 00:00:00 UTC | NULL |
+| id | bitemporal_id | emp_code | name | valid_from | valid_to | transaction_from | transaction_to |
+|  --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | 1 | 001 | Jane | 2019-01-10 | 9999-12-31 | 2019-01-10 | 9999-12-31 |
 
 この時に生成されるレコードのカラムには暗黙的に以下のような値が保存されます。
 
@@ -270,20 +273,20 @@ Timecop.freeze("2019/1/20") {
 
 上記の操作を行うと以下のようなレコードが生成されます。
 
-| id | bitemporal_id | emp_code | name | valid_from | valid_to | deleted_at |
-|  --- | --- | --- | --- | --- | --- | --- |
-| 1 | 1 | 001 | Jane | 2019-01-10 00:00:00 UTC | 9999-12-31 00:00:00 UTC | 2019-01-20 00:00:00 UTC |
-| 2 | 1 | 001 | Jane | 2019-01-10 00:00:00 UTC | 2019-01-20 00:00:00 UTC | NULL |
-| 3 | 1 | 001 | Tom | 2019-01-20 00:00:00 UTC | 9999-12-31 00:00:00 UTC | NULL |
+| id | bitemporal_id | emp_code | name | valid_from | valid_to | transaction_from | transaction_to |
+|  --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | 1 | 001 | Jane | 2019-01-10 | 9999-12-31 | 2019-01-10 | 2019-01-20 |
+| 2 | 1 | 001 | Jane | 2019-01-10 | 2019-01-20 | 2019-01-20 | 9999-12-31 |
+| 3 | 1 | 001 | Tom | 2019-01-20 | 9999-12-31 | 2019-01-20 | 9999-12-31 |
 
 更新時には以下のような処理を行っており、結果的に新しいレコードが2つ生成されることになります。
 また、この時に生成されるレコードは共通の `bitemporal_id` を保持します。
 
-1. 更新対象のレコード（`id = 1`）を論理削除する
-2. 更新を行った時間までの履歴レコード（`id = 2`）を新しく生成する
-3. 更新を行った時間からの履歴レコード（`id = 3`）を新しく生成する
+1. 更新対象のレコード（`id = 1`）のシステム時間の終了時刻を更新する
+2. 更新を行った時間までのレコード（`id = 2`）を新しく生成する
+3. 更新を行った時間からのレコード（`id = 3`）を新しく生成する
 
-activerecord-bitemporal ではレコードの内容を変更する際にレコードを直接変更するのではなくて『既存のレコードは論理削除』して『変更後のレコードを新しく生成』していきます。
+activerecord-bitemporal ではレコードの内容を変更する際にレコードを直接変更するのではなくて『既存のレコードはシステム時間では参照しないような時刻』にして『変更後のレコードを新しく生成』していきます。
 ただし、`#update_columns` で更新を行うと強制的にレコードが上書きされるので注意してください。
 
 ```ruby
@@ -301,11 +304,11 @@ Timecop.freeze("2019/1/20") {
 上記の場合は以下のようなレコードになります。
 `id = 1` のレコードが直接変更されるので注意してください。
 
-| id | bitemporal_id | emp_code | name | valid_from | valid_to | deleted_at |
-|  --- | --- | --- | --- | --- | --- | --- |
-| 1 | 1 | 001 | Tom | 2019-01-10 00:00:00 UTC | 9999-12-31 00:00:00 UTC | NULL |
+| id | bitemporal_id | emp_code | name | valid_from | valid_to | transaction_from | transaction_to |
+|  --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | 1 | 001 | Tom | 2019-01-10 | 9999-12-31 | 2019-01-10 | 9999-12-31 |
 
-論理削除を行いつつ上書きして更新したいのであれば activerecord-bitemporal 側で用意している `#force_update` を利用する事が出来ます。
+離席を生成せずに上書きして更新したいのであれば activerecord-bitemporal 側で用意している `#force_update` を利用する事が出来ます。
 
 ```ruby
 employee = nil
@@ -317,19 +320,19 @@ Timecop.freeze("2019/1/20") {
   # #force_update のでは自身を受け取る
   # このブロック内であれば履歴を生成せずにレコードの変更が行われる
   employee.force_update { |employee|
-    employee.update_columns(name: "Tom")
+    employee.update(name: "Tom")
   }
 }
 ```
 
 上記の場合は以下のレコードが生成されます。
 
-| id | bitemporal_id | emp_code | name | valid_from | valid_to | deleted_at |
-|  --- | --- | --- | --- | --- | --- | --- |
-| 1 | 1 | 001 | Jane | 2019-01-10 00:00:00 UTC | 9999-12-31 00:00:00 UTC | 2019-01-20 00:00:00 UTC |
-| 2 | 1 | 001 | Tom | 2019-01-10 00:00:00 UTC | 9999-12-31 00:00:00 UTC | NULL |
+| id | bitemporal_id | emp_code | name | valid_from | valid_to | transaction_from | transaction_to |
+|  --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | 1 | 001 | Jane | 2019-01-10 | 9999-12-31 | 2019-01-10 | 2019-01-20 |
+| 2 | 1 | 001 | Tom | 2019-01-10 | 9999-12-31 | 2019-01-20 | 9999-12-31 |
 
-この場合は `id = 1` が論理削除され、新しい `id = 2` のレコードが生成されます。
+この場合は `id = 1` はシステムの終了時刻が更新され、新しい `id = 2` のレコードが生成されます。
 
 
 ### 更新時間を指定して更新
@@ -339,7 +342,7 @@ TODO:
 
 ### 削除
 
-更新と同様にレコードを論理削除しつつ、新しいレコードが生成されます。
+更新と同様にレコードのシステム時間の終了時刻を更新しつつ、新しいレコードが生成されます。
 
 ```ruby
 employee = nil
@@ -359,19 +362,19 @@ Timecop.freeze("2019/1/30") {
 
 上記の場合では以下のようなレコードが生成されます。
 
-| id | bitemporal_id | emp_code | name | valid_from | valid_to | deleted_at |
-|  --- | --- | --- | --- | --- | --- | --- |
-| 1 | 1 | 001 | Jane | 2019-01-10 00:00:00 UTC | 9999-12-31 00:00:00 UTC | 2019-01-20 00:00:00 UTC |
-| 2 | 1 | 001 | Jane | 2019-01-10 00:00:00 UTC | 2019-01-20 00:00:00 UTC | NULL |
-| 3 | 1 | 001 | Tom | 2019-01-20 00:00:00 UTC | 9999-12-31 00:00:00 UTC | 2019-01-30 00:00:00 UTC |
-| 4 | 1 | 001 | Tom | 2019-01-20 00:00:00 UTC | 2019-01-30 00:00:00 UTC | NULL |
+| id | bitemporal_id | emp_code | name | valid_from | valid_to | transaction_from | transaction_to |
+|  --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | 1 | 001 | Jane | 2019-01-10 | 9999-12-31 | 2019-01-10 | 2019-01-20 |
+| 2 | 1 | 001 | Jane | 2019-01-10 | 2019-01-20 | 2019-01-20 | 9999-12-31 |
+| 3 | 1 | 001 | Tom | 2019-01-20 | 9999-12-31 | 2019-01-20 | 2019-01-30 |
+| 4 | 1 | 001 | Tom | 2019-01-20 | 2019-01-30 | 2019-01-30 | 9999-12-31 |
 
 削除も更新と同様に
 
-1. 削除対象のレコード（`id = 3`）を論理削除する
+1. 削除対象のレコード（`id = 3`）のシステム時間の終了時刻を更新する
 2. 削除を行った時間までの履歴レコード（`id = 4`）を新しく生成する
 
-という風に『論理削除してから新しいレコードを生成する』という処理を行っています。
+という風に『システム時間の終了時刻を更新してから新しいレコードを生成する』という処理を行っています。
 
 
 ### ユニーク制約
@@ -412,7 +415,7 @@ BTDM では DB からレコードを参照する場合、暗黙的に
 Timecop.freeze("2019/1/20") {
   # 現在の時間の履歴を返すために暗黙的に時間指定や論理削除されたレコードが除かれる
   puts Employee.all.to_sql
-  # => SELECT "employees".* FROM "employees" WHERE "employees"."valid_from" <= '2019-01-20 00:00:00' AND "employees"."valid_to" > '2019-01-20 00:00:00' AND "employees"."deleted_at" IS NULL
+  # => SELECT "employees".* FROM "employees" WHERE "employees"."valid_from" <= '2019-01-20 00:00:00' AND "employees"."valid_to" > '2019-01-20 00:00:00' AND "employees"."transaction_to" = '9999-12-31 00:00:00'
 }
 ```
 
@@ -435,14 +438,15 @@ Timecop.freeze("2019/1/20") {
   # => 1
 
   pp Employee.first
-  # => #<Employee:0x000056230b1ecdf8
+  # => #<Employee:0x000055efd894e9e0
   #     id: 1,
   #     bitemporal_id: 1,
   #     emp_code: nil,
   #     name: "Tom",
-  #     valid_from: 2019-01-15 00:00:00 UTC,
-  #     valid_to: 9999-12-31 00:00:00 UTC,
-  #     deleted_at: nil>
+  #     valid_from: 2019-01-15,
+  #     valid_to: 9999-12-31,
+  #     transaction_from: 2019-01-15,
+  #     transaction_to: 9999-12-31>
 
   # 更新前の名前で検索しても引っかからない
   pp Employee.where(name: "Jane").first
@@ -450,7 +454,7 @@ Timecop.freeze("2019/1/20") {
 
   # なぜなら暗黙的に時間指定のクエリが追加されている為
   puts Employee.where(name: "Jane").to_sql
-  # => SELECT "employees".* FROM "employees" WHERE "employees"."valid_from" <= '2019-01-20 00:00:00' AND "employees"."valid_to" > '2019-01-20 00:00:00' AND "employees"."deleted_at" IS NULL AND "employees"."name" = 'Jane'
+  # => SELECT "employees".* FROM "employees" WHERE "employees"."valid_from" <= '2019-01-20 00:00:00' AND "employees"."valid_to" > '2019-01-20 00:00:00' AND "employees"."transaction_to" = '9999-12-31 00:00:00' AND "employees"."name" = 'Jane'
 }
 ```
 
@@ -460,7 +464,7 @@ Timecop.freeze("2019/1/20") {
 ```ruby
 # default_scope であれば unscoped で無効化することが出来るが、BTDM のデフォルトクエリはそのまま
 puts Employee.unscoped { Employee.all.to_sql }
-# => SELECT "employees".* FROM "employees" WHERE "employees"."valid_from" <= '2019-01-20 00:00:00' AND "employees"."valid_to" > '2019-01-20 00:00:00' AND "employees"."deleted_at" IS NULL
+# => SELECT "employees".* FROM "employees" WHERE "employees"."valid_from" <= '2019-10-25 07:56:06.731259' AND "employees"."valid_to" > '2019-10-25 07:56:06.731259' AND "employees"."transaction_to" = '9999-12-31 00:00:00'
 ```
 
 
@@ -478,7 +482,7 @@ puts Employee.unscoped { Employee.all.to_sql }
 Timecop.freeze("2019/1/20") {
   # 時間指定をしているクエリを取り除く
   puts Employee.ignore_valid_datetime.to_sql
-  # => SELECT "employees".* FROM "employees" WHERE "employees"."deleted_at" IS NULL
+  # => SELECT "employees".* FROM "employees" WHERE "employees"."transaction_to" = '9999-12-31 00:00:00'
 
   # 論理削除しているレコードも含める
   puts Employee.within_deleted.to_sql
@@ -530,7 +534,7 @@ Timecop.freeze("2019/1/15") {
 Timecop.freeze("2019/1/20") {
   # valid_at で任意の時間を参照して検索する事が出来る
   puts Employee.valid_at("2019/1/10").to_sql
-  # => SELECT "employees".* FROM "employees" WHERE "employees"."valid_from" <= '2019-01-10 00:00:00' AND "employees"."valid_to" > '2019-01-10 00:00:00' AND "employees"."deleted_at" IS NULL
+  # => SELECT "employees".* FROM "employees" WHERE "employees"."valid_from" <= '2019-01-10 00:00:00' AND "employees"."valid_to" > '2019-01-10 00:00:00' AND "employees"."transaction_to" = '9999-12-31 00:00:00'
 
   pp Employee.valid_at("2019/1/10").map(&:name)
   # => ["Jane"]
@@ -539,14 +543,15 @@ Timecop.freeze("2019/1/20") {
 
   # そのまま続けてリレーション出来る
   pp Employee.valid_at("2019/1/17").where(name: "Tom").first
-  # => #<Employee:0x000055ccb3ec58d0
+  # => #<Employee:0x000055678afd1d20
   #     id: 1,
   #     bitemporal_id: 1,
   #     emp_code: "001",
   #     name: "Tom",
-  #     valid_from: 2019-01-15 00:00:00 UTC,
-  #     valid_to: 9999-12-31 00:00:00 UTC,
-  #     deleted_at: nil>
+  #     valid_from: 2019-01-15,
+  #     valid_to: 9999-12-31,
+  #     transaction_from: 2019-01-15,
+  #     transaction_to: 9999-12-31>
 }
 ```
 
@@ -572,9 +577,10 @@ Timecop.freeze("2019/1/20") {
   #     bitemporal_id: 1,
   #     emp_code: "001",
   #     name: "Jane",
-  #     valid_from: 2019-01-10 00:00:00 UTC,
-  #     valid_to: 2019-01-15 00:00:00 UTC,
-  #     deleted_at: nil>
+  #     valid_from: 2019-01-10,
+  #     valid_to: 2019-01-15,
+  #     transaction_from: 2019-01-15,
+  #     transaction_to: 9999-12-31>
 
   # 見つからなければ nil を返す
   pp Employee.find_at_time("2019/1/12", employee2.id)
@@ -644,13 +650,13 @@ Timecop.freeze("2019/1/20") {
 
 レコードの内容
 
-| id | bitemporal_id | emp_code | name | valid_from | valid_to | deleted_at |
-|  --- | --- | --- | --- | --- | --- | --- |
-| 1 | 1 | 001 | Jane | 2019-01-10 00:00:00 UTC | 9999-12-31 00:00:00 UTC | 2019-01-15 00:00:00 UTC |
-| 2 | 1 | 001 | Jane | 2019-01-10 00:00:00 UTC | 2019-01-15 00:00:00 UTC | NULL |
-| 3 | 1 | 001 | Tom | 2019-01-15 00:00:00 UTC | 9999-12-31 00:00:00 UTC | 2019-01-20 00:00:00 UTC |
-| 4 | 1 | 001 | Tom | 2019-01-15 00:00:00 UTC | 2019-01-20 00:00:00 UTC | NULL |
-| 5 | 1 | 001 | Kevin | 2019-01-20 00:00:00 UTC | 9999-12-31 00:00:00 UTC | NULL |
+| id | bitemporal_id | emp_code | name | valid_from | valid_to | transaction_from | transaction_to |
+|  --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | 1 | 001 | Jane | 2019-01-10 | 9999-12-31 | 2019-01-10 | 2019-01-15 |
+| 2 | 1 | 001 | Jane | 2019-01-10 | 2019-01-15 | 2019-01-15 | 9999-12-31 |
+| 3 | 1 | 001 | Tom | 2019-01-15 | 9999-12-31 | 2019-01-15 | 2019-01-20 |
+| 4 | 1 | 001 | Tom | 2019-01-15 | 2019-01-20 | 2019-01-20 | 9999-12-31 |
+| 5 | 1 | 001 | Kevin | 2019-01-20 | 9999-12-31 | 2019-01-20 | 9999-12-31 |
 
 また、元々の DB の `id` は `#swapped_id` で参照する事が出来ます。
 
@@ -713,11 +719,6 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/kufu/activerecord-bitemporal.
 
-
-## Code of Conduct
-
-Everyone interacting in the activerecord-bitemporal project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/kufu/activerecord-bitemporal/blob/master/CODE_OF_CONDUCT.md).
-
 ## Copyright
 
-The gem is available as open source under the terms of the [Apache License 2.0](https://github.com/kufu/activerecord-bitemporal/blob/master/LICENSE).
+See ./LICENSE

--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -10,7 +10,8 @@ require "activerecord-bitemporal/version"
 module ActiveRecord::Bitemporal
   DEFAULT_VALID_FROM = Time.utc(1900, 12, 31).in_time_zone.freeze
   DEFAULT_VALID_TO   = Time.utc(9999, 12, 31).in_time_zone.freeze
-  DEFAULT_TRANSACTION_TO = Time.utc(9999, 12, 31).in_time_zone.freeze
+  DEFAULT_TRANSACTION_FROM = Time.utc(1900, 12, 31).in_time_zone.freeze
+  DEFAULT_TRANSACTION_TO   = Time.utc(9999, 12, 31).in_time_zone.freeze
 
   extend ActiveSupport::Concern
   included do

--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -156,6 +156,9 @@ ActiveSupport.on_load(:active_record) do
   ActiveRecord::Base
     .prepend ActiveRecord::Bitemporal::Patches::Persistence
 
+  ActiveRecord::Relation::Merger
+    .prepend ActiveRecord::Bitemporal::Patches::Merger
+
   ActiveRecord::Associations::Association
     .prepend ActiveRecord::Bitemporal::Patches::Association
 
@@ -167,7 +170,4 @@ ActiveSupport.on_load(:active_record) do
 
   ActiveRecord::Reflection::AssociationReflection
     .prepend ActiveRecord::Bitemporal::Patches::AssociationReflection
-
-  ActiveRecord::Relation::Merger
-    .prepend ActiveRecord::Bitemporal::Patches::Merger
 end

--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -108,11 +108,16 @@ module ActiveRecord::Bitemporal::Bitemporalize
 
   def bitemporalize(
     enable_strict_by_validates_bitemporal_id: false,
-    enable_default_scope: true
+    enable_default_scope: true,
+    enable_merge_with_except_bitemporal_default_scope: true
   )
     extend ClassMethods
     include InstanceMethods
     include ActiveRecord::Bitemporal::Scope
+
+    if enable_merge_with_except_bitemporal_default_scope
+      relation_delegate_class(ActiveRecord::Relation).prepend ActiveRecord::Bitemporal::Relation::MergeWithExceptBitemporalDefaultScope
+    end
 
     if enable_default_scope
       default_scope {

--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -74,7 +74,7 @@ module ActiveRecord::Bitemporal::Bitemporalize
     def swap_id!(without_clear_changes_information: false)
       @_swapped_id = self.id
       self.id = self.send(bitemporal_id_key)
-      clear_changes_information unless without_clear_changes_information
+      clear_attribute_changes([:id]) unless without_clear_changes_information
     end
 
     def swapped_id

--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -112,7 +112,7 @@ module ActiveRecord::Bitemporal::Bitemporalize
   def bitemporalize(
     enable_strict_by_validates_bitemporal_id: false,
     enable_default_scope: true,
-    enable_merge_with_except_bitemporal_default_scope: true
+    enable_merge_with_except_bitemporal_default_scope: false
   )
     extend ClassMethods
     include InstanceMethods

--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -55,6 +55,9 @@ module ActiveRecord::Bitemporal::Bitemporalize
     def inherited(klass)
       super
       klass.prepend_relation_delegate_class ActiveRecord::Bitemporal::Relation
+      if relation_delegate_class(ActiveRecord::Relation).ancestors.include? ActiveRecord::Bitemporal::Relation::MergeWithExceptBitemporalDefaultScope
+        klass.relation_delegate_class(ActiveRecord::Relation).prepend ActiveRecord::Bitemporal::Relation::MergeWithExceptBitemporalDefaultScope
+      end
     end
 
   private

--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -167,4 +167,7 @@ ActiveSupport.on_load(:active_record) do
 
   ActiveRecord::Reflection::AssociationReflection
     .prepend ActiveRecord::Bitemporal::Patches::AssociationReflection
+
+  ActiveRecord::Relation::Merger
+    .prepend ActiveRecord::Bitemporal::Patches::Merger
 end

--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -10,8 +10,7 @@ require "activerecord-bitemporal/version"
 module ActiveRecord::Bitemporal
   DEFAULT_VALID_FROM = Time.utc(1900, 12, 31).in_time_zone.freeze
   DEFAULT_VALID_TO   = Time.utc(9999, 12, 31).in_time_zone.freeze
-  DEFAULT_TRANSACTION_FROM = Time.utc(1900, 12, 31).in_time_zone.freeze
-  DEFAULT_TRANSACTION_TO   = Time.utc(9999, 12, 31).in_time_zone.freeze
+  DEFAULT_TRANSACTION_TO = Time.utc(9999, 12, 31).in_time_zone.freeze
 
   extend ActiveSupport::Concern
   included do

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -126,7 +126,7 @@ module ActiveRecord
         records = ActiveRecord::Bitemporal.with_bitemporal_option(**bitemporal_option) { super }
 
         return records if records.empty?
-        return records unless bitemporal_value[:with_valid_datetime] && valid_datetime_
+        return records unless ActiveRecord::Bitemporal.valid_datetime || bitemporal_value[:with_valid_datetime] && bitemporal_value[:with_valid_datetime] != :default_scope && valid_datetime_
 
         records.each do |record|
           record.send(:bitemporal_option_storage)[:valid_datetime] = valid_datetime_

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -542,7 +542,6 @@ module ActiveRecord
                            end
         transaction_to = record.transaction_to || ActiveRecord::Bitemporal::DEFAULT_TRANSACTION_TO
         transaction_at_scope = finder_class.unscoped
-          .ignore_bitemporal_datetime
           .bitemporal_where_bind("transaction_to", :gt, transaction_from)
           .bitemporal_where_bind("transaction_from", :lt, transaction_to)
 

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -534,7 +534,7 @@ module ActiveRecord
           .transaction_to_gt(transaction_from)
           .transaction_from_lt(transaction_to)
 
-        relation.merge(valid_at_scope).merge(transaction_at_scope)
+        relation.merge(valid_at_scope.with_valid_datetime).merge(transaction_at_scope.with_transaction_datetime)
       end
     end
   end

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -112,12 +112,18 @@ module ActiveRecord
       end
       include Finder
 
+      def build_arel(*)
+        ActiveRecord::Bitemporal.with_bitemporal_option(**bitemporal_option) {
+          super
+        }
+      end
+
       def load
         return super if loaded?
         valid_datetime_ = valid_datetime
 
         # このタイミングで先読みしているアソシエーションが読み込まれるので時間を固定
-        records = ActiveRecord::Bitemporal.valid_at(valid_datetime_) { super }
+        ActiveRecord::Bitemporal.with_bitemporal_option(**bitemporal_option) { super }
 
         return records if records.empty?
         return records unless bitemporal_value[:with_valid_datetime] && valid_datetime_

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -326,6 +326,7 @@ module ActiveRecord
             @previously_new_record = false
             # NOTE: Hook to copying swapped_id
             @_swapped_id = fresh_object.swapped_id
+            bitemporal_option_storage[:relation_valid_datetime] = fresh_object.relation_valid_datetime
             self
           end
         elsif Gem::Version.new("6.1.0") <= ActiveRecord.version
@@ -346,6 +347,7 @@ module ActiveRecord
             @previously_new_record = false
             # NOTE: Hook to copying swapped_id
             @_swapped_id = fresh_object.swapped_id
+            bitemporal_option_storage[:relation_valid_datetime] = fresh_object.relation_valid_datetime
             self
           end
         else
@@ -365,6 +367,7 @@ module ActiveRecord
             @new_record = false
             # NOTE: Hook to copying swapped_id
             @_swapped_id = fresh_object.swapped_id
+            bitemporal_option_storage[:relation_valid_datetime] = fresh_object.relation_valid_datetime
             self
           end
         end

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -123,7 +123,7 @@ module ActiveRecord
         valid_datetime_ = valid_datetime
 
         # このタイミングで先読みしているアソシエーションが読み込まれるので時間を固定
-        ActiveRecord::Bitemporal.with_bitemporal_option(**bitemporal_option) { super }
+        records = ActiveRecord::Bitemporal.with_bitemporal_option(**bitemporal_option) { super }
 
         return records if records.empty?
         return records unless bitemporal_value[:with_valid_datetime] && valid_datetime_

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -347,7 +347,11 @@ module ActiveRecord
             @previously_new_record = false
             # NOTE: Hook to copying swapped_id
             @_swapped_id = fresh_object.swapped_id
-            bitemporal_option_storage[:valid_datetime] = fresh_object.valid_datetime
+            if fresh_object.valid_datetime
+              bitemporal_option_storage[:valid_datetime] = fresh_object.valid_datetime
+            else
+              bitemporal_option_storage.delete(:valid_datetime)
+            end
             self
           end
         else
@@ -367,7 +371,11 @@ module ActiveRecord
             @new_record = false
             # NOTE: Hook to copying swapped_id
             @_swapped_id = fresh_object.swapped_id
-            bitemporal_option_storage[:valid_datetime] = fresh_object.valid_datetime
+            if fresh_object.valid_datetime
+              bitemporal_option_storage[:valid_datetime] = fresh_object.valid_datetime
+            else
+              bitemporal_option_storage.delete(:valid_datetime)
+            end
             self
           end
         end

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -120,6 +120,7 @@ module ActiveRecord
         records = ActiveRecord::Bitemporal.valid_at(valid_datetime) { super }
 
         return records if records.empty?
+        return records unless bitemporal_value[:with_relation_valid_datetime]
 
         records.each do |record|
           record.send(:bitemporal_option_storage)[:relation_valid_datetime] = valid_datetime

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -533,7 +533,13 @@ module ActiveRecord
 
         # MEMO: Must refer Time.current, when not new record
         #       Because you don't want transaction_from to be rewritten
-        transaction_from = record.new_record? ? (record.transaction_from || Time.current) : Time.current
+        transaction_from = if record.transaction_from == ActiveRecord::Bitemporal::DEFAULT_TRANSACTION_FROM
+                             Time.current
+                           elsif !record.new_record?
+                             Time.current
+                           else
+                             record.transaction_from
+                           end
         transaction_to = record.transaction_to || ActiveRecord::Bitemporal::DEFAULT_TRANSACTION_TO
         transaction_at_scope = finder_class.unscoped
           .ignore_bitemporal_datetime

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -33,10 +33,6 @@ module ActiveRecord
       ensure
         self.bitemporal_option_storage = tmp_opt
       end
-
-      def valid_datetime
-        bitemporal_option[:valid_datetime]&.in_time_zone&.to_datetime
-      end
     private
       def bitemporal_option_storage
         @bitemporal_option_storage ||= {}
@@ -80,6 +76,9 @@ module ActiveRecord
           end
         end
 
+        def valid_datetime
+          bitemporal_option[:valid_datetime]&.in_time_zone&.to_datetime
+        end
       private
         def bitemporal_option_storage
           Current.option ||= {}
@@ -120,7 +119,7 @@ module ActiveRecord
         records = ActiveRecord::Bitemporal.valid_at(valid_datetime) { super }
 
         return records if records.empty?
-        return records unless bitemporal_value[:with_valid_datetime]
+        return records unless bitemporal_value[:with_valid_datetime] && valid_datetime
 
         records.each do |record|
           record.send(:bitemporal_option_storage)[:valid_datetime] = valid_datetime
@@ -187,6 +186,10 @@ module ActiveRecord
             next unless association.respond_to?(:bitemporal_option_merge!)
             association.bitemporal_option_merge!(other)
           end
+        end
+
+        def valid_datetime
+          bitemporal_option[:valid_datetime]&.in_time_zone&.to_datetime
         end
       end
       include PersistenceOptionable

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -513,7 +513,7 @@ module ActiveRecord
           #   一番近い未来の履歴レコードを参照して更新する
           # という仕様があるため、それを考慮して valid_to を設定する
           if (record.valid_datetime && (record.valid_from..record.valid_to).cover?(record.valid_datetime)) == false && (record.persisted?)
-            finder_class.where(bitemporal_id: record.bitemporal_id).valid_from_gt(target_datetime).ignore_valid_datetime.order(valid_from: :asc).first.valid_from
+            finder_class.ignore_valid_datetime.where(bitemporal_id: record.bitemporal_id).valid_from_gt(target_datetime).order(valid_from: :asc).first.valid_from
           else
             valid_to
           end

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -65,7 +65,7 @@ module ActiveRecord
         end
 
         def valid_datetime
-          bitemporal_option[:valid_datetime]&.in_time_zone&.to_datetime
+          bitemporal_option[:valid_datetime]&.in_time_zone
         end
 
         def ignore_valid_datetime(&block)
@@ -190,7 +190,7 @@ module ActiveRecord
         end
 
         def valid_datetime
-          bitemporal_option[:valid_datetime]&.in_time_zone&.to_datetime
+          bitemporal_option[:valid_datetime]&.in_time_zone
         end
       end
       include PersistenceOptionable

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -546,7 +546,6 @@ module ActiveRecord
           .bitemporal_where_bind("transaction_to", :gt, transaction_from)
           .bitemporal_where_bind("transaction_from", :lt, transaction_to)
 
-        puts relation.merge(valid_at_scope).merge(transaction_at_scope).to_sql if $debug
         relation.merge(valid_at_scope).merge(transaction_at_scope)
       end
     end

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -61,11 +61,11 @@ module ActiveRecord
         include Optionable
 
         def valid_at(datetime, &block)
-          with_bitemporal_option(ignore_valid_datetime: false, valid_datetime: datetime, relation_valid_datetime: datetime, &block)
+          with_bitemporal_option(ignore_valid_datetime: false, valid_datetime: datetime, &block)
         end
 
         def valid_at!(datetime, &block)
-          with_bitemporal_option(ignore_valid_datetime: false, valid_datetime: datetime, relation_valid_datetime: datetime, force_valid_datetime: true, &block)
+          with_bitemporal_option(ignore_valid_datetime: false, valid_datetime: datetime, force_valid_datetime: true, &block)
         end
 
         def ignore_valid_datetime(&block)
@@ -74,7 +74,7 @@ module ActiveRecord
 
         def merge_by(option)
           if bitemporal_option_storage[:force_valid_datetime]
-            bitemporal_option_storage.merge(option.merge(valid_datetime: bitemporal_option_storage[:valid_datetime], relation_valid_datetime: bitemporal_option_storage[:valid_datetime]))
+            bitemporal_option_storage.merge(option.merge(valid_datetime: bitemporal_option_storage[:valid_datetime]))
           else
             bitemporal_option_storage.merge(option)
           end
@@ -120,10 +120,10 @@ module ActiveRecord
         records = ActiveRecord::Bitemporal.valid_at(valid_datetime) { super }
 
         return records if records.empty?
-        return records unless bitemporal_value[:with_relation_valid_datetime]
+        return records unless bitemporal_value[:with_valid_datetime]
 
         records.each do |record|
-          record.send(:bitemporal_option_storage)[:relation_valid_datetime] = valid_datetime
+          record.send(:bitemporal_option_storage)[:valid_datetime] = valid_datetime
         end
       end
 
@@ -177,10 +177,6 @@ module ActiveRecord
 
         def valid_at(datetime, &block)
           with_bitemporal_option(valid_datetime: datetime, &block)
-        end
-
-        def relation_valid_datetime
-          bitemporal_option[:relation_valid_datetime]&.in_time_zone&.to_datetime
         end
 
         def bitemporal_option_merge_with_association!(other)
@@ -348,7 +344,7 @@ module ActiveRecord
             @previously_new_record = false
             # NOTE: Hook to copying swapped_id
             @_swapped_id = fresh_object.swapped_id
-            bitemporal_option_storage[:relation_valid_datetime] = fresh_object.relation_valid_datetime
+            bitemporal_option_storage[:valid_datetime] = fresh_object.valid_datetime
             self
           end
         else
@@ -368,7 +364,7 @@ module ActiveRecord
             @new_record = false
             # NOTE: Hook to copying swapped_id
             @_swapped_id = fresh_object.swapped_id
-            bitemporal_option_storage[:relation_valid_datetime] = fresh_object.relation_valid_datetime
+            bitemporal_option_storage[:valid_datetime] = fresh_object.valid_datetime
             self
           end
         end

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -336,7 +336,6 @@ module ActiveRecord
             @previously_new_record = false
             # NOTE: Hook to copying swapped_id
             @_swapped_id = fresh_object.swapped_id
-            bitemporal_option_storage[:relation_valid_datetime] = fresh_object.relation_valid_datetime
             self
           end
         elsif Gem::Version.new("6.1.0") <= ActiveRecord.version
@@ -359,11 +358,6 @@ module ActiveRecord
             @previously_new_record = false
             # NOTE: Hook to copying swapped_id
             @_swapped_id = fresh_object.swapped_id
-            if fresh_object.valid_datetime
-              bitemporal_option_storage[:valid_datetime] = fresh_object.valid_datetime
-            else
-              bitemporal_option_storage.delete(:valid_datetime)
-            end
             self
           end
         else
@@ -385,11 +379,6 @@ module ActiveRecord
             @new_record = false
             # NOTE: Hook to copying swapped_id
             @_swapped_id = fresh_object.swapped_id
-            if fresh_object.valid_datetime
-              bitemporal_option_storage[:valid_datetime] = fresh_object.valid_datetime
-            else
-              bitemporal_option_storage.delete(:valid_datetime)
-            end
             self
           end
         end

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -522,8 +522,7 @@ module ActiveRecord
         transaction_from = record.new_record? ? (record.transaction_from || Time.current) : Time.current
         transaction_to = record.transaction_to || ActiveRecord::Bitemporal::DEFAULT_TRANSACTION_TO
         transaction_at_scope = finder_class.unscoped
-          .ignore_valid_datetime
-          .within_deleted
+          .ignore_bitemporal_datetime
           .bitemporal_where_bind("transaction_to", :gt, transaction_from)
           .bitemporal_where_bind("transaction_from", :lt, transaction_to)
 

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -114,15 +114,16 @@ module ActiveRecord
 
       def load
         return super if loaded?
+        valid_datetime_ = valid_datetime
 
         # このタイミングで先読みしているアソシエーションが読み込まれるので時間を固定
-        records = ActiveRecord::Bitemporal.valid_at(valid_datetime) { super }
+        records = ActiveRecord::Bitemporal.valid_at(valid_datetime_) { super }
 
         return records if records.empty?
-        return records unless bitemporal_value[:with_valid_datetime] && valid_datetime
+        return records unless bitemporal_value[:with_valid_datetime] && valid_datetime_
 
         records.each do |record|
-          record.send(:bitemporal_option_storage)[:valid_datetime] = valid_datetime
+          record.send(:bitemporal_option_storage)[:valid_datetime] = valid_datetime_
         end
       end
 

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -64,6 +64,10 @@ module ActiveRecord
           with_bitemporal_option(ignore_valid_datetime: false, valid_datetime: datetime, force_valid_datetime: true, &block)
         end
 
+        def valid_datetime
+          bitemporal_option[:valid_datetime]&.in_time_zone&.to_datetime
+        end
+
         def ignore_valid_datetime(&block)
           with_bitemporal_option(ignore_valid_datetime: true, valid_datetime: nil, &block)
         end
@@ -74,10 +78,6 @@ module ActiveRecord
           else
             bitemporal_option_storage.merge(option)
           end
-        end
-
-        def valid_datetime
-          bitemporal_option[:valid_datetime]&.in_time_zone&.to_datetime
         end
       private
         def bitemporal_option_storage

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -321,11 +321,14 @@ module ActiveRecord
 
             self.class.connection.clear_query_cache
 
-            fresh_object = if apply_scoping?(options)
-              _find_record(options)
-            else
-              self.class.unscoped { self.class.bitemporal_default_scope.scoping { _find_record(options) } }
-            end
+            fresh_object =
+              ActiveRecord::Bitemporal.with_bitemporal_option(**bitemporal_option) {
+                if apply_scoping?(options)
+                  _find_record(options)
+                else
+                  self.class.unscoped { self.class.bitemporal_default_scope.scoping { _find_record(options) } }
+                end
+              }
 
             @association_cache = fresh_object.instance_variable_get(:@association_cache)
             @attributes = fresh_object.instance_variable_get(:@attributes)
@@ -343,11 +346,13 @@ module ActiveRecord
             self.class.connection.clear_query_cache
 
             fresh_object =
-              if options && options[:lock]
-                self.class.unscoped { self.class.lock(options[:lock]).bitemporal_default_scope.find(id) }
-              else
-                self.class.unscoped { self.class.bitemporal_default_scope.find(id) }
-              end
+              ActiveRecord::Bitemporal.with_bitemporal_option(**bitemporal_option) {
+                if options && options[:lock]
+                  self.class.unscoped { self.class.lock(options[:lock]).bitemporal_default_scope.find(id) }
+                else
+                  self.class.unscoped { self.class.bitemporal_default_scope.find(id) }
+                end
+              }
 
             @attributes = fresh_object.instance_variable_get(:@attributes)
             @new_record = false
@@ -368,11 +373,13 @@ module ActiveRecord
             self.class.connection.clear_query_cache
 
             fresh_object =
-              if options && options[:lock]
-                self.class.unscoped { self.class.lock(options[:lock]).bitemporal_default_scope.find(id) }
-              else
-                self.class.unscoped { self.class.bitemporal_default_scope.find(id) }
-              end
+              ActiveRecord::Bitemporal.with_bitemporal_option(**bitemporal_option) {
+                if options && options[:lock]
+                  self.class.unscoped { self.class.lock(options[:lock]).bitemporal_default_scope.find(id) }
+                else
+                  self.class.unscoped { self.class.bitemporal_default_scope.find(id) }
+                end
+              }
 
             @attributes = fresh_object.instance_variable_get("@attributes")
             @new_record = false

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -118,6 +118,9 @@ module ActiveRecord
 
         # このタイミングで先読みしているアソシエーションが読み込まれるので時間を固定
         records = ActiveRecord::Bitemporal.valid_at(valid_datetime) { super }
+
+        return records if records.empty?
+
         records.each do |record|
           record.send(:bitemporal_option_storage)[:relation_valid_datetime] = valid_datetime
         end

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -476,7 +476,11 @@ module ActiveRecord
     end
 
     module Uniqueness
+      require_relative "./scope.rb"
+      using ::ActiveRecord::Bitemporal::Scope::ActiveRecordRelationScope
+
       private
+
       def scope_relation(record, relation)
         finder_class = find_finder_class_for(record)
         return super unless finder_class.bi_temporal_model?

--- a/lib/activerecord-bitemporal/patches.rb
+++ b/lib/activerecord-bitemporal/patches.rb
@@ -49,8 +49,6 @@ module ActiveRecord::Bitemporal
     end
 
     module Association
-      include ::ActiveRecord::Bitemporal::Optionable
-
       def skip_statement_cache?(scope)
         super || bi_temporal_model?
       end
@@ -59,9 +57,10 @@ module ActiveRecord::Bitemporal
         scope = super
         return scope unless scope.bi_temporal_model?
 
-        if owner.class&.bi_temporal_model? && owner.valid_datetime
-          scope.merge!(klass.valid_at(owner.valid_datetime))
-          scope.merge!(scope.bitemporal_value[:through].valid_at(owner.valid_datetime)) if scope.bitemporal_value[:through]
+        if owner.class&.bi_temporal_model? && (owner.valid_datetime || owner.bitemporal_option[:relation_valid_datetime])
+          valid_datetime = owner.valid_datetime || owner.bitemporal_option[:relation_valid_datetime]
+          scope.merge!(klass.valid_at(valid_datetime))
+          scope.merge!(scope.bitemporal_value[:through].valid_at(valid_datetime)) if scope.bitemporal_value[:through]
         end
         return scope
       end

--- a/lib/activerecord-bitemporal/patches.rb
+++ b/lib/activerecord-bitemporal/patches.rb
@@ -57,8 +57,8 @@ module ActiveRecord::Bitemporal
         scope = super
         return scope unless scope.bi_temporal_model?
 
-        if owner.class&.bi_temporal_model? && (owner.valid_datetime || owner.bitemporal_option[:relation_valid_datetime])
-          valid_datetime = owner.valid_datetime || owner.bitemporal_option[:relation_valid_datetime]
+        if owner.class&.bi_temporal_model? && owner.valid_datetime
+          valid_datetime = owner.valid_datetime
           scope.merge!(klass.valid_at(valid_datetime))
           scope.merge!(scope.bitemporal_value[:through].valid_at(valid_datetime)) if scope.bitemporal_value[:through]
         end

--- a/lib/activerecord-bitemporal/patches.rb
+++ b/lib/activerecord-bitemporal/patches.rb
@@ -105,7 +105,7 @@ module ActiveRecord::Bitemporal
     module Merger
       def merge
         if relation.klass.bi_temporal_model? && other.klass.bi_temporal_model?
-          relation.bitemporal_clause.predicates.merge!(other.bitemporal_clause.predicates)
+          relation.bitemporal_value.merge! other.bitemporal_value
         end
         super
       end

--- a/lib/activerecord-bitemporal/patches.rb
+++ b/lib/activerecord-bitemporal/patches.rb
@@ -95,11 +95,6 @@ module ActiveRecord::Bitemporal
         return super unless klass&.bi_temporal_model?
         klass.bitemporal_id_key
       end
-
-      def association_scope_cache(conn, owner, &block)
-        clear_association_scope_cache if klass&.bi_temporal_model?
-        super
-      end
     end
 
     module Merger

--- a/lib/activerecord-bitemporal/patches.rb
+++ b/lib/activerecord-bitemporal/patches.rb
@@ -59,7 +59,7 @@ module ActiveRecord::Bitemporal
 
         if owner.class&.bi_temporal_model? && owner.valid_datetime
           valid_datetime = owner.valid_datetime
-          scope.merge!(klass.valid_at(valid_datetime))
+          scope = scope.valid_at(valid_datetime)
           scope.merge!(scope.bitemporal_value[:through].valid_at(valid_datetime)) if scope.bitemporal_value[:through]
         end
         return scope

--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -87,7 +87,7 @@ module ActiveRecord::Bitemporal
       end
     }
 
-    if ActiveRecord.version < Gem::Version.new("6.1.0.alpha")
+    if ActiveRecord.version < Gem::Version.new("6.1.0")
       class WhereClauseWithCheckTable < ActiveRecord::Relation::WhereClause
         def bitemporal_include?(column)
           !!predicates.grep(::Arel::Nodes::Node).find do |node|
@@ -162,7 +162,7 @@ module ActiveRecord::Bitemporal
         end
       }
 
-      if ActiveRecord.version < Gem::Version.new("6.1.0.alpha")
+      if ActiveRecord.version < Gem::Version.new("6.1.0")
         %i(valid_from valid_to transaction_from transaction_to).each { |column|
           scope :"ignore_#{column}", -> {
             unscope(where: "#{table.name}.#{column}")
@@ -359,7 +359,7 @@ module ActiveRecord::Bitemporal
         where(table[attr_name].public_send(operator, predicate_builder.build_bind_attribute(attr_name, value)))
       }
 
-      if ActiveRecord.version < Gem::Version.new("6.1.0.alpha")
+      if ActiveRecord.version < Gem::Version.new("6.1.0")
       else
         scope :bitemporal_rewhere_bind, -> (attr_name, operator, value, table = self.table) {
           rewhere(table[attr_name].public_send(operator, predicate_builder.build_bind_attribute(attr_name, value)))

--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -74,11 +74,11 @@ module ActiveRecord::Bitemporal
     }
 
     def valid_datetime
-      bitemporal_clause[:valid_datetime]&.in_time_zone&.to_datetime
+      bitemporal_clause[:valid_datetime]&.in_time_zone
     end
 
     def transaction_datetime
-      bitemporal_clause[:transaction_datetime]&.in_time_zone&.to_datetime
+      bitemporal_clause[:transaction_datetime]&.in_time_zone
     end
 
     def bitemporal_option
@@ -127,7 +127,7 @@ module ActiveRecord::Bitemporal
           :gteq   # column >= datetime
         ].each { |op|
           scope :"#{column}_#{op}", -> (datetime) {
-            target_datetime = datetime&.in_time_zone&.to_datetime || Time.current
+            target_datetime = datetime&.in_time_zone || Time.current
             public_send(:"ignore_#{column}").where(table[column].public_send(op, target_datetime))
               .tap { |relation| relation.merge!(bitemporal_value[:through].unscoped.public_send(:"#{column}_#{op}", target_datetime)) if bitemporal_value[:through] }
           }

--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -348,7 +348,7 @@ module ActiveRecord::Bitemporal
         ignore_valid_from.ignore_valid_to.without_valid_datetime
       }
       scope :except_valid_datetime, -> {
-        except_valid_from.except_valid_to.without_valid_datetime
+        except_valid_from.except_valid_to.tap { |relation| relation.bitemporal_value.except! :with_valid_datetime }
       }
 
       # transaction_from <= datetime && datetime < transaction_to

--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -84,7 +84,7 @@ module ActiveRecord::Bitemporal
     if ActiveRecord.version < Gem::Version.new("6.1.0.alpha")
       class WhereClauseWithCheckTable < ActiveRecord::Relation::WhereClause
         def bitemporal_include?(column)
-          !!predicates.find do |node|
+          !!predicates.grep(::Arel::Nodes::Node).find do |node|
             node.bitemporal_include?(column)
           end
         end
@@ -94,7 +94,7 @@ module ActiveRecord::Bitemporal
         def except_predicates(columns)
           columns = Array(columns)
           predicates.reject do |node|
-            node.bitemporal_include?(*columns)
+            ::Arel::Nodes::Node === node && node.bitemporal_include?(*columns)
           end
         end
       end

--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -107,7 +107,7 @@ module ActiveRecord::Bitemporal
     module MergeWithExceptBitemporalDefaultScope
       using BitemporalChecker
       def merge!(other)
-        if klass.bi_temporal_model? && other.klass.bi_temporal_model?
+        if other.is_a?(Relation) && klass.bi_temporal_model? && other.klass.bi_temporal_model?
           super(other.except_bitemporal_default_scope)
         else
           super

--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -106,7 +106,7 @@ module ActiveRecord::Bitemporal
 
     module MergeWithExceptBitemporalDefaultScope
       using BitemporalChecker
-      def merge!(other)
+      def merge(other)
         if other.is_a?(Relation) && klass.bi_temporal_model? && other.klass.bi_temporal_model?
           super(other.except_bitemporal_default_scope)
         else

--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -50,9 +50,6 @@ module ActiveRecord::Bitemporal
                 case node
                 when Arel::Nodes::LessThan, Arel::Nodes::LessThanOrEqual, Arel::Nodes::GreaterThan, Arel::Nodes::GreaterThanOrEqual
                   y << node if node && node.left.respond_to?(:relation)
-                when Arel::Nodes::Or, Arel::Nodes::And
-                  each_operatable_node(node.left) { |node| y << node }
-                  each_operatable_node(node.right) { |node| y << node }
                 when Arel::Nodes::Grouping
                   each_operatable_node(node.expr) { |node| y << node }
                 end

--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -6,9 +6,13 @@ module ActiveRecord::Bitemporal
       def bitemporal_include?(*columns)
         case self
         when Arel::Nodes::Between, Arel::Nodes::In, Arel::Nodes::NotIn, Arel::Nodes::Equality, Arel::Nodes::NotEqual, Arel::Nodes::LessThan, Arel::Nodes::LessThanOrEqual, Arel::Nodes::GreaterThan, Arel::Nodes::GreaterThanOrEqual
-          subrelation = (self.left.kind_of?(Arel::Attributes::Attribute) ? self.left : self.right)
-          # Add check table name
-          columns.include?(subrelation.name.to_s) || columns.include?("#{subrelation.relation.name}.#{subrelation.name}")
+          if self.left.kind_of?(Arel::Attributes::Attribute)
+            subrelation = self.left
+            columns.include?(subrelation.name.to_s) || columns.include?("#{subrelation.relation.name}.#{subrelation.name}")
+          elsif self.right.kind_of?(Arel::Attributes::Attribute)
+            subrelation = self.right
+            columns.include?(subrelation.name.to_s) || columns.include?("#{subrelation.relation.name}.#{subrelation.name}")
+          end
         else
           false
         end

--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -139,7 +139,6 @@ module ActiveRecord::Bitemporal
         ].each { |op|
           scope :"#{column}_#{op}", -> (datetime) {
             target_datetime = datetime&.in_time_zone || Time.current
-#             public_send(:"ignore_#{column}").where(table[column].public_send(op, target_datetime))
             public_send(:"ignore_#{column}").bitemporal_where_bind(column, op, target_datetime)
               .tap { |relation| relation.merge!(bitemporal_value[:through].unscoped.public_send(:"#{column}_#{op}", target_datetime)) if bitemporal_value[:through] }
           }

--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -130,7 +130,7 @@ module ActiveRecord::Bitemporal
 
         refine Array do
           def delete_once(other)
-            index(other).then { |i| delete_at(i) if i }
+            index(other).yield_self { |i| delete_at(i) if i }
           end
         end
       }

--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -104,6 +104,17 @@ module ActiveRecord::Bitemporal
       end
     end
 
+    module MergeWithExceptBitemporalDefaultScope
+      using BitemporalChecker
+      def merge!(other)
+        if klass.bi_temporal_model? && other.klass.bi_temporal_model?
+          super(other.except_bitemporal_default_scope)
+        else
+          super
+        end
+      end
+    end
+
     def valid_datetime
       bitemporal_clause[:valid_datetime]&.in_time_zone
     end

--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -107,7 +107,7 @@ module ActiveRecord::Bitemporal
     module MergeWithExceptBitemporalDefaultScope
       using BitemporalChecker
       def merge(other)
-        if other.is_a?(Relation) && klass.bi_temporal_model? && other.klass.bi_temporal_model?
+        if other.is_a?(Relation) && other.klass.bi_temporal_model?
           super(other.except_bitemporal_default_scope)
         else
           super

--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -50,6 +50,11 @@ module ActiveRecord::Bitemporal
                 case node
                 when Arel::Nodes::LessThan, Arel::Nodes::LessThanOrEqual, Arel::Nodes::GreaterThan, Arel::Nodes::GreaterThanOrEqual
                   y << node if node && node.left.respond_to?(:relation)
+                when Arel::Nodes::Or, Arel::Nodes::And
+                  if Gem::Version.new("6.1.0") <= ActiveRecord.version
+                    each_operatable_node(node.left) { |node| y << node }
+                    each_operatable_node(node.right) { |node| y << node }
+                  end
                 when Arel::Nodes::Grouping
                   each_operatable_node(node.expr) { |node| y << node }
                 end

--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -47,6 +47,8 @@ module ActiveRecord::Bitemporal
             when Arel::Nodes::LessThan, Arel::Nodes::LessThanOrEqual, Arel::Nodes::GreaterThan, Arel::Nodes::GreaterThanOrEqual
               node
             end
+          }.select { |node|
+            node.left.respond_to? :relation
           }.inject(Hash.new { |hash, key| hash[key] = {} }) { |result, node|
             result[node.left.relation.name][node.left.name] = [node.operator, node.right.try(:val)]
             result

--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -137,12 +137,12 @@ module ActiveRecord::Bitemporal
         }
       }
 
-      scope :with_relation_valid_datetime, -> {
-        tap { |relation| relation.bitemporal_value[:with_relation_valid_datetime] = true }
+      scope :with_valid_datetime, -> {
+        tap { |relation| relation.bitemporal_value[:with_valid_datetime] = true }
       }
 
-      scope :without_relation_valid_datetime, -> {
-        tap { |relation| relation.bitemporal_value[:with_relation_valid_datetime] = false }
+      scope :without_valid_datetime, -> {
+        tap { |relation| relation.bitemporal_value[:with_valid_datetime] = false }
       }
 
       # valid_from <= datetime && datetime < valid_to
@@ -151,7 +151,7 @@ module ActiveRecord::Bitemporal
           datetime = ActiveRecord::Bitemporal.valid_datetime
         end
         datetime = Time.current if datetime.nil?
-        valid_from_lteq(datetime).valid_to_gt(datetime).with_relation_valid_datetime
+        valid_from_lteq(datetime).valid_to_gt(datetime).with_valid_datetime
       }
       scope :ignore_valid_datetime, -> {
         ignore_valid_from.ignore_valid_to
@@ -180,9 +180,9 @@ module ActiveRecord::Bitemporal
 
       scope :bitemporal_default_scope, -> {
         if ActiveRecord::Bitemporal.valid_datetime
-          bitemporal_at(Time.current).with_relation_valid_datetime
+          bitemporal_at(Time.current).with_valid_datetime
         else
-          bitemporal_at(Time.current).without_relation_valid_datetime
+          bitemporal_at(Time.current).without_valid_datetime
         end
       }
 

--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -67,7 +67,7 @@ module ActiveRecord::Bitemporal
           each_operatable_node
             .select { |node| names.include? node.left.name.to_s }
             .inject(Hash.new { |hash, key| hash[key] = {} }) { |result, node|
-              value = node.right.try(:val) || node.right.try(:value).try(:value_before_type_cast)
+              value = node.right.try(:val) || node.right.try(:value).then { |it| it.try(:value_before_type_cast) || it }
               result[node.left.relation.name][node.left.name.to_s] = [node.operator, value]
               result
             }

--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -41,7 +41,7 @@ module ActiveRecord::Bitemporal
         }
 
         def select_operatable_node(nodes = predicates)
-          nodes.flat_map { |node|
+          Array(nodes).flat_map { |node|
             case node
             when Arel::Nodes::LessThan, Arel::Nodes::LessThanOrEqual, Arel::Nodes::GreaterThan, Arel::Nodes::GreaterThanOrEqual
               node && node.left.respond_to?(:relation) ? node : nil

--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActiveRecord::Bitemporal
   using Module.new {
     refine ::Arel::Nodes::Node do

--- a/spec/activerecord-bitemporal/association_spec.rb
+++ b/spec/activerecord-bitemporal/association_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe "Association" do
 
       describe ".find" do
         it { expect(company.employees.find(mado.id)).to have_attributes(name: "Mado") }
-        it { expect(company.employees.find(mado.id, tom).pluck(:name)).to contain_exactly("Mado", "Tom") }
+        it { expect(company.employees.find(mado.id, tom.id).pluck(:name)).to contain_exactly("Mado", "Tom") }
       end
 
       describe ".find_by" do

--- a/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
@@ -683,6 +683,11 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
           it { is_expected.to have_transaction_at(_01_01, table: "users") }
         end
       end
+
+      context "default_scope" do
+        let(:relation) { User.where(name: "mami").merge(Timecop.freeze(_01_01) { User.where(name: "homu") }) }
+        it { is_expected.to have_bitemporal_at(_01_01, table: "users") }
+      end
     end
 
     describe "ActiveRecord::Bitemporal.valid_at" do

--- a/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
@@ -666,6 +666,13 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         end
       end
     end
+
+    context "with where(Arel.sql)" do
+      let!(:blog) { Blog.create(name: "Ruby") }
+      let(:relation) { Blog.where(Arel.sql("valid_from").lteq(Time.current)) }
+      subject { relation }
+      it { is_expected.to have_attributes(first: blog) }
+    end
   end
 
   describe "bitemporal_option" do

--- a/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
@@ -751,22 +751,22 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
 
       context "default_scope" do
         let(:relation) { Blog.all }
-        it { is_expected.to include(relation_valid_datetime: time_current) }
-        it { is_expected.not_to include(valid_datetime: nil) }
+        it { is_expected.not_to include(:relation_valid_datetime) }
+        it { is_expected.not_to include(:valid_datetime) }
       end
 
       context ".valid_at" do
         let(:valid_datetime) { "2019/01/1".in_time_zone }
         let(:relation) { Blog.valid_at(valid_datetime) }
         it { is_expected.to include(relation_valid_datetime: valid_datetime) }
-        it { is_expected.not_to include(valid_datetime: nil) }
+        it { is_expected.not_to include(:valid_datetime) }
       end
 
       context "#valid_at" do
         let(:valid_datetime) { "2019/01/1".in_time_zone }
         let(:relation) { Blog.all }
         let(:bitemporal_option) { Timecop.freeze(time_current) { record.valid_at(valid_datetime) { |it| it.bitemporal_option } } }
-        it { is_expected.to include(relation_valid_datetime: time_current) }
+        it { is_expected.not_to include(:relation_valid_datetime) }
         it { is_expected.to include(valid_datetime: valid_datetime) }
       end
 
@@ -774,7 +774,7 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         let(:valid_datetime) { "2019/01/1".in_time_zone }
         let(:record) { Blog.find_at_time(valid_datetime, blog.id) }
         it { is_expected.to include(relation_valid_datetime: valid_datetime) }
-        it { is_expected.not_to include(valid_datetime: nil) }
+        it { is_expected.not_to include(:valid_datetime) }
       end
 
       context "ActiveRecord::Bitemporal.valid_at" do
@@ -783,14 +783,14 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         context "around get relation" do
           let(:relation) { ActiveRecord::Bitemporal.valid_at(valid_datetime) { Blog.all } }
           it { is_expected.to include(relation_valid_datetime: valid_datetime) }
-          it { is_expected.not_to include(valid_datetime: nil) }
+          it { is_expected.not_to include(:valid_datetime) }
 
           context "in .valid_at" do
             let(:bitemporal_valid_datetime) { "2019/05/1".in_time_zone }
             let(:relation_valid_datetime) { "2019/01/1".in_time_zone }
             let(:relation) { ActiveRecord::Bitemporal.valid_at(bitemporal_valid_datetime) { Blog.valid_at(relation_valid_datetime) } }
             it { is_expected.to include(relation_valid_datetime: relation_valid_datetime) }
-            it { is_expected.not_to include(valid_datetime: nil) }
+            it { is_expected.not_to include(:valid_datetime) }
           end
 
           context "outside .valid_at" do
@@ -798,14 +798,14 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
             let(:relation_valid_datetime) { "2019/01/1".in_time_zone }
             let(:relation) { ActiveRecord::Bitemporal.valid_at(bitemporal_valid_datetime) { Blog.all }.valid_at(relation_valid_datetime) }
             it { is_expected.to include(relation_valid_datetime: relation_valid_datetime) }
-            it { is_expected.not_to include(valid_datetime: nil) }
+            it { is_expected.not_to include(:valid_datetime) }
           end
         end
 
         context "around get record" do
           let(:record) { ActiveRecord::Bitemporal.valid_at(valid_datetime) { Blog.all.first } }
           it { is_expected.to include(relation_valid_datetime: valid_datetime) }
-          it { is_expected.not_to include(valid_datetime: nil) }
+          it { is_expected.not_to include(:valid_datetime) }
         end
 
         context "around get bitemporal_option" do
@@ -862,8 +862,8 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
 
         context "default_scope" do
           let(:relation) { Blog.all.first.articles }
-          it { is_expected.to include(relation_valid_datetime: time_current) }
-          it { is_expected.not_to include(valid_datetime: nil) }
+          it { is_expected.not_to include(:relation_valid_datetime) }
+          it { is_expected.not_to include(:valid_datetime) }
         end
 
         context "owner.valid_at" do
@@ -871,13 +871,13 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
           let(:owner) { Blog.valid_at(valid_datetime).first }
           let(:relation) { owner.articles }
           it { is_expected.to include(relation_valid_datetime: valid_datetime) }
-          it { is_expected.not_to include(valid_datetime: nil) }
+          it { is_expected.not_to include(:valid_datetime) }
 
           context "with association.valid_at" do
             let(:association_valid_datetime) { "2019/05/1".in_time_zone }
             let(:relation) { owner.articles.valid_at(association_valid_datetime) }
             it { is_expected.to include(relation_valid_datetime: association_valid_datetime) }
-            it { is_expected.not_to include(valid_datetime: nil) }
+            it { is_expected.not_to include(:valid_datetime) }
           end
         end
 
@@ -885,9 +885,16 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
           let(:valid_datetime) { "2019/01/1".in_time_zone }
           let(:relation) { Blog.all.first.articles.valid_at(valid_datetime) }
           it { is_expected.to include(relation_valid_datetime: valid_datetime) }
-          it { is_expected.not_to include(valid_datetime: nil) }
+          it { is_expected.not_to include(:valid_datetime) }
         end
       end
+    end
+  end
+
+  describe ".with_relation_valid_datetime" do
+    context "create association when after record loaded" do
+      let!(:blog) { Blog.create; Blog.first }
+      it { expect { Article.create(blog_id: blog.id) }.to change { blog.articles.count }.by(1) }
     end
   end
 end

--- a/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
@@ -304,9 +304,14 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
 
     describe ".merge" do
       context "bitemporal_datetime" do
-        context ".merge(.valid_at)" do
+        context ".merge(.bitemporal_at)" do
           let(:relation) { User.merge(User.bitemporal_at(_01_01)) }
           it { is_expected.to have_bitemporal_at(_01_01, table: "users") }
+        end
+
+        context ".merge(.bitemporal_at.except_bitemporal_datetime)" do
+          let(:relation) { User.merge(User.bitemporal_at(_01_01).except_bitemporal_datetime) }
+          it { is_expected.to not_have_bitemporal_at(table: "users") }
         end
 
         context ".merge(.ignore_bitemporal_datetime)" do
@@ -314,9 +319,29 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
           it { is_expected.to not_have_bitemporal_at(table: "users") }
         end
 
+        context ".merge(.ignore_bitemporal_datetime.except_bitemporal_datetime)" do
+          let(:relation) { User.merge(User.ignore_bitemporal_datetime.except_bitemporal_datetime) }
+          it { is_expected.to not_have_bitemporal_at(table: "users") }
+        end
+
+        context ".merge(.ignore_bitemporal_datetime.bitepmoral_at.except_bitemporal_datetime)" do
+          let(:relation) { User.merge(User.ignore_bitemporal_datetime.bitemporal_at(_01_01).except_bitemporal_datetime) }
+          it { is_expected.to not_have_bitemporal_at(table: "users") }
+        end
+
+        context ".merge(.ignore_bitemporal_datetime.bitepmoral_at.except_bitemporal_datetime.bitemporal_at)" do
+          let(:relation) { User.merge(User.ignore_bitemporal_datetime.bitemporal_at(_01_01).except_bitemporal_datetime.bitemporal_at(_01_01)) }
+          it { is_expected.to have_bitemporal_at(_01_01, table: "users") }
+        end
+
         context ".merge(.except_valid_datetime)" do
           let(:relation) { User.merge(User.except_valid_datetime) }
           it { is_expected.to have_bitemporal_at(time_current, table: "users") }
+        end
+
+        context ".merge(.except_valid_datetime.bitemporal_at)" do
+          let(:relation) { User.merge(User.except_valid_datetime.bitemporal_at(_01_01)) }
+          it { is_expected.to have_bitemporal_at(_01_01, table: "users") }
         end
 
         context ".merge(.bitemporal_at).bitemporal_at" do
@@ -341,6 +366,11 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
 
         context ".bitemporal_at.merge(.ignore_bitemporal_datetime)" do
           let(:relation) { User.bitemporal_at(_01_01).merge(User.ignore_bitemporal_datetime) }
+          it { is_expected.to not_have_bitemporal_at(table: "users") }
+        end
+
+        context ".bitemporal_at.merge(.ignore_bitemporal_datetime.except_bitemporal_datetime)" do
+          let(:relation) { User.bitemporal_at(_01_01).merge(User.ignore_bitemporal_datetime.except_bitemporal_datetime) }
           it { is_expected.to not_have_bitemporal_at(table: "users") }
         end
 
@@ -372,8 +402,32 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
           it { is_expected.to have_transaction_at(time_current, table: "users") }
         end
 
+        context ".merge(.valid_at)" do
+          let(:relation) { User.merge(User.valid_at(_01_01).except_valid_datetime) }
+          it { is_expected.to not_have_valid_at(table: "users") }
+          it { is_expected.to have_transaction_at(time_current, table: "users") }
+        end
+
         context ".merge(.ignore_valid_datetime)" do
           let(:relation) { User.merge(User.ignore_valid_datetime) }
+          it { is_expected.to not_have_valid_at(table: "users") }
+          it { is_expected.to have_transaction_at(time_current, table: "users") }
+        end
+
+        context ".merge(.ignore_valid_datetime.except_valid_datetime)" do
+          let(:relation) { User.merge(User.ignore_valid_datetime.except_valid_datetime) }
+          it { is_expected.to not_have_valid_at(table: "users") }
+          it { is_expected.to have_transaction_at(time_current, table: "users") }
+        end
+
+        context ".merge(.ignore_valid_datetime.valid_at)" do
+          let(:relation) { User.merge(User.ignore_valid_datetime.valid_at(_01_01)) }
+          it { is_expected.to have_valid_at(_01_01, table: "users") }
+          it { is_expected.to have_transaction_at(time_current, table: "users") }
+        end
+
+        context ".merge(.ignore_valid_datetime.valid_at.except_valid_datetime)" do
+          let(:relation) { User.merge(User.ignore_valid_datetime.valid_at(_01_01).except_valid_datetime) }
           it { is_expected.to not_have_valid_at(table: "users") }
           it { is_expected.to have_transaction_at(time_current, table: "users") }
         end
@@ -381,6 +435,12 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         context ".merge(.except_valid_datetime)" do
           let(:relation) { User.merge(User.except_valid_datetime) }
           it { is_expected.to have_valid_at(time_current, table: "users") }
+          it { is_expected.to have_transaction_at(time_current, table: "users") }
+        end
+
+        context ".merge(.except_valid_datetime" do
+          let(:relation) { User.merge(User.except_valid_datetime.valid_at(_01_01)) }
+          it { is_expected.to have_valid_at(_01_01, table: "users") }
           it { is_expected.to have_transaction_at(time_current, table: "users") }
         end
 
@@ -410,6 +470,12 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
 
         context ".valid_at.merge(.ignore_valid_datetime)" do
           let(:relation) { User.valid_at(_01_01).merge(User.ignore_valid_datetime) }
+          it { is_expected.to not_have_valid_at(table: "users") }
+          it { is_expected.to have_transaction_at(time_current, table: "users") }
+        end
+
+        context ".valid_at.merge(.ignore_valid_datetime.except_valid_datetime)" do
+          let(:relation) { User.valid_at(_01_01).merge(User.ignore_valid_datetime.except_valid_datetime) }
           it { is_expected.to not_have_valid_at(table: "users") }
           it { is_expected.to have_transaction_at(time_current, table: "users") }
         end
@@ -446,16 +512,46 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
           it { is_expected.to have_transaction_at(_01_01, table: "users") }
         end
 
+        context ".merge(.transaction_at.except_transaction_datetime)" do
+          let(:relation) { User.merge(User.transaction_at(_01_01).except_transaction_datetime) }
+          it { is_expected.to have_valid_at(time_current, table: "users") }
+          it { is_expected.to not_have_transaction_at(table: "users") }
+        end
+
         context ".merge(.ignore_transaction_datetime)" do
           let(:relation) { User.merge(User.ignore_transaction_datetime) }
           it { is_expected.to have_valid_at(time_current, table: "users") }
           it { is_expected.to not_have_transaction_at(table: "users") }
         end
 
-        context ".merge(.except_valid_datetime)" do
-          let(:relation) { User.merge(User.except_valid_datetime) }
+        context ".merge(.ignore_transaction_datetime.except_transaction_datetime)" do
+          let(:relation) { User.merge(User.ignore_transaction_datetime.except_transaction_datetime) }
+          it { is_expected.to have_valid_at(time_current, table: "users") }
+          it { is_expected.to not_have_transaction_at(table: "users") }
+        end
+
+        context ".merge(.ignore_transaction_datetime.transaction_at.except_transaction_datetime)" do
+          let(:relation) { User.merge(User.ignore_transaction_datetime.transaction_at(_01_01).except_transaction_datetime) }
+          it { is_expected.to have_valid_at(time_current, table: "users") }
+          it { is_expected.to not_have_transaction_at(table: "users") }
+        end
+
+        context ".merge(.ignore_transaction_datetime.transaction_at.except_transaction_datetime.transaction_at)" do
+          let(:relation) { User.merge(User.ignore_transaction_datetime.transaction_at(_01_01).except_transaction_datetime.transaction_at(_01_01)) }
+          it { is_expected.to have_valid_at(time_current, table: "users") }
+          it { is_expected.to have_transaction_at(_01_01, table: "users") }
+        end
+
+        context ".merge(.except_transaction_datetime)" do
+          let(:relation) { User.merge(User.except_transaction_datetime) }
           it { is_expected.to have_valid_at(time_current, table: "users") }
           it { is_expected.to have_transaction_at(time_current, table: "users") }
+        end
+
+        context ".merge(.except_transaction_datetime.transaction_at)" do
+          let(:relation) { User.merge(User.except_transaction_datetime.transaction_at(_01_01)) }
+          it { is_expected.to have_valid_at(time_current, table: "users") }
+          it { is_expected.to have_transaction_at(_01_01, table: "users") }
         end
 
         context ".merge(.transaction_at).transaction_at" do
@@ -484,6 +580,12 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
 
         context ".transaction_at.merge(.ignore_transaction_datetime)" do
           let(:relation) { User.transaction_at(_01_01).merge(User.ignore_transaction_datetime) }
+          it { is_expected.to have_valid_at(time_current, table: "users") }
+          it { is_expected.to not_have_transaction_at(table: "users") }
+        end
+
+        context ".transaction_at.merge(.ignore_transaction_datetime.except_transaction_datetime)" do
+          let(:relation) { User.transaction_at(_01_01).merge(User.ignore_transaction_datetime.except_transaction_datetime) }
           it { is_expected.to have_valid_at(time_current, table: "users") }
           it { is_expected.to not_have_transaction_at(table: "users") }
         end

--- a/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
@@ -317,9 +317,6 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         context ".merge(.except_valid_datetime)" do
           let(:relation) { User.merge(User.except_valid_datetime) }
           it { is_expected.to have_bitemporal_at(time_current, table: "users") }
-          it do
-            puts sql
-          end
         end
 
         context ".merge(.bitemporal_at).bitemporal_at" do

--- a/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
@@ -150,6 +150,12 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         it { is_expected.to have_valid_at(time_current, table: "users") }
         it { is_expected.to have_transaction_at(transaction_datetime, table: "users") }
       end
+
+      context ".where(String).ignore_bitemporal_datetime" do
+        let(:relation) { User.where("age < 20").ignore_bitemporal_datetime }
+        it { is_expected.to not_have_bitemporal_at(table: "users") }
+        it { is_expected.to scan_once "age < 20" }
+      end
     end
 
     describe ".except_valid_datetime" do

--- a/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 ActiveRecord::Schema.define(version: 1) do

--- a/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
@@ -1071,6 +1071,52 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         end
       end
     end
+
+    describe ".or" do
+      let(:relation) { Blog.where(name: "Homu").or(Blog.where(name: "Mami")) }
+      it { is_expected.to include(valid_datetime: time_current, ignore_valid_datetime: false) }
+
+      context ".valid_at.or(...)" do
+        let(:datetime) { "2019/01/1".in_time_zone }
+        let(:relation) { Blog.valid_at(datetime).where(name: "Homu").or(Blog.where(name: "Mami")) }
+        it { is_expected.to include(valid_datetime: time_current, ignore_valid_datetime: false) }
+      end
+
+      context ".or(valid_at)" do
+        let(:datetime) { "2019/01/1".in_time_zone }
+        let(:relation) { Blog.where(name: "Homu").or(Blog.valid_at(datetime).where(name: "Mami")) }
+        it { is_expected.to include(valid_datetime: datetime, ignore_valid_datetime: false) }
+      end
+
+      context ".valid_at.or(valid_at)" do
+        let(:datetime1) { "2019/05/1".in_time_zone }
+        let(:datetime2) { "2019/01/1".in_time_zone }
+        let(:relation) { Blog.valid_at(datetime1).where(name: "Homu").or(Blog.valid_at(datetime2).where(name: "Mami")) }
+        it { is_expected.to include(valid_datetime: datetime2, ignore_valid_datetime: false) }
+      end
+
+      context ".transaction_at.or(valid_at)" do
+        let(:datetime1) { "2019/05/1".in_time_zone }
+        let(:datetime2) { "2019/01/1".in_time_zone }
+        let(:relation) { Blog.transaction_at(datetime1).where(name: "Homu").or(Blog.transaction_at(datetime2).where(name: "Mami")) }
+        it { is_expected.to include(transaction_datetime: datetime2) }
+      end
+
+      context ".ignore_valid_datetime.or(...)" do
+        let(:relation) { Blog.ignore_valid_datetime.where(name: "Homu").or(Blog.where(name: "Mami")) }
+        it { is_expected.to include(valid_datetime: time_current, ignore_valid_datetime: false) }
+      end
+
+      context ".or(ignore_valid_datetime)" do
+        let(:relation) { Blog.where(name: "Homu").or(Blog.ignore_valid_datetime.where(name: "Mami")) }
+        it { is_expected.to include(valid_datetime: time_current, ignore_valid_datetime: false) }
+      end
+
+      context ".ignore_valid_datetime.or(ignore_valid_datetime)" do
+        let(:relation) { Blog.ignore_valid_datetime.where(name: "Homu").or(Blog.ignore_valid_datetime.where(name: "Mami")) }
+        it { is_expected.to include(valid_datetime: nil, ignore_valid_datetime: true) }
+      end
+    end
   end
 
   describe ".with_valid_datetime" do

--- a/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
@@ -758,30 +758,26 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
 
       context "default_scope" do
         let(:relation) { Blog.all }
-        it { is_expected.not_to include(:relation_valid_datetime) }
         it { is_expected.not_to include(:valid_datetime) }
       end
 
       context ".valid_at" do
         let(:valid_datetime) { "2019/01/1".in_time_zone }
         let(:relation) { Blog.valid_at(valid_datetime) }
-        it { is_expected.to include(relation_valid_datetime: valid_datetime) }
-        it { is_expected.not_to include(:valid_datetime) }
+        it { is_expected.to include(valid_datetime: valid_datetime) }
       end
 
       context "#valid_at" do
         let(:valid_datetime) { "2019/01/1".in_time_zone }
         let(:relation) { Blog.all }
         let(:bitemporal_option) { Timecop.freeze(time_current) { record.valid_at(valid_datetime) { |it| it.bitemporal_option } } }
-        it { is_expected.not_to include(:relation_valid_datetime) }
         it { is_expected.to include(valid_datetime: valid_datetime) }
       end
 
       context ".find_at_time" do
         let(:valid_datetime) { "2019/01/1".in_time_zone }
         let(:record) { Blog.find_at_time(valid_datetime, blog.id) }
-        it { is_expected.to include(relation_valid_datetime: valid_datetime) }
-        it { is_expected.not_to include(:valid_datetime) }
+        it { is_expected.to include(valid_datetime: valid_datetime) }
       end
 
       context "ActiveRecord::Bitemporal.valid_at" do
@@ -789,35 +785,30 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
 
         context "around get relation" do
           let(:relation) { ActiveRecord::Bitemporal.valid_at(valid_datetime) { Blog.all } }
-          it { is_expected.to include(relation_valid_datetime: valid_datetime) }
-          it { is_expected.not_to include(:valid_datetime) }
+          it { is_expected.to include(valid_datetime: valid_datetime) }
 
           context "in .valid_at" do
             let(:bitemporal_valid_datetime) { "2019/05/1".in_time_zone }
-            let(:relation_valid_datetime) { "2019/01/1".in_time_zone }
-            let(:relation) { ActiveRecord::Bitemporal.valid_at(bitemporal_valid_datetime) { Blog.valid_at(relation_valid_datetime) } }
-            it { is_expected.to include(relation_valid_datetime: relation_valid_datetime) }
-            it { is_expected.not_to include(:valid_datetime) }
+            let(:valid_datetime) { "2019/01/1".in_time_zone }
+            let(:relation) { ActiveRecord::Bitemporal.valid_at(bitemporal_valid_datetime) { Blog.valid_at(valid_datetime) } }
+            it { is_expected.to include(valid_datetime: valid_datetime) }
           end
 
           context "outside .valid_at" do
             let(:bitemporal_valid_datetime) { "2019/05/1".in_time_zone }
-            let(:relation_valid_datetime) { "2019/01/1".in_time_zone }
-            let(:relation) { ActiveRecord::Bitemporal.valid_at(bitemporal_valid_datetime) { Blog.all }.valid_at(relation_valid_datetime) }
-            it { is_expected.to include(relation_valid_datetime: relation_valid_datetime) }
-            it { is_expected.not_to include(:valid_datetime) }
+            let(:valid_datetime) { "2019/01/1".in_time_zone }
+            let(:relation) { ActiveRecord::Bitemporal.valid_at(bitemporal_valid_datetime) { Blog.all }.valid_at(valid_datetime) }
+            it { is_expected.to include(valid_datetime: valid_datetime) }
           end
         end
 
         context "around get record" do
           let(:record) { ActiveRecord::Bitemporal.valid_at(valid_datetime) { Blog.all.first } }
-          it { is_expected.to include(relation_valid_datetime: valid_datetime) }
-          it { is_expected.not_to include(:valid_datetime) }
+          it { is_expected.to include(valid_datetime: valid_datetime) }
         end
 
         context "around get bitemporal_option" do
           let(:bitemporal_option) { ActiveRecord::Bitemporal.valid_at(valid_datetime) { Blog.all.first.bitemporal_option } }
-          it { is_expected.to include(relation_valid_datetime: valid_datetime) }
           it { is_expected.to include(valid_datetime: valid_datetime) }
         end
       end
@@ -827,35 +818,30 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
 
         context "around get relation" do
           let(:relation) { ActiveRecord::Bitemporal.valid_at!(valid_datetime) { Blog.all } }
-          it { is_expected.to include(relation_valid_datetime: valid_datetime) }
-          it { is_expected.not_to include(valid_datetime: nil) }
+          it { is_expected.to include(valid_datetime: valid_datetime) }
 
           context "in .valid_at" do
             let(:bitemporal_valid_datetime) { "2019/05/1".in_time_zone }
-            let(:relation_valid_datetime) { "2019/01/1".in_time_zone }
-            let(:relation) { ActiveRecord::Bitemporal.valid_at!(bitemporal_valid_datetime) { Blog.valid_at(relation_valid_datetime) } }
-            it { is_expected.to include(relation_valid_datetime: bitemporal_valid_datetime) }
-            it { is_expected.not_to include(valid_datetime: nil) }
+            let(:valid_datetime) { "2019/01/1".in_time_zone }
+            let(:relation) { ActiveRecord::Bitemporal.valid_at!(bitemporal_valid_datetime) { Blog.valid_at(valid_datetime) } }
+            it { is_expected.to include(valid_datetime: bitemporal_valid_datetime) }
           end
 
           context "outside .valid_at" do
             let(:bitemporal_valid_datetime) { "2019/05/1".in_time_zone }
-            let(:relation_valid_datetime) { "2019/01/1".in_time_zone }
-            let(:relation) { ActiveRecord::Bitemporal.valid_at!(bitemporal_valid_datetime) { Blog.all }.valid_at(relation_valid_datetime) }
-            it { is_expected.to include(relation_valid_datetime: relation_valid_datetime) }
-            it { is_expected.not_to include(valid_datetime: nil) }
+            let(:valid_datetime) { "2019/01/1".in_time_zone }
+            let(:relation) { ActiveRecord::Bitemporal.valid_at!(bitemporal_valid_datetime) { Blog.all }.valid_at(valid_datetime) }
+            it { is_expected.to include(valid_datetime: valid_datetime) }
           end
         end
 
         context "around get record" do
           let(:record) { ActiveRecord::Bitemporal.valid_at!(valid_datetime) { Blog.all.first } }
-          it { is_expected.to include(relation_valid_datetime: valid_datetime) }
-          it { is_expected.not_to include(valid_datetime: nil) }
+          it { is_expected.to include(valid_datetime: valid_datetime) }
         end
 
         context "around get bitemporal_option" do
           let(:bitemporal_option) { ActiveRecord::Bitemporal.valid_at!(valid_datetime) { Blog.all.first.bitemporal_option } }
-          it { is_expected.to include(relation_valid_datetime: valid_datetime) }
           it { is_expected.to include(valid_datetime: valid_datetime) }
         end
       end
@@ -869,7 +855,6 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
 
         context "default_scope" do
           let(:relation) { Blog.all.first.articles }
-          it { is_expected.not_to include(:relation_valid_datetime) }
           it { is_expected.not_to include(:valid_datetime) }
         end
 
@@ -877,28 +862,25 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
           let(:valid_datetime) { "2019/01/1".in_time_zone }
           let(:owner) { Blog.valid_at(valid_datetime).first }
           let(:relation) { owner.articles }
-          it { is_expected.to include(relation_valid_datetime: valid_datetime) }
-          it { is_expected.not_to include(:valid_datetime) }
+          it { is_expected.to include(valid_datetime: valid_datetime) }
 
           context "with association.valid_at" do
             let(:association_valid_datetime) { "2019/05/1".in_time_zone }
             let(:relation) { owner.articles.valid_at(association_valid_datetime) }
-            it { is_expected.to include(relation_valid_datetime: association_valid_datetime) }
-            it { is_expected.not_to include(:valid_datetime) }
+            it { is_expected.to include(valid_datetime: association_valid_datetime) }
           end
         end
 
         context "association.valid_at" do
           let(:valid_datetime) { "2019/01/1".in_time_zone }
           let(:relation) { Blog.all.first.articles.valid_at(valid_datetime) }
-          it { is_expected.to include(relation_valid_datetime: valid_datetime) }
-          it { is_expected.not_to include(:valid_datetime) }
+          it { is_expected.to include(valid_datetime: valid_datetime) }
         end
       end
     end
   end
 
-  describe ".with_relation_valid_datetime" do
+  describe ".with_valid_datetime" do
     context "create association when after record loaded" do
       let!(:blog) { Blog.create; Blog.first }
       it { expect { Article.create(blog_id: blog.id) }.to change { blog.articles.count }.by(1) }

--- a/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
@@ -632,7 +632,10 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
           end
         end
 
-        describe "with association" do
+        # NOTE: Rails 6.0 is not supported.
+        #     > Association loading isn't to be affected by scoping consistently whether preloaded / eager loaded or not, with the exception of unscoped.
+        #     https://github.com/rails/rails/blob/v6.0.0/activerecord/CHANGELOG.md#rails-600rc1-april-24-2019
+        xdescribe "with association" do
           let(:relation) { Blog.create.articles }
           let(:scoping_valid_datetime) { "2019/01/1".in_time_zone }
           around { |e| Article.valid_at(scoping_valid_datetime).scoping { e.run } }

--- a/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
@@ -1771,6 +1771,111 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
       let!(:blog) { Blog.create; Blog.first }
       it { expect { Article.create(blog_id: blog.id) }.to change { blog.articles.count }.by(1) }
     end
+
+    context ".except_valid_datetime" do
+      let(:relation) { Blog.all.except_valid_datetime }
+      it { expect(relation.bitemporal_value).not_to include(:with_valid_datetime) }
+    end
+
+    context ".ignore_valid_datetime.except_valid_datetime" do
+      let(:relation) { Blog.ignore_valid_datetime.except_valid_datetime }
+      it { expect(relation.bitemporal_value).not_to include(:with_valid_datetime) }
+    end
+
+    context ".except_valid_datetime.ignore_valid_datetime" do
+      let(:relation) { Blog.except_valid_datetime.ignore_valid_datetime }
+      it { expect(relation.bitemporal_value).to include(with_valid_datetime: false) }
+    end
+
+    context ".valid_at" do
+      let(:relation) { Blog.valid_at("2020/10/01") }
+      it { expect(relation.bitemporal_value).to include(with_valid_datetime: true) }
+    end
+
+    xcontext ".valid_at.except_valid_datetime" do
+      let(:relation) { Blog.valid_at("2020/10/01").except_valid_datetime }
+      it { expect(relation.bitemporal_value).to include(with_valid_datetime: true) }
+    end
+
+    context ".merge(.)" do
+      let(:relation) { Blog.all.merge(User.all) }
+      it { expect(relation.bitemporal_value).to include(with_valid_datetime: :default_scope) }
+    end
+
+    context ".merge(.valid_at)" do
+      let(:relation) { Blog.all.merge(User.valid_at("2020/01/01")) }
+      it { expect(relation.bitemporal_value).to include(with_valid_datetime: true) }
+    end
+
+    context ".merge(.ignore_valid_datetime)" do
+      let(:relation) { Blog.all.merge(User.ignore_valid_datetime) }
+      it { expect(relation.bitemporal_value).to include(with_valid_datetime: false) }
+    end
+
+    context ".merge(.except_valid_datetime)" do
+      let(:relation) { Blog.all.merge(User.except_valid_datetime) }
+      it { expect(relation.bitemporal_value).to include(with_valid_datetime: :default_scope) }
+    end
+
+    context ".valid_at.merge(.)" do
+      let(:relation) { Blog.valid_at("2020/10/01").merge(User.all) }
+      it { expect(relation.bitemporal_value).to include(with_valid_datetime: :default_scope) }
+    end
+
+    context ".valid_at.merge(.valid_at)" do
+      let(:relation) { Blog.valid_at("2020/10/01").merge(User.valid_at("2020/01/01")) }
+      it { expect(relation.bitemporal_value).to include(with_valid_datetime: true) }
+    end
+
+    context ".valid_at.merge(.ignore_valid_datetime)" do
+      let(:relation) { Blog.valid_at("2020/10/01").merge(User.ignore_valid_datetime) }
+      it { expect(relation.bitemporal_value).to include(with_valid_datetime: false) }
+    end
+
+    context ".valid_at.merge(.except_valid_datetime)" do
+      let(:relation) { Blog.valid_at("2020/10/01").merge(User.except_valid_datetime) }
+      it { expect(relation.bitemporal_value).to include(with_valid_datetime: true) }
+    end
+
+    context ".ignore_valid_datetime.merge(.)" do
+      let(:relation) { Blog.ignore_valid_datetime.merge(User.all) }
+      it { expect(relation.bitemporal_value).to include(with_valid_datetime: :default_scope) }
+    end
+
+    context ".ignore_valid_datetime.merge(.valid_at)" do
+      let(:relation) { Blog.ignore_valid_datetime.merge(User.valid_at("2020/01/01")) }
+      it { expect(relation.bitemporal_value).to include(with_valid_datetime: true) }
+    end
+
+    context ".ignore_valid_datetime.merge(.ignore_valid_datetime)" do
+      let(:relation) { Blog.ignore_valid_datetime.merge(User.ignore_valid_datetime) }
+      it { expect(relation.bitemporal_value).to include(with_valid_datetime: false) }
+    end
+
+    context ".ignore_valid_datetime.merge(.except_valid_datetime)" do
+      let(:relation) { Blog.ignore_valid_datetime.merge(User.except_valid_datetime) }
+      it { expect(relation.bitemporal_value).to include(with_valid_datetime: false) }
+    end
+
+    context ".except_valid_datetime.merge(.)" do
+      let(:relation) { Blog.except_valid_datetime.merge(User.all) }
+      it { expect(relation.bitemporal_value).to include(with_valid_datetime: :default_scope) }
+    end
+
+    context ".except_valid_datetime.merge(.valid_at)" do
+      let(:relation) { Blog.except_valid_datetime.merge(User.valid_at("2020/01/01")) }
+      it { expect(relation.bitemporal_value).to include(with_valid_datetime: true) }
+    end
+
+    context ".except_valid_datetime.merge(.ignore_valid_datetime)" do
+      let(:relation) { Blog.except_valid_datetime.merge(User.ignore_valid_datetime) }
+      it { expect(relation.bitemporal_value).to include(with_valid_datetime: false) }
+    end
+
+    context ".except_valid_datetime.merge(.except_valid_datetime)" do
+      let(:relation) { Blog.except_valid_datetime.merge(User.except_valid_datetime) }
+      it { expect(relation.bitemporal_value).not_to include(:with_valid_datetime) }
+    end
   end
 
   describe ".with_transaction_datetime" do

--- a/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
@@ -311,7 +311,17 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
 
         context ".merge(.bitemporal_at.except_bitemporal_datetime)" do
           let(:relation) { User.merge(User.bitemporal_at(_01_01).except_bitemporal_datetime) }
+          it { is_expected.to have_bitemporal_at(time_current, table: "users") }
+        end
+
+        context ".merge(.bitemporal_at.ignore_bitemporal_datetime.except_bitemporal_datetime)" do
+          let(:relation) { User.merge(User.bitemporal_at(_01_01).ignore_bitemporal_datetime.except_bitemporal_datetime) }
           it { is_expected.to not_have_bitemporal_at(table: "users") }
+        end
+
+        context ".merge(.bitemporal_at.bitemporal_at.except_bitemporal_datetime)" do
+          let(:relation) { User.merge(User.bitemporal_at(_06_01).bitemporal_at(_01_01).except_bitemporal_datetime) }
+          it { is_expected.to have_bitemporal_at(time_current, table: "users") }
         end
 
         context ".merge(.ignore_bitemporal_datetime)" do
@@ -324,14 +334,29 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
           it { is_expected.to not_have_bitemporal_at(table: "users") }
         end
 
+        context ".merge(.ignore_bitemporal_datetime.except_bitemporal_datetime.except_bitemporal_datetime)" do
+          let(:relation) { User.merge(User.ignore_bitemporal_datetime.except_bitemporal_datetime.except_bitemporal_datetime) }
+          it { is_expected.to not_have_bitemporal_at(table: "users") }
+        end
+
         context ".merge(.ignore_bitemporal_datetime.bitepmoral_at.except_bitemporal_datetime)" do
           let(:relation) { User.merge(User.ignore_bitemporal_datetime.bitemporal_at(_01_01).except_bitemporal_datetime) }
-          it { is_expected.to not_have_bitemporal_at(table: "users") }
+          it { is_expected.to have_bitemporal_at(time_current, table: "users") }
+        end
+
+        context ".merge(.ignore_bitemporal_datetime.bitepmoral_at.except_bitemporal_datetime.except_bitemporal_datetime)" do
+          let(:relation) { User.merge(User.ignore_bitemporal_datetime.bitemporal_at(_01_01).except_bitemporal_datetime.except_bitemporal_datetime) }
+          it { is_expected.to have_bitemporal_at(time_current, table: "users") }
         end
 
         context ".merge(.ignore_bitemporal_datetime.bitepmoral_at.except_bitemporal_datetime.bitemporal_at)" do
           let(:relation) { User.merge(User.ignore_bitemporal_datetime.bitemporal_at(_01_01).except_bitemporal_datetime.bitemporal_at(_01_01)) }
           it { is_expected.to have_bitemporal_at(_01_01, table: "users") }
+        end
+
+        context ".merge(.ignore_bitemporal_datetime.bitepmoral_at.except_bitemporal_datetime.bitemporal_at.except_bitemporal_datetime)" do
+          let(:relation) { User.merge(User.ignore_bitemporal_datetime.bitemporal_at(_01_01).except_bitemporal_datetime.bitemporal_at(_01_01).except_bitemporal_datetime) }
+          it { is_expected.to have_bitemporal_at(time_current, table: "users") }
         end
 
         context ".merge(.except_valid_datetime)" do
@@ -402,9 +427,15 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
           it { is_expected.to have_transaction_at(time_current, table: "users") }
         end
 
-        context ".merge(.valid_at)" do
+        context ".merge(.valid_at.except_bitemporal_datetime)" do
           let(:relation) { User.merge(User.valid_at(_01_01).except_valid_datetime) }
-          it { is_expected.to not_have_valid_at(table: "users") }
+          it { is_expected.to have_valid_at(time_current, table: "users") }
+          it { is_expected.to have_transaction_at(time_current, table: "users") }
+        end
+
+        context ".merge(.valid_at.valid_at.except_bitemporal_datetime)" do
+          let(:relation) { User.merge(User.valid_at(_06_01).valid_at(_01_01).except_valid_datetime) }
+          it { is_expected.to have_valid_at(time_current, table: "users") }
           it { is_expected.to have_transaction_at(time_current, table: "users") }
         end
 
@@ -428,7 +459,13 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
 
         context ".merge(.ignore_valid_datetime.valid_at.except_valid_datetime)" do
           let(:relation) { User.merge(User.ignore_valid_datetime.valid_at(_01_01).except_valid_datetime) }
-          it { is_expected.to not_have_valid_at(table: "users") }
+          it { is_expected.to have_valid_at(time_current, table: "users") }
+          it { is_expected.to have_transaction_at(time_current, table: "users") }
+        end
+
+        context ".merge(.ignore_valid_datetime.valid_at.except_valid_datetime.except_valid_datetime)" do
+          let(:relation) { User.merge(User.ignore_valid_datetime.valid_at(_01_01).except_valid_datetime.except_valid_datetime) }
+          it { is_expected.to have_valid_at(time_current, table: "users") }
           it { is_expected.to have_transaction_at(time_current, table: "users") }
         end
 
@@ -515,7 +552,13 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         context ".merge(.transaction_at.except_transaction_datetime)" do
           let(:relation) { User.merge(User.transaction_at(_01_01).except_transaction_datetime) }
           it { is_expected.to have_valid_at(time_current, table: "users") }
-          it { is_expected.to not_have_transaction_at(table: "users") }
+          it { is_expected.to have_transaction_at(time_current, table: "users") }
+        end
+
+        context ".merge(.transaction_at.transaction_at.except_transaction_datetime)" do
+          let(:relation) { User.merge(User.transaction_at(_06_01).transaction_at(_01_01).except_transaction_datetime) }
+          it { is_expected.to have_valid_at(time_current, table: "users") }
+          it { is_expected.to have_transaction_at(time_current, table: "users") }
         end
 
         context ".merge(.ignore_transaction_datetime)" do
@@ -533,7 +576,13 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         context ".merge(.ignore_transaction_datetime.transaction_at.except_transaction_datetime)" do
           let(:relation) { User.merge(User.ignore_transaction_datetime.transaction_at(_01_01).except_transaction_datetime) }
           it { is_expected.to have_valid_at(time_current, table: "users") }
-          it { is_expected.to not_have_transaction_at(table: "users") }
+          it { is_expected.to have_transaction_at(time_current, table: "users") }
+        end
+
+        context ".merge(.ignore_transaction_datetime.transaction_at.except_transaction_datetime.except_transaction_datetime)" do
+          let(:relation) { User.merge(User.ignore_transaction_datetime.transaction_at(_01_01).except_transaction_datetime.except_transaction_datetime) }
+          it { is_expected.to have_valid_at(time_current, table: "users") }
+          it { is_expected.to have_transaction_at(time_current, table: "users") }
         end
 
         context ".merge(.ignore_transaction_datetime.transaction_at.except_transaction_datetime.transaction_at)" do
@@ -562,6 +611,18 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
 
         context ".merge(.ignore_transaction_datetime).transaction_at" do
           let(:relation) { User.merge(User.ignore_transaction_datetime).transaction_at(_01_01) }
+          it { is_expected.to have_valid_at(time_current, table: "users") }
+          it { is_expected.to have_transaction_at(_01_01, table: "users") }
+        end
+
+        context ".merge(.ignore_transaction_datetime.except_transaction_datetime).transaction_at" do
+          let(:relation) { User.merge(User.ignore_transaction_datetime.except_transaction_datetime).transaction_at(_01_01) }
+          it { is_expected.to have_valid_at(time_current, table: "users") }
+          it { is_expected.to have_transaction_at(_01_01, table: "users") }
+        end
+
+        context ".merge(.ignore_transaction_datetime.except_transaction_datetime).transaction_at" do
+          let(:relation) { User.merge(User.ignore_transaction_datetime.except_transaction_datetime.except_transaction_datetime).transaction_at(_01_01) }
           it { is_expected.to have_valid_at(time_current, table: "users") }
           it { is_expected.to have_transaction_at(_01_01, table: "users") }
         end

--- a/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
@@ -1099,7 +1099,6 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         let(:datetime1) { "2019/05/1".in_time_zone }
         let(:datetime2) { "2019/01/1".in_time_zone }
         let(:relation) { Blog.transaction_at(datetime1).where(name: "Homu").or(Blog.transaction_at(datetime2).where(name: "Mami")) }
-        it { is_expected.to include(transaction_datetime: datetime2) }
       end
 
       context ".ignore_valid_datetime.or(...)" do
@@ -1115,6 +1114,11 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
       context ".ignore_valid_datetime.or(ignore_valid_datetime)" do
         let(:relation) { Blog.ignore_valid_datetime.where(name: "Homu").or(Blog.ignore_valid_datetime.where(name: "Mami")) }
         it { is_expected.to include(valid_datetime: nil, ignore_valid_datetime: true) }
+      end
+
+      context "where with String" do
+        let(:relation) { Blog.where('name = "Homu"').or(Blog.where('name = "Mami"')) }
+        it { is_expected.to include(valid_datetime: time_current, ignore_valid_datetime: false) }
       end
     end
   end

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -598,12 +598,12 @@ RSpec.describe ActiveRecord::Bitemporal do
 
     context "with #valid_at" do
       let(:employee) { Employee.create!(valid_from: "2019/01/01") }
-      it { expect { ActiveRecord::Bitemporal.valid_at("2020/01/01") { employee.reload } }.to change { employee.relation_valid_datetime }.from(nil).to("2020/01/01".in_time_zone) }
+      it { expect { ActiveRecord::Bitemporal.valid_at("2020/01/01") { employee.reload } }.to change { employee.valid_datetime }.from(nil).to("2020/01/01".in_time_zone) }
     end
 
     # TODO
     xcontext "with #valid_at" do
-      it { expect { employee.valid_at('2020/01/01', &:reload) }.to change { employee.relation_valid_datetime } }
+      it { expect { employee.valid_at('2020/01/01', &:reload) }.to change { employee.valid_datetime } }
     end
   end
 
@@ -843,7 +843,8 @@ RSpec.describe ActiveRecord::Bitemporal do
       end
     end
 
-    context "after `.valid_at`" do
+    # TODO:
+    xcontext "after `.valid_at`" do
       let(:first)  { Company.ignore_valid_datetime.order(:valid_from).first }
       let(:second) { Company.ignore_valid_datetime.order(:valid_from).second }
       let(:third)  { Company.ignore_valid_datetime.order(:valid_from).third }
@@ -1370,21 +1371,21 @@ RSpec.describe ActiveRecord::Bitemporal do
         end
 
         context "`valid_at` within call bitemporal_option" do
-          it { expect(Employee.valid_at(current_year).find(employee.id).bitemporal_option).to eq(relation_valid_datetime: current_year) }
-          it { expect(Employee.valid_at(current_year).find_by(name: "Tom").bitemporal_option).to eq(relation_valid_datetime: current_year) }
-          it { expect(Employee.valid_at(current_year).where(name: "Tom").first.bitemporal_option).to eq(relation_valid_datetime: current_year) }
+          it { expect(Employee.valid_at(current_year).find(employee.id).bitemporal_option).to eq(valid_datetime: current_year) }
+          it { expect(Employee.valid_at(current_year).find_by(name: "Tom").bitemporal_option).to eq(valid_datetime: current_year) }
+          it { expect(Employee.valid_at(current_year).where(name: "Tom").first.bitemporal_option).to eq(valid_datetime: current_year) }
         end
 
         context "`valid_at` without call bitemporal_option" do
-          it { expect(Employee.valid_at(current_year).find(employee.id).bitemporal_option).to eq(relation_valid_datetime: current_year) }
-          it { expect(Employee.valid_at(current_year).find_by(name: "Tom").bitemporal_option).to eq(relation_valid_datetime: current_year) }
-          it { expect(Employee.valid_at(current_year).where(name: "Tom").first.bitemporal_option).to eq(relation_valid_datetime: current_year) }
+          it { expect(Employee.valid_at(current_year).find(employee.id).bitemporal_option).to eq(valid_datetime: current_year) }
+          it { expect(Employee.valid_at(current_year).find_by(name: "Tom").bitemporal_option).to eq(valid_datetime: current_year) }
+          it { expect(Employee.valid_at(current_year).where(name: "Tom").first.bitemporal_option).to eq(valid_datetime: current_year) }
         end
 
         context "relation to `valid_at`" do
-          it { expect(Employee.where(emp_code: "001").valid_at(current_year).find(employee.id).bitemporal_option).to eq(relation_valid_datetime: current_year) }
-          it { expect(Employee.where(emp_code: "001").valid_at(current_year).find_by(name: "Tom").bitemporal_option).to eq(relation_valid_datetime: current_year) }
-          it { expect(Employee.where(emp_code: "001").valid_at(current_year).where(name: "Tom").first.bitemporal_option).to eq(relation_valid_datetime: current_year) }
+          it { expect(Employee.where(emp_code: "001").valid_at(current_year).find(employee.id).bitemporal_option).to eq(valid_datetime: current_year) }
+          it { expect(Employee.where(emp_code: "001").valid_at(current_year).find_by(name: "Tom").bitemporal_option).to eq(valid_datetime: current_year) }
+          it { expect(Employee.where(emp_code: "001").valid_at(current_year).where(name: "Tom").first.bitemporal_option).to eq(valid_datetime: current_year) }
         end
       end
 
@@ -1442,19 +1443,13 @@ RSpec.describe ActiveRecord::Bitemporal do
         end
         it do
           Company.includes(:employees, employees: :address).find_at_time(time_current, company.id).tap { |c|
-            expect(c.valid_datetime).to eq nil
-            expect(c.employees.first.valid_datetime).to eq nil
-            expect(c.employees.first.address.valid_datetime).to eq nil
-            expect(c.relation_valid_datetime).to eq time_current
-            expect(c.employees.first.relation_valid_datetime).to eq time_current
-            expect(c.employees.first.address.relation_valid_datetime).to eq time_current
+            expect(c.valid_datetime).to eq time_current
+            expect(c.employees.first.valid_datetime).to eq time_current
+            expect(c.employees.first.address.valid_datetime).to eq time_current
             ActiveRecord::Bitemporal.valid_at("2019/1/1") {
-              expect(c.valid_datetime).to eq "2019/1/1"
-              expect(c.employees.first.valid_datetime).to eq "2019/1/1"
-              expect(c.employees.first.address.valid_datetime).to eq "2019/1/1"
-              expect(c.relation_valid_datetime).to eq time_current
-              expect(c.employees.first.relation_valid_datetime).to eq time_current
-              expect(c.employees.first.address.relation_valid_datetime).to eq time_current
+              expect(c.valid_datetime).to eq time_current
+              expect(c.employees.first.valid_datetime).to eq time_current
+              expect(c.employees.first.address.valid_datetime).to eq time_current
             }
           }
         end
@@ -1501,19 +1496,13 @@ RSpec.describe ActiveRecord::Bitemporal do
         end
         it do
           Company.includes(:employees, employees: :address).find_at_time(time_current, company.id).tap { |c|
-            expect(c.valid_datetime).to eq nil
-            expect(c.employees.first.valid_datetime).to eq nil
-            expect(c.employees.first.address.valid_datetime).to eq nil
-            expect(c.relation_valid_datetime).to eq time_current
-            expect(c.employees.first.relation_valid_datetime).to eq time_current
-            expect(c.employees.first.address.relation_valid_datetime).to eq time_current
+            expect(c.valid_datetime).to eq time_current
+            expect(c.employees.first.valid_datetime).to eq time_current
+            expect(c.employees.first.address.valid_datetime).to eq time_current
             ActiveRecord::Bitemporal.valid_at!("2019/1/1") {
               expect(c.valid_datetime).to eq "2019/1/1"
               expect(c.employees.first.valid_datetime).to eq "2019/1/1"
               expect(c.employees.first.address.valid_datetime).to eq "2019/1/1"
-              expect(c.relation_valid_datetime).to eq "2019/1/1"
-              expect(c.employees.first.relation_valid_datetime).to eq "2019/1/1"
-              expect(c.employees.first.address.relation_valid_datetime).to eq "2019/1/1"
             }
           }
         end
@@ -1625,7 +1614,7 @@ RSpec.describe ActiveRecord::Bitemporal do
 
       context "call `.valid_at` later" do
         it { expect(Employee.ignore_valid_datetime.valid_at("2019/1/1").bitemporal_option).to include(ignore_valid_datetime: false, valid_datetime: "2019/1/1".in_time_zone) }
-        it { expect(Employee.ignore_valid_datetime.valid_at("2019/1/1").first.bitemporal_option).to include(relation_valid_datetime: "2019/1/1".in_time_zone) }
+        it { expect(Employee.ignore_valid_datetime.valid_at("2019/1/1").first.bitemporal_option).to include(valid_datetime: "2019/1/1".in_time_zone) }
       end
     end
   end

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -589,11 +589,13 @@ RSpec.describe ActiveRecord::Bitemporal do
     context "call #update" do
       subject { -> { employee.update!(name: "Kevin") } }
       it { is_expected.to change { employee.reload.swapped_id } }
+      it { is_expected.to change { employee.reload.relation_valid_datetime } }
     end
 
     context "call .update" do
       subject { -> { Employee.find(employee.id).update!(name: "Kevin") } }
       it { is_expected.to change { employee.reload.swapped_id } }
+      it { is_expected.to change { employee.reload.relation_valid_datetime } }
     end
   end
 

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -482,7 +482,7 @@ RSpec.describe ActiveRecord::Bitemporal do
 
       it do
         Employee.valid_at("2018/12/5 9:00").tap { |m|
-          expect(m.valid_datetime.zone).to eq "+09:00"
+          expect(m.valid_datetime.zone).to eq "JST"
         }
       end
 

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -2062,4 +2062,10 @@ RSpec.describe ActiveRecord::Bitemporal do
       end
     end
   end
+
+  describe "ActiveRecord" do
+    context "[Bug fix] https://github.com/rails/rails/pull/38583 in Rails 5.x" do
+      it { expect { Employee.where(Arel.sql("name").eq("Tom")).except_bitemporal_default_scope.to_sql }.not_to raise_error }
+    end
+  end
 end

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -596,7 +596,8 @@ RSpec.describe ActiveRecord::Bitemporal do
       it { is_expected.to change { employee.reload.swapped_id } }
     end
 
-    context "with ActiveRecord::Bitemporal.valid_at" do
+    # TODO: Not yet supported
+    xcontext "with ActiveRecord::Bitemporal.valid_at" do
       let(:employee) { Employee.create!(valid_from: "2019/01/01") }
       it { expect { ActiveRecord::Bitemporal.valid_at("2020/01/01") { employee.reload } }.to change { employee.valid_datetime }.from(nil).to("2020/01/01".in_time_zone) }
     end

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -601,6 +601,14 @@ RSpec.describe ActiveRecord::Bitemporal do
       it { expect { ActiveRecord::Bitemporal.valid_at("2020/01/01") { employee.reload } }.to change { employee.valid_datetime }.from(nil).to("2020/01/01".in_time_zone) }
     end
 
+    context "without ActiveRecord::Bitemporal.valid_at" do
+      let(:employee) {
+        employee = Employee.create!(valid_from: "2019/01/01")
+        Employee.find_at_time("2020/01/01", employee.id)
+      }
+      it { expect { employee.reload }.to change { employee.bitemporal_option }.to be_empty }
+    end
+
     # TODO:
     xcontext "with #valid_at" do
       let(:employee) { Employee.create!(valid_from: "2019/01/01") }

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -1476,7 +1476,7 @@ RSpec.describe ActiveRecord::Bitemporal do
             result = ActiveRecord::Bitemporal.valid_at("2019/1/1") {
               expect(Employee.ignore_valid_datetime.to_sql).not_to match %r/"valid_from" <= /
               expect(Employee.ignore_valid_datetime.to_sql).not_to match %r/"valid_to" > /
-              expect(Employee.ignore_valid_datetime.first.valid_datetime).to eq "2019/1/1"
+#               expect(Employee.ignore_valid_datetime.first.valid_datetime).to eq "2019/1/1"
               Employee.ignore_valid_datetime.first
             }
             expect(result.valid_datetime).to be_nil
@@ -1496,7 +1496,7 @@ RSpec.describe ActiveRecord::Bitemporal do
               }
               expect(Employee.ignore_valid_datetime.to_sql).not_to match %r/"valid_from" <= /
               expect(Employee.ignore_valid_datetime.to_sql).not_to match %r/"valid_to" > /
-              expect(Employee.ignore_valid_datetime.first.valid_datetime).to eq "2019/2/2"
+#               expect(Employee.ignore_valid_datetime.first.valid_datetime).to eq "2019/2/2"
               Employee.ignore_valid_datetime.first
             }
             expect(result.valid_datetime).to be_nil

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -589,13 +589,21 @@ RSpec.describe ActiveRecord::Bitemporal do
     context "call #update" do
       subject { -> { employee.update!(name: "Kevin") } }
       it { is_expected.to change { employee.reload.swapped_id } }
-      it { is_expected.to change { employee.reload.relation_valid_datetime } }
     end
 
     context "call .update" do
       subject { -> { Employee.find(employee.id).update!(name: "Kevin") } }
       it { is_expected.to change { employee.reload.swapped_id } }
-      it { is_expected.to change { employee.reload.relation_valid_datetime } }
+    end
+
+    context "with #valid_at" do
+      let(:employee) { Employee.create!(valid_from: "2019/01/01") }
+      it { expect { ActiveRecord::Bitemporal.valid_at("2020/01/01") { employee.reload } }.to change { employee.relation_valid_datetime }.from(nil).to("2020/01/01".in_time_zone) }
+    end
+
+    # TODO
+    xcontext "with #valid_at" do
+      it { expect { employee.valid_at('2020/01/01', &:reload) }.to change { employee.relation_valid_datetime } }
     end
   end
 

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -596,13 +596,14 @@ RSpec.describe ActiveRecord::Bitemporal do
       it { is_expected.to change { employee.reload.swapped_id } }
     end
 
-    context "with #valid_at" do
+    context "with ActiveRecord::Bitemporal.valid_at" do
       let(:employee) { Employee.create!(valid_from: "2019/01/01") }
       it { expect { ActiveRecord::Bitemporal.valid_at("2020/01/01") { employee.reload } }.to change { employee.valid_datetime }.from(nil).to("2020/01/01".in_time_zone) }
     end
 
-    # TODO
+    # TODO:
     xcontext "with #valid_at" do
+      let(:employee) { Employee.create!(valid_from: "2019/01/01") }
       it { expect { employee.valid_at('2020/01/01', &:reload) }.to change { employee.valid_datetime } }
     end
   end
@@ -1363,11 +1364,9 @@ RSpec.describe ActiveRecord::Bitemporal do
         let(:next_year) { 1.year.since.beginning_of_year.to_date }
         let!(:employee) { Employee.create(emp_code: "001", name: "Tom", valid_from: previous_year, valid_to: next_year) }
         context "not `valid_at`" do
-          # TODO: be not empty bitemporal_option
-          #       bitemporal_option[:valid_datetime] is Time.current
-          xit { expect(Employee.find(employee.id).bitemporal_option).to be_empty }
-          xit { expect(Employee.find_by(name: "Tom").bitemporal_option).to be_empty }
-          xit { expect(Employee.where(name: "Tom").first.bitemporal_option).to be_empty }
+          it { expect(Employee.find(employee.id).bitemporal_option).to be_empty }
+          it { expect(Employee.find_by(name: "Tom").bitemporal_option).to be_empty }
+          it { expect(Employee.where(name: "Tom").first.bitemporal_option).to be_empty }
         end
 
         context "`valid_at` within call bitemporal_option" do
@@ -1455,11 +1454,12 @@ RSpec.describe ActiveRecord::Bitemporal do
         end
 
         context "with ignore_valid_datetime" do
-          xit do
+          it do
             result = ActiveRecord::Bitemporal.valid_at("2019/1/1") {
               expect(Employee.ignore_valid_datetime.to_sql).not_to match %r/"valid_from" <= /
               expect(Employee.ignore_valid_datetime.to_sql).not_to match %r/"valid_to" > /
               expect(Employee.ignore_valid_datetime.first.valid_datetime).to eq "2019/1/1"
+              Employee.ignore_valid_datetime.first
             }
             expect(result.valid_datetime).to be_nil
           end
@@ -1467,7 +1467,7 @@ RSpec.describe ActiveRecord::Bitemporal do
       end
 
       context "relation object" do
-        xit do
+        it do
           Company.valid_at("2019/1/1").tap { |m|
             expect(m.valid_datetime).to eq "2019/1/1"
             result = ActiveRecord::Bitemporal.valid_at("2019/2/2") {

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -601,12 +601,21 @@ RSpec.describe ActiveRecord::Bitemporal do
       it { expect { ActiveRecord::Bitemporal.valid_at("2020/01/01") { employee.reload } }.to change { employee.valid_datetime }.from(nil).to("2020/01/01".in_time_zone) }
     end
 
+    context "within #valid_at" do
+      let(:employee) { Employee.create!(valid_from: "2019/01/01") }
+      it do
+        employee.valid_at("2019/04/01") { |record|
+          expect(record.reload.valid_datetime).to eq "2019/04/01".in_time_zone
+        }
+      end
+    end
+
     context "without ActiveRecord::Bitemporal.valid_at" do
       let(:employee) {
         employee = Employee.create!(valid_from: "2019/01/01")
         Employee.find_at_time("2020/01/01", employee.id)
       }
-      it { expect { employee.reload }.to change { employee.bitemporal_option }.to be_empty }
+      it { expect { employee.reload }.not_to change { employee.bitemporal_option } }
     end
 
     # TODO:

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -831,7 +831,7 @@ RSpec.describe ActiveRecord::Bitemporal do
 
     context "failure" do
       context "`valid_datetime` is `company.valid_from`" do
-        let(:company) { Company.create!(valid_from: "2019/2/1") }
+        let!(:company) { Company.create!(valid_from: "2019/2/1") }
         let(:company_count) { -> { Company.ignore_valid_datetime.bitemporal_for(company.id).count } }
         let(:company_transaction_to) { -> { Company.ignore_valid_datetime.within_deleted.bitemporal_for(company.id).first.transaction_to } }
         let(:valid_datetime) { company.valid_from }

--- a/spec/activerecord-bitemporal/relation_spec.rb
+++ b/spec/activerecord-bitemporal/relation_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe "Relation" do
     it do
       Timecop.freeze(Time.utc(2018, 12, 25).in_time_zone) {
         expect(subject.to_sql).to match %r/"employees"."valid_from" <= '2018-12-25 00:00:00' AND "employees"."valid_to" > '2018-12-25 00:00:00'/
-        expect(subject.arel.to_sql).to match %r/"employees"."valid_from" <= \$1 AND "employees"."valid_to" > \$2/
+        expect(subject.arel.to_sql).to match %r/"employees"."transaction_from" <= \$1 AND "employees"."transaction_to" > \$2/
+        expect(subject.arel.to_sql).to match %r/"employees"."valid_from" <= \$3 AND "employees"."valid_to" > \$4/
       }
     end
 
@@ -81,7 +82,7 @@ RSpec.describe "Relation" do
     it do
       Timecop.freeze(Time.utc(2018, 12, 25).in_time_zone) {
         expect(subject.to_sql).to match %r/"employees"."valid_from" <= '2018-12-25 00:00:00' AND "employees"."valid_to" > '2018-12-25 00:00:00'/
-        expect(subject.arel.to_sql).to match %r/"employees"."valid_from" <= \$1 AND "employees"."valid_to" > \$2/
+        expect(subject.arel.to_sql).to match %r/"employees"."valid_from" <= \$3 AND "employees"."valid_to" > \$4/
       }
     end
 
@@ -142,6 +143,11 @@ RSpec.describe "Relation" do
     subject { relation.bitemporal_option }
     it { is_expected.to include(valid_datetime: "2019/2/2".in_time_zone) }
     it { expect(relation.loaded?).to be_falsey }
+    it do
+      puts relation.to_sql
+      puts relation.arel.to_sql
+      pp subject
+    end
   end
 
   describe "preload" do

--- a/spec/activerecord-bitemporal/relation_spec.rb
+++ b/spec/activerecord-bitemporal/relation_spec.rb
@@ -137,15 +137,6 @@ RSpec.describe "Relation" do
     end
   end
 
-  describe ".except" do
-    # TODO: deprecated
-    #       bitemporal_option has not state
-    xdescribe "relation `bitemporal_option`" do
-      subject { Company.with_bitemporal_option(hoge: 42).except(:where).bitemporal_option }
-      it { is_expected.to include(hoge: 42) }
-    end
-  end
-
   describe ".merge" do
     let(:relation) { Company.valid_at("2019/1/1").merge(Company.valid_at("2019/2/2")) }
     subject { relation.bitemporal_option }

--- a/spec/activerecord-bitemporal/relation_spec.rb
+++ b/spec/activerecord-bitemporal/relation_spec.rb
@@ -143,11 +143,6 @@ RSpec.describe "Relation" do
     subject { relation.bitemporal_option }
     it { is_expected.to include(valid_datetime: "2019/2/2".in_time_zone) }
     it { expect(relation.loaded?).to be_falsey }
-    it do
-      puts relation.to_sql
-      puts relation.arel.to_sql
-      pp subject
-    end
   end
 
   describe "preload" do

--- a/spec/activerecord-bitemporal/scopes_spec.rb
+++ b/spec/activerecord-bitemporal/scopes_spec.rb
@@ -94,8 +94,8 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
       let(:from) { "2019/1/20" }
       let(:to) { "2019/1/30" }
       subject { Employee.valid_in(from: from, to: to).arel.to_sql }
-      it { is_expected.to match %r/"employees"."valid_to" >= \$1/ }
-      it { is_expected.to match %r/"employees"."valid_from" <= \$2/ }
+      it { is_expected.to match %r/"employees"."valid_to" >= \$3/ }
+      it { is_expected.to match %r/"employees"."valid_from" <= \$4/ }
     end
   end
 
@@ -168,8 +168,8 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
       let(:from) { "2019/1/20" }
       let(:to) { "2019/1/30" }
       subject { Employee.valid_allin(from: from, to: to).arel.to_sql }
-      it { is_expected.to match %r/"employees"."valid_from" >= \$1/ }
-      it { is_expected.to match %r/"employees"."valid_to" <= \$2/ }
+      it { is_expected.to match %r/"employees"."valid_from" >= \$3/ }
+      it { is_expected.to match %r/"employees"."valid_to" <= \$4/ }
     end
   end
 

--- a/spec/activerecord-bitemporal/transaction_at_spec.rb
+++ b/spec/activerecord-bitemporal/transaction_at_spec.rb
@@ -603,7 +603,7 @@ RSpec.describe "transaction_at" do
     end
   end
 
-  xdescribe "without created_at deleted_at" do
+  describe "without created_at deleted_at" do
     ActiveRecord::Schema.define(version: 1) do
       create_table :without_created_at_deleted_ats, force: true do |t|
         t.string :name

--- a/spec/activerecord-bitemporal/uniqueness_spec.rb
+++ b/spec/activerecord-bitemporal/uniqueness_spec.rb
@@ -325,6 +325,16 @@ RSpec.describe ActiveRecord::Bitemporal::Uniqueness do
         it { is_expected.to be_truthy }
       end
     end
+
+    context "`valid_at` is duplicated in past history" do
+      let(:record) {
+        employee = EmployeeWithUniquness.create(name: "A", valid_from: "2000/01/01")
+        employee.update!(name: "B")
+        employee
+      }
+      subject { record.valid_at("2010/01/01", &:valid?) }
+      it { is_expected.to be_falsey }
+    end
   end
 
   describe EmployeeWithUniqunessAndScope do


### PR DESCRIPTION
## Summary

* Implement `transaction_at`
    * Added `transaction_from / transaction_to` aware queries
* Refactoring.
    * Changed to use `default_scope`
    * Basically keep the existing behavior
* Add necessary `scope`


## Add `transaction_at`

* Add query that considers `transaction_datetime`
    * Queries that refer to `transaction_from / transaction_to`
* `transaction datetime` will be "system created/deleted" information
    * `transaction_from` : system created time (equivalent to the current `created_at`)
    * `transaction_to`: the time when the transaction was deleted from the system (equivalent to the current `deleted_at`).
* `transaction_to`: the time when the transaction was deleted from the system (equivalent to the current `deleted_at`) * `transaction_to`: the time when the transaction was deleted from the system (equivalent to the current `deleted_at`)


Translated with www.DeepL.com/Translator (free version)

```ruby
# Implicitly add a transaction_from / transaction_to query with current time
users = User.all
puts users.to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."transaction_from" <= '2020-02-17 09:28:14.703454'
#       AND "users"."transaction_to"   >  '2020-02-17 09:28:14.703454'
#       AND "users"."valid_from"       <= '2020-02-17 09:28:14.703454'
#       AND "users"."valid_to"         >  '2020-02-17 09:28:14.703454'


# Can be fixed with transaction_at as well as valid_at
users = User.transaction_at("2019/01/01")
puts users.to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."valid_from"       <= '2020-02-17 09:28:14.709770'
#       AND "users"."valid_to"         >  '2020-02-17 09:28:14.709770'
#       AND "users"."transaction_from" <= '2019-01-01 00:00:00'
#       AND "users"."transaction_to"   >  '2019-01-01 00:00:00'


# ignore_transaction_datetime as well as ignore_valid_datetime can be used to delete a query
users = User.ignore_transaction_datetime
puts users.to_sql
# =>  SELECT "users".*
#       FROM "users"
#      WHERE "users"."valid_from" <= '2020-02-17 09:28:14.710453'
#        AND "users"."valid_to"   >  '2020-02-17 09:28:14.710453'


# Can be used in conjunction with valid_at
users = User.transaction_at("2019/01/01").valid_at("2019/05/05")
puts users.to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."transaction_from" <= '2019-01-01 00:00:00'
#       AND "users"."transaction_to"   >  '2019-01-01 00:00:00'
#       AND "users"."valid_from"       <= '2019-05-05 00:00:00'
#       AND "users"."valid_to"         >  '2019-05-05 00:00:00'


# If you want to set valid_at and transaction_at to the same time, you can use bitemporal_at
users = User.bitemporal_at("2020/04/01")
puts users.to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."transaction_from" <= '2020-04-01 00:00:00'
#       AND "users"."transaction_to"   >  '2020-04-01 00:00:00'
#       AND "users"."valid_from"       <= '2020-04-01 00:00:00'
#       AND "users"."valid_to"         >  '2020-04-01 00:00:00'


# If you want to delete all queries, use ignore_bitemporal_datetime
users = User.ignore_bitemporal_datetime
puts users.to_sql
```

### Scope 一覧

| Scope | Meaning | valid_at | transaction_at |
| --- | --- | --- | --- |
| default | bitemporal_at(current time) | current time | current time |
| `valid_at(datetime)` | Add a valid_at query for datetime | `datetime` | current time |
| `transaction_at(datetime)` | Add a transaction_at query for datetime | current time | `datetime` |
| `bitemporal_at(datetime)` | Add a valid_At and transaction_at query for datetime | `datetime` | `datetime` |
| `ignore_valid_datetime` | Remove valid_at query | none | current time |
| `ignore_transaction_datetime` | Remove transaction_at query | current time | none |
| `ignore_bitemporal_datetime` | Remove valid_at and transaction_at query | none | none |
| `except_valid_datetime` | Except valid_at query | none | current time |
| `except_transaction_datetime` | Except transaction_at query | current time | none |
| `except_bitemporal_datetime` | Except valid_at and transaction_at query | none | none |

NOTE: The difference between `ignore_xxx` and `except_xxx` affects `.merge` (see below).



## Changed the timing of when the default query is generated

* Default queries are now defined in `default_scope`
* Also, the timing for adding default queries has changed
    * The `current time` referenced by default has changed

### Before

* `ActiveRecord` refers to the current time when building the SQL
    * Same `relation` will generate different SQL

```ruby
relation = nil
Timecop.freeze("2020/04/01") {
  relation = Company.all
}

# current time will be added regardless of the time the relation was generated
puts relation.to_sql
# => SELECT "companies".*
#      FROM "companies"
#     WHERE "companies"."valid_from" <= '2021-03-05 02:58:25.287078'
#       AND "companies"."valid_to"   >  '2021-03-05 02:58:25.287078'
#       AND "companies"."deleted_at" IS NULL


# The following queries will all have different times
relation = User.where(name: "Tom")
puts relation.to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."valid_from" <= '2021-03-05 02:58:25.294115'
#       AND "users"."valid_to"   >  '2021-03-05 02:58:25.294115'
#       AND "users"."deleted_at" IS NULL
#       AND "users"."name"       =  'Tom'

sleep 1
puts relation.to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."valid_from" <= '2021-03-05 02:58:26.296544'
#       AND "users"."valid_to"   >  '2021-03-05 02:58:26.296544'
#       AND "users"."deleted_at" IS NULL
#       AND "users"."name"       =  'Tom'

sleep 1
puts relation.to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."valid_from" <= '2021-03-05 02:58:27.298266'
#       AND "users"."valid_to"   >  '2021-03-05 02:58:27.298266'
#       AND "users"."deleted_at" IS NULL
#       AND "users"."name"       =  'Tom'


# relation See also records after generation
Company.create(name: "Company1")
relation = Company.all
Company.create(name: "Company2")

pp relation.pluck(:name)
# => ["Company1", "Company2"]
```

### After

* The query is added at the time when the first `relation` is generated.

```ruby
relation = nil
Timecop.freeze("2020/04/01") {
  relation = Company.all
}

# The query for the time when the relation was created will be added
puts relation.to_sql
# => SELECT "companies".*
#      FROM "companies"
#     WHERE "companies"."transaction_from" <= '2020-04-01 00:00:00'
#       AND "companies"."transaction_to"   >  '2020-04-01 00:00:00'
#       AND "companies"."valid_from"       <= '2020-04-01 00:00:00'
#       AND "companies"."valid_to"         >  '2020-04-01 00:00:00'


# The following queries will all have the same time
relation = User.where(name: "Tom")
puts relation.to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."transaction_from" <= '2021-03-05 03:07:34.679500'
#       AND "users"."transaction_to"   >  '2021-03-05 03:07:34.679500'
#       AND "users"."valid_from"       <= '2021-03-05 03:07:34.679500'
#       AND "users"."valid_to"         >  '2021-03-05 03:07:34.679500'
#       AND "users"."name"             =  'Tom'

sleep 1
puts relation.to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."transaction_from" <= '2021-03-05 03:07:34.679500'
#       AND "users"."transaction_to"   >  '2021-03-05 03:07:34.679500'
#       AND "users"."valid_from"       <= '2021-03-05 03:07:34.679500'
#       AND "users"."valid_to"         >  '2021-03-05 03:07:34.679500'
#       AND "users"."name"             =  'Tom'

sleep 1
puts relation.to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."transaction_from" <= '2021-03-05 03:07:34.679500'
#       AND "users"."transaction_to"   >  '2021-03-05 03:07:34.679500'
#       AND "users"."valid_from"       <= '2021-03-05 03:07:34.679500'
#       AND "users"."valid_to"         >  '2021-03-05 03:07:34.679500'
#       AND "users"."name"             =  'Tom'

# relation Do not reference records after generation
Company.create(name: "Company1")
relation = Company.all
Company.create(name: "Company2")

pp relation.pluck(:name)
# => ["Company1"]
```


## `.or` 

* `bitemporal` queries for `other` are now `OR` when doing `relation.or(other)`.

### Before

* `relation.or(other)` will `OR` the query of `other` without the query of `bitemporal datetime`

```ruby
# Only .valid_at("04/01") is included
puts User.valid_at("04/01").where(name: "Mado").or(User.where(name: "Mami")).to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."valid_from" <= '2020-04-01 00:00:00'
#       AND "users"."valid_to"   >  '2020-04-01 00:00:00'
#       AND "users"."deleted_at" IS NULL
#       AND (
#           "users"."name"       =  'Mado'
#        OR "users"."name"       =  'Mami'
#           )

# valid datetime query is not included
puts User.ignore_valid_datetime.where(name: "Mado").or(User.where(name: "Mami")).to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."deleted_at" IS NULL
#       AND (
#           "users"."name" = 'Mado'
#        OR "users"."name" = 'Mami'
#           )
```

### Before

* `relation.or(other)` then the query of `other`, including the query of `bitemporal datetime`, will be `ORed` as is

```ruby
relation1 = User.where(name: "Mami")
relation2 = User.valid_at("04/01").where(name: "Mado")

# Each relation has its own time query
puts relation1.to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."transaction_from" <= '2020-11-10 00:35:56.494922'
#       AND "users"."transaction_to"   >  '2020-11-10 00:35:56.494922'
#       AND "users"."valid_from"       <= '2020-11-10 00:35:56.494922'
#       AND "users"."valid_to"         >  '2020-11-10 00:35:56.494922'
#       AND "users"."name"             =  'Mami'

puts relation2.to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."transaction_from" <= '2020-11-10 00:35:56.500714'
#       AND "users"."transaction_to"   >  '2020-11-10 00:35:56.500714'
#       AND "users"."valid_from"       <= '2020-04-01 00:00:00'
#       AND "users"."valid_to"         >  '2020-04-01 00:00:00'
#       AND "users"."name"             =  'Mado'


# Include all time queries or be included
puts relation2.or(relation1).to_sql
# = >SELECT "users".*
#      FROM "users"
#     WHERE (
#               "users"."transaction_from" <= '2020-11-10 00:35:56.500714'
#           AND "users"."transaction_to"   >  '2020-11-10 00:35:56.500714'
#           AND "users"."valid_from"       <= '2020-04-01 00:00:00'
#           AND "users"."valid_to"         >  '2020-04-01 00:00:00'
#           AND "users"."name"             =  'Mado'
#            OR "users"."transaction_from" <= '2020-11-10 00:35:56.494922'
#           AND "users"."transaction_to"   >  '2020-11-10 00:35:56.494922'
#           AND "users"."valid_from"       <= '2020-11-10 00:35:56.494922'
#           AND "users"."valid_to"         >  '2020-11-10 00:35:56.494922'
#           AND "users"."name"             =  'Mami'
#           )
```


## `.merge`

* `datetime` of `.merge` relation is now added to (overwritten by) the WHERE clause
    * This is the same for `valid datetime` and `transaction datetime`

### Before

* Queries other than `datetime` are added to the WHERE clause

```ruby
# Only ORDER clause will be added
puts User.valid_at("04/01").where(name: "Mado").merge(User.order(:valid_from)).to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."valid_from" <= '2020-04-01 00:00:00'
#       AND "users"."valid_to"   >  '2020-04-01 00:00:00'
#       AND "users"."deleted_at" IS NULL
#       AND "users"."name"       =  'Mado'
#     ORDER BY "valid_from" ASC


# ignore_valid_datetime will be reflected
puts User.where(name: "Mado").merge(User.ignore_valid_datetime).to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."deleted_at" IS NULL
#       AND "users"."name" = 'Mado'


puts User.valid_at("04/01").where(name: "Mado").merge(User.ignore_valid_datetime).to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."deleted_at" IS NULL
#       AND "users"."name" = 'Mado'
puts User.ignore_valid_datetime.where(name: "Mado").merge(User.valid_at("04/01")).to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."valid_from" <= '2020-04-01 00:00:00'
#       AND "users"."valid_to"   >  '2020-04-01 00:00:00'
#       AND "users"."deleted_at" IS NULL
#       AND "users"."name"       =  'Mado'
```


### After

* Add the query including `datetime` to the WHERE clause
    * This is because the relation to `merge` implicitly has a `datetime` query

```ruby
# User.order(:valid_from) has an implicit datetime query, so it will be overridden
puts User.valid_at("04/01").where(name: "Mado").merge(User.order(:valid_from)).to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."name"             =  'Mado'
#       AND "users"."transaction_from" <= '2020-11-04 06:21:56.246126'
#       AND "users"."transaction_to"   >  '2020-11-04 06:21:56.246126'
#       AND "users"."valid_from"       <= '2020-11-04 06:21:56.246126'
#       AND "users"."valid_to"         >  '2020-11-04 06:21:56.246126'
#     ORDER BY "valid_from" ASC


# ignore_valid_datetime が反映される
puts User.where(name: "Mado").merge(User.ignore_valid_datetime).to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."name"             =  'Mado'
#       AND "users"."transaction_from" <= '2020-11-11 04:06:54.500840'
#       AND "users"."transaction_to"   >  '2020-11-11 04:06:54.500840'


puts User.valid_at("04/01").where(name: "Mado").merge(User.ignore_valid_datetime).to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."name"             =  'Mado'
#       AND "users"."transaction_from" <= '2020-11-11 04:27:58.669169'
#       AND "users"."transaction_to"   >  '2020-11-11 04:27:58.669169'
puts User.ignore_valid_datetime.where(name: "Mado").merge(User.valid_at("04/01")).to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."name"             =  'Mado'
#       AND "users"."transaction_from" <= '2020-11-11 04:37:53.548309'
#       AND "users"."transaction_to"   >  '2020-11-11 04:37:53.548309'
#       AND "users"."valid_from"       <= '2020-04-01 00:00:00'
#       AND "users"."valid_to"         >  '2020-04-01 00:00:00'



# merge queries are added even if .ignore_valid_datetime is set
puts User.ignore_valid_datetime.where(name: "Mado").merge(User.order(:valid_from)).to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."name"             =  'Mado'
#       AND "users"."transaction_from" <= '2020-11-04 07:03:34.284555'
#       AND "users"."transaction_to"   >  '2020-11-04 07:03:34.284555'
#       AND "users"."valid_from"       <= '2020-11-04 07:03:34.284555'
#       AND "users"."valid_to"         >  '2020-11-04 07:03:34.284555'
#     ORDER BY "valid_from" ASC


# valid_at も上書きされる
puts User.valid_at("04/01").merge(User.valid_at("10/01")).to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."transaction_from" <= '2020-11-11 03:52:46.482420'
#       AND "users"."transaction_to"   >  '2020-11-11 03:52:46.482420'
#       AND "users"."valid_from"       <= '2020-10-01 00:00:00'
#       AND "users"."valid_to"         >  '2020-10-01 00:00:00'
```

### `merge` + `ignore_xxx`

* Merging a relation with `ignore_xxx` also removes the query from the original relation
* This has always been the behavior

```ruby
# Can explicitly remove the valid datetime query
puts User.all.merge(User.ignore_valid_datetime).to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."transaction_from" <= '2020-11-11 03:46:29.655353'
#       AND "users"."transaction_to"   >  '2020-11-11 03:46:29.655353'


# Note that valid_at queries will also be stripped
puts User.valid_at("04/01").merge(User.order(:valid_from).ignore_valid_datetime).to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."transaction_from" <= '2020-11-11 03:45:34.322366'
#       AND "users"."transaction_to"   >  '2020-11-11 03:45:34.322366'
```

### `merge` + `except_xxx`

* `except_xxx` is provided separately from `ignore_xxx`.
* This is basically the same as `ignore_xxx`.

```ruby
# Both will lose the valid datetime query
puts User.valid_at("04/01").ignore_valid_datetime.to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."transaction_from" <= '2020-11-14 07:42:54.403333'
#       AND "users"."transaction_to"   >  '2020-11-14 07:42:54.403333'

puts User.valid_at("04/01").except_valid_datetime.to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."transaction_from" <= '2020-11-14 07:42:54.408800'
#       AND "users"."transaction_to"   >  '2020-11-14 07:42:54.408800'
```

* However, if you do `.merge`, `ignore_xxx` will remove the `datetime` query from the original relation, but `except_xxx` will only remove the `datetime` query from the relation to be `.merged` without removing it.

```ruby
# No more valid datetime queries
puts User.valid_at("04/01").merge(User.ignore_valid_datetime).to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."transaction_from" <= '2020-11-14 07:47:25.201365'
#       AND "users"."transaction_to"   >  '2020-11-14 07:47:25.201365'

# valid datetime The query is still valid
puts User.valid_at("04/01").merge(User.except_valid_datetime).to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."valid_from"       <= '2020-04-01 00:00:00'
#       AND "users"."valid_to"         >  '2020-04-01 00:00:00'
#       AND "users"."transaction_from" <= '2020-11-14 07:47:25.202810'
#       AND "users"."transaction_to"   >  '2020-11-14 07:47:25.202810'
```

* If you want to remove `datetime` from the relation only, you can use `except_xxx`
* If you want to `merge` with a query other than `datetime`, you can use

```ruby
# valid datetime query will be overwritten
puts User.valid_at("04/01").merge(User.order(:valid_from)).to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."transaction_from" <= '2020-11-14 07:50:51.711024'
#       AND "users"."transaction_to"   >  '2020-11-14 07:50:51.711024'
#       AND "users"."valid_from"       <= '2020-11-14 07:50:51.711024'
#       AND "users"."valid_to"         >  '2020-11-14 07:50:51.711024'
#     ORDER BY "valid_from" ASC

# ignore_valid_datetime Then the valid datetime query disappears
puts User.valid_at("04/01").merge(User.ignore_valid_datetime.order(:valid_from)).to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."transaction_from" <= '2020-11-14 07:50:51.713109'
#       AND "users"."transaction_to"   >  '2020-11-14 07:50:51.713109'
#     ORDER BY "valid_from" ASC

# except_valid_datetime leaves the original valid datetime
puts User.valid_at("04/01").merge(User.except_valid_datetime.order(:valid_from)).to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."valid_from"       <= '2020-04-01 00:00:00'
#       AND "users"."valid_to"         >  '2020-04-01 00:00:00'
#       AND "users"."transaction_from" <= '2020-11-14 07:50:51.714346'
#       AND "users"."transaction_to"   >  '2020-11-14 07:50:51.714346'
#     ORDER BY "valid_from" ASC
```


### Summary

| base relation | relation to merge | Overwritten? |
| --- | --- | --- |
| `default` | `default` | Yes |
| `default` | `valid_at` | Yes |
| `default` | `ignore_valid_datetime` | Yes |
| `default` | `except_valid_datetime` | No |
| `valid_at` | `default` | Yes |
| `valid_at` | `valid_at` | Yes |
| `valid_at` | `ignore_valid_datetime` | Yes |
| `valid_at` | `except_valid_datetime` | No |
| `ignore_valid_datetime` | `default` | Yes |
| `ignore_valid_datetime` | `valid_at` | Yes |
| `ignore_valid_datetime` | `ignore_valid_datetime` | Yes |
| `ignore_valid_datetime` | `except_valid_datetime` | Yes |
| `except_valid_datetime` | `default` | Yes |
| `except_valid_datetime` | `valid_at` | Yes |
| `except_valid_datetime` | `ignore_valid_datetime` | Yes |
| `except_valid_datetime` | `except_valid_datetime` | Yes |



## `scoping` and `unscoped`

### `scoping`

* `scope` can be set to be added implicitly in a `scoping` block.
* `scoping` can be used to reflect a `scope` in any context.
  * See here for more information about `scoping`.
  * [default_scopeよりaround_actionとscopingを使おう - アトラシエの開発ブログ](http://attracie.hatenablog.com/entry/2016/12/16/175614)
  * [Rails 6からActiveRecordのAssociationはscopingの影響を受けなくなっている件と対処法 | もばらぶエンジニアブログ](https://engineering.mobalab.net/2019/09/26/scoping-on-rails6/)

```ruby
# Implicitly valid_at query is added in scoping block
# Implicitly set default_scope in the image
User.valid_at("2020/01/01").scoping {
  puts User.all.to_sql
  # => SELECT "users".*
  #      FROM "users"
  #     WHERE "users"."transaction_from" <= '2020-02-19 13:02:07.419577'
  #       AND "users"."transaction_to"   >  '2020-02-19 13:02:07.419577'
  #       AND "users"."valid_from"       <= '2020-01-01 00:00:00'
  #       AND "users"."valid_to"         >  '2020-01-01 00:00:00'

  # If nested, this will take precedence
  puts User.valid_at("2000/04/01").to_sql
  # = >SELECT "users".*
  #      FROM "users"
  #     WHERE "users"."transaction_from" <= '2020-02-19 13:02:48.614761'
  #       AND "users"."transaction_to"   >  '2020-02-19 13:02:48.614761'
  #       AND "users"."valid_from"       <= '2000-04-01 00:00:00'
  #       AND "users"."valid_to"         >  '2000-04-01 00:00:00'
}

# Can chain
User.ignore_valid_datetime.transaction_at("1999/01/01").scoping {
  puts User.all.to_sql
  # => SELECT "users".*
  #      FROM "users"
  #     WHERE "users"."transaction_from" <= '1999-01-01 00:00:00'
  #       AND "users"."transaction_to"   >  '1999-01-01 00:00:00'
}
```

### `unscoped`

* `unscoped` can be used to disable `default_scope`.

```ruby
# unscoped does not reflect default_scope
puts User.unscoped.to_sql
# => SELECT "users".* FROM "users"

# Can also add a query after unscoped
puts User.unscoped.valid_at("2020/01/01").to_sql
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."valid_from" <= '2020-01-01 00:00:00'
#       AND "users"."valid_to"   >  '2020-01-01 00:00:00'

# Note that relations other than default_scope before unscoped will also disappear.
puts User.unscoped.where(name: "homu").to_sql
# => SELECT "users".* FROM "users" WHERE "users"."name" = 'homu'
puts User.where(name: "homu").unscoped.to_sql
# => SELECT "users".* FROM "users"

# Passing a block will be reflected in everything in the block
User.unscoped {
  puts User.all.to_sql
  # => SELECT "users".* FROM "users"
  puts User.where(name: "homu").to_sql
  # => SELECT "users".* FROM "users" WHERE "users"."name" = 'homu'
}
```


## Notes on adding an ORDER clause to a `.joins` table

* If you `.merge` a table with `.joins`, the default query of the model to be `.merged` will be added to the `WHERE` clause

```ruby
# I want only the ORDER clause for employees to be added, but queries like valid_datetime are added to the WHERE clause
* If you `.merge` a table with `.joins`, the default query of the model to be `.merged` will be added to the `WHERE` clause.
puts Company.joins(:employees).merge(Employee.order(:valid_from)).to_sql
# => SELECT "companies".*
#      FROM "companies"
#     INNER JOIN "employees"
#        ON "employees"."transaction_from" <= '2020-11-24 08:54:20.001658'
#       AND "employees"."transaction_to"   >  '2020-11-24 08:54:20.001658'
#       AND "employees"."valid_from"       <= '2020-11-24 08:54:19.987477'
#       AND "employees"."valid_to"         >  '2020-11-24 08:54:19.987477'
#       AND "employees"."company_id"       =  "companies"."bitemporal_id"
#     WHERE "companies"."transaction_from" <= '2020-11-24 08:54:19.987477'
#       AND "companies"."transaction_to"   >  '2020-11-24 08:54:19.987477'
#       AND "companies"."valid_from"       <= '2020-11-24 08:55:19.987477'
#       AND "companies"."valid_to"         >  '2020-11-24 08:54:19.987477'
#       AND "employees"."transaction_from" <= '2020-11-24 08:54:19.994199'
#       AND "employees"."transaction_to"   >  '2020-11-24 08:54:19.994199'
#       AND "employees"."valid_from"       <= '2020-11-24 08:54:19.994199'
#       AND "employees"."valid_to"         >  '2020-11-24 08:54:19.994199'
#     ORDER BY "employees"."valid_from" ASC
```

* To do such `.merge`, you need to explicitly call `.except_bitemporal_datetime` to `.merge`

```ruby
puts Company.joins(:employees).merge(Employee.except_bitemporal_datetime.order(:valid_from)).to_sql
# => SELECT "companies".*
#      FROM "companies"
#     INNER JOIN "employees"
#        ON "employees"."transaction_from" <= '2020-11-24 09:06:58.903516'
#       AND "employees"."transaction_to"   >  '2020-11-24 09:06:58.903516'
#       AND "employees"."valid_from"       <= '2020-11-24 09:06:58.888550'
#       AND "employees"."valid_to"         >  '2020-11-24 09:06:58.888550'
#       AND "employees"."company_id"       =  "companies"."bitemporal_id"
#     WHERE "companies"."transaction_from" <= '2020-11-24 09:06:58.888550'
#       AND "companies"."transaction_to"   >  '2020-11-24 09:06:58.888550'
#       AND "companies"."valid_from"       <= '2020-11-24 09:06:58.888550'
#       AND "companies"."valid_to"         >  '2020-11-24 09:06:58.888550'
#     ORDER BY "employees"."valid_from" ASC
```



## `.join` + `.ignore_valid_datetime` (+ `.merge`) behavior

* If `.joins`, the default query for the `.joins` table will be added to the `JOIN` clause

```ruby
puts Company.joins(:employees).to_sql
# => SELECT "companies".*
#      FROM "companies"
#     INNER JOIN "employees"
#        ON "employees"."transaction_from" <= '2020-11-24 09:19:06.419048'
#       AND "employees"."transaction_to"   >  '2020-11-24 09:19:06.419048'
#       AND "employees"."valid_from"       <= '2020-11-24 09:19:06.407589'
#       AND "employees"."valid_to"         >  '2020-11-24 09:19:06.407589'
#       AND "employees"."company_id"       =  "companies"."bitemporal_id"
#     WHERE "companies"."transaction_from" <= '2020-11-24 09:19:06.407589'
#       AND "companies"."transaction_to"   >  '2020-11-24 09:19:06.407589'
#       AND "companies"."valid_from"       <= '2020-11-24 09:19:06.407589'
#       AND "companies"."valid_to"         >  '2020-11-24 09:19:06.407589'
```


* Also, if the parent relation has `.ignore_valid_datetime`, its status will be reflected in the JOIN clause.

```ruby
# valid_datetime is also removed from JOIN clauses
puts Company.ignore_valid_datetime.joins(:employees).to_sql
# => SELECT "companies".*
#      FROM "companies"
#     INNER JOIN "employees"
#        ON "employees"."transaction_from" <= '2020-11-24 09:32:50.162201'
#       AND "employees"."transaction_to"   >  '2020-11-24 09:32:50.162201'
#       AND "employees"."company_id"       =  "companies"."bitemporal_id"
#     WHERE "companies"."transaction_from" <= '2020-11-24 09:32:50.154771'
#       AND "companies"."transaction_to"   >  '2020-11-24 09:32:50.154771'
```

* `.merge` of `.ignore_valid_datetime` relation will not be reflected in JOIN clause

```ruby
# .merge of .ignore_valid_datetime relation does not remove it from JOIN clause.
# On the contrary, it adds the transaction_datetime query to the WHERE clause.
puts Company.joins(:employees).merge(Employee.ignore_valid_datetime).to_sql
# => SELECT "companies".*
#      FROM "companies"
#     INNER JOIN "employees"
#        ON "employees"."transaction_from" <= '2020-11-24 09:47:45.216881'
#       AND "employees"."transaction_to"   >  '2020-11-24 09:47:45.216881'
#       AND "employees"."valid_from"       <= '2020-11-24 09:47:45.208227'
#       AND "employees"."valid_to"         >  '2020-11-24 09:47:45.208227'
#       AND "employees"."company_id"       =  "companies"."bitemporal_id"
#     WHERE "companies"."transaction_from" <= '2020-11-24 09:47:45.208227'
#       AND "companies"."transaction_to"   >  '2020-11-24 09:47:45.208227'
#       AND "companies"."valid_from"       <= '2020-11-24 09:47:45.208227'
#       AND "companies"."valid_to"         >  '2020-11-24 09:47:45.208227'
#       AND "employees"."transaction_from" <= '2020-11-24 09:47:45.211373'
#       AND "employees"."transaction_to"   >  '2020-11-24 09:47:45.211373'
```
