### PR TITLE
Use correct precision.

### DIFF
--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -535,6 +535,24 @@ RSpec.describe ActiveRecord::Bitemporal do
         it { is_expected.to be_falsey }
       end
     end
+
+    describe 'attributes' do
+      before do
+        model_class.table_name = 'families'
+      end
+
+      it 'truncates time on assignment' do
+        time = Time.new(2000, 1, 1, 0, 0, 0).change(nsec: 12345)
+
+        instance = model_class.new(
+          valid_from: time,
+          valid_to: time
+        )
+
+        expect(instance.valid_from.nsec).to eq(0)
+        expect(instance.valid_to.nsec).to eq(0)
+      end
+    end
   end
 
   describe "#reload" do

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -752,7 +752,7 @@ RSpec.describe ActiveRecord::Bitemporal do
         let(:time_current) { employee.updated_at + 10.days }
         let(:valid_at) { employee.updated_at + 5.days }
         let(:employee_deleted_at) {
-          Employee.ignore_valid_datetime.within_deleted.find(employee.id).deleted_at
+          Employee.ignore_valid_datetime.within_deleted.where.not(deleted_at: nil).find(employee.id).deleted_at
         }
         subject { employee_deleted_at }
         before do
@@ -810,7 +810,7 @@ RSpec.describe ActiveRecord::Bitemporal do
       let(:time_current) { employee.updated_at + 10.days }
       let(:valid_at) { employee.updated_at + 5.days }
       let(:employee_deleted_at) {
-        Employee.ignore_valid_datetime.within_deleted.find(employee.id).deleted_at
+        Employee.ignore_valid_datetime.within_deleted.where.not(deleted_at: nil).find(employee.id).deleted_at
       }
       subject { employee_deleted_at }
       before do

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -63,6 +63,17 @@ ActiveRecord::Schema.define(version: 1) do
 
     t.timestamps
   end
+
+  create_table :families, force: true do |t|
+    t.string :name
+
+    t.integer :bitemporal_id
+    t.datetime :valid_from, precision: 0
+    t.datetime :valid_to, precision: 0
+    t.datetime :deleted_at
+
+    t.timestamps
+  end
 end
 
 class Company < ActiveRecord::Base


### PR DESCRIPTION
Thank you for the great gem :)

`ActiveRecord::Attributes.attribute` overrides the type of existing attributes. It isn't considered an expected behavior because database's subsecond precision is ignored by type caster.
In default mysql, datetime should be rounded nsec because the default precision is 0.

```ruby
Employee.column_for_attribute(:valid_from).precision #=> 0

ActiveRecord::Bitemporal.valid_at(time) do
  employee = Employee.create!(...)
  employee.valid_from.nsec #=> 481148000. expected 0.
  employee.reload
  employee.valid_from.nsec #=> 0
end
```

Redefine the type in load_schema to use the correct precision dynamically fetched from the database.