### PR TITLE
Make it continuously testable, even after 2020

### DIFF
--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -1080,7 +1080,10 @@ RSpec.describe ActiveRecord::Bitemporal do
   describe "Optionable" do
     describe "#bitemporal_option" do
       context "after query method" do
-        let!(:employee) { Employee.create(emp_code: "001", name: "Tom", valid_from: "2018/1/1", valid_to: "2020/1/1") }
+        let(:previous_year) { 1.year.ago.beginning_of_year.to_date }
+        let(:current_year) { Time.current.beginning_of_year.to_date }
+        let(:next_year) { 1.year.since.beginning_of_year.to_date }
+        let!(:employee) { Employee.create(emp_code: "001", name: "Tom", valid_from: previous_year, valid_to: next_year) }
         context "not `valid_at`" do
           it { expect(Employee.find(employee.id).bitemporal_option).to be_empty }
           it { expect(Employee.find_by(name: "Tom").bitemporal_option).to be_empty }
@@ -1088,21 +1091,21 @@ RSpec.describe ActiveRecord::Bitemporal do
         end
 
         context "`valid_at` within call bitemporal_option" do
-          it { expect(Employee.valid_at("2019/1/1").find(employee.id).bitemporal_option).to eq(valid_datetime: "2019/1/1") }
-          it { expect(Employee.valid_at("2019/1/1").find_by(name: "Tom").bitemporal_option).to eq(valid_datetime: "2019/1/1") }
-          it { expect(Employee.valid_at("2019/1/1").where(name: "Tom").first.bitemporal_option).to eq(valid_datetime: "2019/1/1") }
+          it { expect(Employee.valid_at(current_year).find(employee.id).bitemporal_option).to eq(valid_datetime: current_year) }
+          it { expect(Employee.valid_at(current_year).find_by(name: "Tom").bitemporal_option).to eq(valid_datetime: current_year) }
+          it { expect(Employee.valid_at(current_year).where(name: "Tom").first.bitemporal_option).to eq(valid_datetime: current_year) }
         end
 
         context "`valid_at` without call bitemporal_option" do
-          it { expect(Employee.valid_at("2019/1/1").find(employee.id).bitemporal_option).to eq(valid_datetime: "2019/1/1") }
-          it { expect(Employee.valid_at("2019/1/1").find_by(name: "Tom").bitemporal_option).to eq(valid_datetime: "2019/1/1") }
-          it { expect(Employee.valid_at("2019/1/1").where(name: "Tom").first.bitemporal_option).to eq(valid_datetime: "2019/1/1") }
+          it { expect(Employee.valid_at(current_year).find(employee.id).bitemporal_option).to eq(valid_datetime: current_year) }
+          it { expect(Employee.valid_at(current_year).find_by(name: "Tom").bitemporal_option).to eq(valid_datetime: current_year) }
+          it { expect(Employee.valid_at(current_year).where(name: "Tom").first.bitemporal_option).to eq(valid_datetime: current_year) }
         end
 
         context "relation to `valid_at`" do
-          it { expect(Employee.where(emp_code: "001").valid_at("2019/1/1").find(employee.id).bitemporal_option).to eq(valid_datetime: "2019/1/1") }
-          it { expect(Employee.where(emp_code: "001").valid_at("2019/1/1").find_by(name: "Tom").bitemporal_option).to eq(valid_datetime: "2019/1/1") }
-          it { expect(Employee.where(emp_code: "001").valid_at("2019/1/1").where(name: "Tom").first.bitemporal_option).to eq(valid_datetime: "2019/1/1") }
+          it { expect(Employee.where(emp_code: "001").valid_at(current_year).find(employee.id).bitemporal_option).to eq(valid_datetime: current_year) }
+          it { expect(Employee.where(emp_code: "001").valid_at(current_year).find_by(name: "Tom").bitemporal_option).to eq(valid_datetime: current_year) }
+          it { expect(Employee.where(emp_code: "001").valid_at(current_year).where(name: "Tom").first.bitemporal_option).to eq(valid_datetime: current_year) }
         end
       end
 


### PR DESCRIPTION
# Why
This year is 2020.
There are test cases that fail unintentionally that a datetime of test data is described as a fixed value.

# Changes
Use relative datetime for a "valid" period.
It aims to correct unintended test errors.

#  Failures in CI
```
#!/bin/bash -eo pipefail
bundle exec appraisal rails-5.2 rake
>> BUNDLE_GEMFILE=/root/project/gemfiles/rails_5.2.gemfile bundle exec rake
/usr/local/bin/ruby -I/usr/local/bundle/gems/rspec-core-3.9.1/lib:/usr/local/bundle/gems/rspec-support-3.9.2/lib /usr/local/bundle/gems/rspec-core-3.9.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
-- create_table(:companies, {:force=>true})
   -> 0.0140s
-- create_table(:company_without_bitemporals, {:force=>true})
   -> 0.0015s
-- create_table(:employees, {:force=>true})
   -> 0.0018s
-- create_table(:employee_without_bitemporals, {:force=>true})
   -> 0.0014s
-- create_table(:addresses, {:force=>true})
   -> 0.0020s
-- create_table(:address_without_bitemporals, {:force=>true})
   -> 0.0020s
-- create_table(:pictures, {:force=>true})
   -> 0.0036s
-- create_table(:products, {:force=>true})
   -> 0.0016s
-- create_table(:blogs, {:force=>true})
   -> 0.0021s
-- create_table(:users, {:force=>true})
   -> 0.0023s
-- create_table(:articles, {:force=>true})
   -> 0.0025s
...........................................................................................................................................................................**..............................................................................FFF...................................................................................................................................................................................................................................................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) ActiveRecord::Bitemporal#update updated `valid_from` and `valid_to` now time is after behaves like updated Jone 
     # Temporarily skipped with xcontext
     # ./spec/activerecord-bitemporal/bitemporal_spec.rb:589

  2) ActiveRecord::Bitemporal#update updated `valid_from` and `valid_to` now time is after behaves like updated Tom 
     # Temporarily skipped with xcontext
     # ./spec/activerecord-bitemporal/bitemporal_spec.rb:595


Failures:

  1) ActiveRecord::Bitemporal Optionable #bitemporal_option after query method not `valid_at` 
     Failure/Error: where(bitemporal_id_key => ids).yield_self { |it| expects_array ? it&.to_a : it&.take }.presence || raise(::ActiveRecord::RecordNotFound)
     
     ActiveRecord::RecordNotFound:
       ActiveRecord::RecordNotFound
     # ./lib/activerecord-bitemporal/bitemporal.rb:136:in `find'
     # ./spec/activerecord-bitemporal/bitemporal_spec.rb:1085:in `block (6 levels) in <top (required)>'

  2) ActiveRecord::Bitemporal Optionable #bitemporal_option after query method not `valid_at` 
     Failure/Error: it { expect(Employee.find_by(name: "Tom").bitemporal_option).to be_empty }
     
     NoMethodError:
       undefined method `bitemporal_option' for nil:NilClass
     # ./spec/activerecord-bitemporal/bitemporal_spec.rb:1086:in `block (6 levels) in <top (required)>'

  3) ActiveRecord::Bitemporal Optionable #bitemporal_option after query method not `valid_at` 
     Failure/Error: it { expect(Employee.where(name: "Tom").first.bitemporal_option).to be_empty }
     
     NoMethodError:
       undefined method `bitemporal_option' for nil:NilClass
     # ./spec/activerecord-bitemporal/bitemporal_spec.rb:1087:in `block (6 levels) in <top (required)>'

Finished in 12.25 seconds (files took 1.34 seconds to load)
529 examples, 3 failures, 2 pending

Failed examples:

rspec ./spec/activerecord-bitemporal/bitemporal_spec.rb:1085 # ActiveRecord::Bitemporal Optionable #bitemporal_option after query method not `valid_at` 
rspec ./spec/activerecord-bitemporal/bitemporal_spec.rb:1086 # ActiveRecord::Bitemporal Optionable #bitemporal_option after query method not `valid_at` 
rspec ./spec/activerecord-bitemporal/bitemporal_spec.rb:1087 # ActiveRecord::Bitemporal Optionable #bitemporal_option after query method not `valid_at` 

/usr/local/bin/ruby -I/usr/local/bundle/gems/rspec-core-3.9.1/lib:/usr/local/bundle/gems/rspec-support-3.9.2/lib /usr/local/bundle/gems/rspec-core-3.9.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb failed
Exited with code exit status 1
CircleCI received exit code 1
```