### PR TITLE
Add support `#force_update` with `valid_from`

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -367,7 +367,7 @@ module ActiveRecord
         current_time = Time.current
         target_datetime = valid_datetime || current_time
         # NOTE: force_update の場合は自身のレコードを取得するような時間を指定しておく
-        target_datetime = valid_from if force_update?
+        target_datetime = valid_from_changed? ? valid_from_was : valid_from if force_update?
 
         # MEMO: このメソッドに来るまでに validation が発動しているので、以後 validate は考慮しなくて大丈夫
         ActiveRecord::Base.transaction(requires_new: true) do


### PR DESCRIPTION
Add support `#force_update` with `valid_from`.
MEMO: `#force_update` needs to overwrite history

## Before

* `id = 1` is not deleted
* `id = 2` does not overwrite `id = 1`
  * added history record by `2019/01/01 ~ 2020-03-03 02:33:51` 

```ruby
emp = nil
emp = Employee.create!(name: "Mami")
emp.force_update { |it|
  it.update(name: "Homu", valid_from: "2019/01/01")
}

Employee.ignore_valid_datetime.within_deleted.each { |record|
  pp "id = #{record.swapped_id} : #{record.name} #{record.valid_from} ~ #{record.valid_to}, #{record.created_at} ~ #{record.deleted_at}"
}

# output:
# "id = 1 : Mami 2020-03-03 02:33:51 UTC ~ 9999-12-31 00:00:00 UTC, 2020-03-03 02:33:51 UTC ~ "
# "id = 2 : Homu 2019-01-01 00:00:00 UTC ~ 2020-03-03 02:33:51 UTC, 2020-03-03 02:33:51 UTC ~ "
```

## After

* `id = 1` is deleted
* `id = 2` does overwrite `id = 1`
  * added history record by `2019/01/01 ~ 9999-12-31` 

```ruby
emp = nil
emp = Employee.create!(name: "Mami")
emp.force_update { |it|
  it.update(name: "Homu", valid_from: "2019/01/01")
}

Employee.ignore_valid_datetime.within_deleted.each { |record|
  pp "id = #{record.swapped_id} : #{record.name} #{record.valid_from} ~ #{record.valid_to}, #{record.created_at} ~ #{record.deleted_at}"
}

# output:
# "id = 1 : Mami 2020-03-03 02:24:14 UTC ~ 9999-12-31 00:00:00 UTC, 2020-03-03 02:24:14 UTC ~ 2020-03-03 02:24:14 UTC"
# "id = 2 : Homu 2019-01-01 00:00:00 UTC ~ 9999-12-31 00:00:00 UTC, 2020-03-03 02:24:14 UTC ~ "
```