### PR TITLE
Fix redefined `#reload` method

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -459,7 +459,7 @@ module ActiveRecord
 
       module ::ActiveRecord::Persistence
         # MEMO: Must be override ActiveRecord::Persistence#reload
-        alias_method :active_record_bitemporal_original_reload, :reload
+        alias_method :active_record_bitemporal_original_reload, :reload unless method_defined? :active_record_bitemporal_original_reload
         def reload(options = nil)
           return active_record_bitemporal_original_reload(options) unless self.class.bi_temporal_model?
 


### PR DESCRIPTION
When a file was loaded multiple times, `alias_method: active_record_bitemporal_original_reload ,: reload` was called many times, which could cause infinite recursion.
Only call once `alias_method`.