### PR TITLE
Except `bitempral_id` id in `scope_for_create`

### DIFF
--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -135,6 +135,9 @@ ActiveSupport.on_load(:active_record) do
   ActiveRecord::Associations::ThroughAssociation
     .prepend ActiveRecord::Bitemporal::Patches::ThroughAssociation
 
+  ActiveRecord::Associations::SingularAssociation
+    .prepend ActiveRecord::Bitemporal::Patches::SingularAssociation
+
   ActiveRecord::Reflection::AssociationReflection
     .prepend ActiveRecord::Bitemporal::Patches::AssociationReflection
 end

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -197,10 +197,6 @@ module ActiveRecord
         bitemporal_id_key
       end
 
-      def scope_for_create
-        super.except!(bitemporal_id_key)
-      end
-
       private
 
       def bitemporal_option_storage(klass_ = self.klass)

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -197,6 +197,10 @@ module ActiveRecord
         bitemporal_id_key
       end
 
+      def scope_for_create
+        super.except!(bitemporal_id_key)
+      end
+
       private
 
       def bitemporal_option_storage(klass_ = self.klass)

--- a/lib/activerecord-bitemporal/patches.rb
+++ b/lib/activerecord-bitemporal/patches.rb
@@ -109,6 +109,9 @@ module ActiveRecord::Bitemporal
     end
 
     module SingularAssociation
+      # MEMO: Except for primary_key in ActiveRecord
+      #       https://github.com/rails/rails/blob/6-0-stable/activerecord/lib/active_record/associations/singular_association.rb#L34-L36
+      #       excluding bitemporal_id_key
       def scope_for_create
         return super unless klass&.bi_temporal_model?
         super.except!(klass.bitemporal_id_key)

--- a/lib/activerecord-bitemporal/patches.rb
+++ b/lib/activerecord-bitemporal/patches.rb
@@ -107,5 +107,12 @@ module ActiveRecord::Bitemporal
         super
       end
     end
+
+    module SingularAssociation
+      def scope_for_create
+        return super unless klass&.bi_temporal_model?
+        super.except!(klass.bitemporal_id_key)
+      end
+    end
   end
 end

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -1518,4 +1518,31 @@ RSpec.describe ActiveRecord::Bitemporal do
       end
     end
   end
+
+  describe ".scope_for_create" do
+    subject { relation.scope_for_create }
+
+    context "call after `where`" do
+      let(:relation) { Employee.where(id: 1, bitemporal_id: 3) }
+      it { is_expected.to include("id" => 1, "bitemporal_id" => 3) }
+    end
+
+    context "call after `associations.where`" do
+      let(:relation) { Company.create!.employees.where(id: 1, bitemporal_id: 3) }
+      it { is_expected.to include("id" => 1, "bitemporal_id" => 3) }
+    end
+  end
+
+  describe "build association" do
+    subject { target_obj.build_company }
+    context "belong_to associations" do
+      let(:target_obj) { Company.create.employees.create }
+      it { is_expected.to have_attributes(id: nil, bitemporal_id: nil) }
+
+      context "with `bitemporal_id:" do
+        subject { target_obj.build_company(bitemporal_id: 3) }
+        it { is_expected.to have_attributes(id: nil, bitemporal_id: 3) }
+      end
+    end
+  end
 end

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -1534,13 +1534,26 @@ RSpec.describe ActiveRecord::Bitemporal do
   end
 
   describe "build association" do
-    subject { target_obj.build_company }
     context "belong_to associations" do
       let(:target_obj) { Company.create.employees.create }
+      subject { target_obj.build_company }
+
       it { is_expected.to have_attributes(id: nil, bitemporal_id: nil) }
 
       context "with `bitemporal_id:" do
         subject { target_obj.build_company(bitemporal_id: 3) }
+        it { is_expected.to have_attributes(id: nil, bitemporal_id: 3) }
+      end
+    end
+
+    context "has_one associations" do
+      let(:target_obj) { Employee.create }
+      subject { target_obj.build_address }
+
+      it { is_expected.to have_attributes(id: nil, bitemporal_id: nil) }
+
+      context "with `bitemporal_id:" do
+        subject { target_obj.build_address(bitemporal_id: 3) }
         it { is_expected.to have_attributes(id: nil, bitemporal_id: 3) }
       end
     end


### PR DESCRIPTION
Fixed an issue where `bitepmoral_id` was unnecessarily set in association `build_xxx` .

### Before

```ruby
blog = Blog.create
article = blog.articles.create

# build new blog
# bitemporal_id is not nil
new_blog = article.build_blog
pp new_blog.id            # => nil
pp new_blog.bitemporal_id # => 1

# error: `raise_validation_error': Validation failed: Bitemporal has already been taken (ActiveRecord::RecordInvalid)
new_blog.save!
```

### After

```ruby
blog = Blog.create
article = blog.articles.create

# bitemporal_id is nil
new_blog = article.build_blog
pp new_blog.id            # => nil
pp new_blog.bitemporal_id # => nil

# ok
new_blog.save!
```

