### PR TITLE
Fix bitemporal find method

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -131,9 +131,12 @@ module ActiveRecord
 
         def find(*ids)
           return super if block_given?
-          expects_array = ids.first.kind_of?(Array) || ids.size > 1
-          ids = ids.first if ids.first.kind_of?(Array)
-          where(bitemporal_id_key => ids).yield_self { |it| expects_array ? it&.to_a : it&.take }.presence || raise(::ActiveRecord::RecordNotFound)
+          all.spawn.then { |obj|
+            def obj.primary_key
+              "bitemporal_id"
+            end
+            obj.method(:find).super_method.call(*ids)
+          }
         end
 
         def find_at_time!(datetime, *ids)

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -131,7 +131,7 @@ module ActiveRecord
 
         def find(*ids)
           return super if block_given?
-          all.spawn.then { |obj|
+          all.spawn.yield_self { |obj|
             def obj.primary_key
               "bitemporal_id"
             end

--- a/spec/activerecord-bitemporal/association_spec.rb
+++ b/spec/activerecord-bitemporal/association_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe "Association" do
 
       describe ".find" do
         it { expect(employees.find(mado.id)).to have_attributes(name: "Mado") }
-        it { expect(employees.find(mado.id, tom).pluck(:name)).to contain_exactly("Mado", "Tom") }
+        it { expect(employees.find(mado.id, tom.id).pluck(:name)).to contain_exactly("Mado", "Tom") }
       end
 
       describe ".find_by" do

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -89,12 +89,6 @@ RSpec.describe ActiveRecord::Bitemporal do
         it { expect(subject).to be_kind_of(Array) }
       end
 
-      context "is `model`" do
-        let(:ids) { [employee1, employee2, employee2] }
-        it { expect(subject.map(&:name)).to contain_exactly("Tom", "Mado") }
-        it { expect(subject).to be_kind_of(Array) }
-      end
-
       context "non exists employee" do
         let(:ids) { [nil, nil, nil] }
         it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
@@ -118,14 +112,8 @@ RSpec.describe ActiveRecord::Bitemporal do
         it { expect(subject).to be_kind_of(Array) }
       end
 
-      context "is `model`" do
-        let(:ids) { [employee1, employee2, employee2] }
-        it { expect(subject.map(&:name)).to contain_exactly("Tom", "Mado") }
-        it { expect(subject).to be_kind_of(Array) }
-      end
-
       context "is once" do
-        let(:ids) { [employee1] }
+        let(:ids) { [employee1.id] }
         it { expect(subject.map(&:name)).to contain_exactly("Tom") }
         it { expect(subject).to be_kind_of(Array) }
       end
@@ -328,7 +316,7 @@ RSpec.describe ActiveRecord::Bitemporal do
           it { expect(subject).to be_kind_of(Array) }
         end
         context "is once" do
-          let(:ids) { [employee1] }
+          let(:ids) { [employee1.id] }
           let(:datetime) { before_update_time }
           it { expect(subject.map(&:name)).to contain_exactly("Jane") }
           it { expect(subject).to be_kind_of(Array) }
@@ -416,7 +404,7 @@ RSpec.describe ActiveRecord::Bitemporal do
           it { expect(subject).to be_kind_of(Array) }
         end
         context "is once" do
-          let(:ids) { [employee1] }
+          let(:ids) { [employee1.id] }
           let(:datetime) { before_update_time }
           it { expect(subject.map(&:name)).to contain_exactly("Jane") }
           it { expect(subject).to be_kind_of(Array) }
@@ -553,7 +541,7 @@ RSpec.describe ActiveRecord::Bitemporal do
 
   describe "#ignore_valid_datetime" do
     let!(:employee) { Employee.create!(name: "Jone") }
-    let(:update) { -> { Employee.find(employee).update(name: "Tom"); Time.current } }
+    let(:update) { -> { Employee.find(employee.id).update(name: "Tom"); Time.current } }
 
     context "called by `ActiveRecord_Relation`" do
       let(:count) { -> { Employee.where(bitemporal_id: employee).ignore_valid_datetime.count } }


### PR DESCRIPTION
Hi! Thank you for the great gem!

I found that `ActiveRecord::Bitemporal::Relation::Finder#find` method was different in some points from `ActiveRecord::FinderMethods#find` .

a. If `ActiveRecord::RecordNotFound` error is raised, `ActiveRecord::Bitemporal::Relation::Finder#find` error object doesn't have model name, but `ActiveRecord::FinderMethods#find` error object has model name.
b. If model instances are passed as arguments, `ActiveRecord::Bitemporal::Relation::Finder#find` can find object, but `ActiveRecord::FinderMethods#find` raise error.

The following is the content that I confirmed
```
# check bitemporal
[1] pry(main)> Address.include?(ActiveRecord::Bitemporal)
=> true
[2] pry(main)> User.include?(ActiveRecord::Bitemporal)
=> false

# a. 
[3] pry(main)> begin; Address.find(''); rescue => e; error = e; end; p error.model
nil
=> nil
[4] pry(main)> begin; User.find(''); rescue => e; error = e; end; p error.model
"User"
=> "User"

[5] pry(main)> Address.find(Address.first)
=> #<Address:0x00007fb068c6d2a0
[6] pry(main)> User.find(User.first)
ArgumentError: You are passing an instance of ActiveRecord::Base to `find`. Please pass the id of the object by calling `.id`.
```

The current `ActiveRecord::Bitemporal::Relation::Finder#find` is fully useful, but it might be more useful, if that differences are modified.

In this pull request, that two differences are fixed.

Hope that makes sense!