### PR TITLE
retry - Testing with multiple ruby versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   ruby_2_5:
     docker:
-      - image: ruby:2.5.3
+      - image: ruby:2.5.8
       - image: circleci/postgres:11-alpine
 
   ruby_2_6:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,43 +1,35 @@
-version: 2
+version: 2.1
+
+executors:
+  ruby_2_5:
+    docker:
+      - image: ruby:2.5.3
+      - image: circleci/postgres:11-alpine
 
 jobs:
-  rails-5.2:
-    docker:
-      - image: ruby:2.5.3
-      - image: circleci/postgres:11-alpine
+  run_rspec:
+    executor: ruby_2_5
+    parameters:
+      gemfile:
+        type: string
     steps:
       - checkout
+      - run: gem install bundler
       - run: bundle install
-      - run: bundle exec appraisal rails-5.2 bundle install
-      - run: bundle exec appraisal rails-5.2 rake
-
-  rails-master:
-    docker:
-      - image: ruby:2.5.3
-      - image: circleci/postgres:11-alpine
-    steps:
-      - checkout
-      - run: bundle install
-      - run: bundle exec appraisal rails-master bundle install
-      - run: bundle exec appraisal rails-master rake
-
-  rails-6.0:
-    docker:
-      - image: ruby:2.5.3
-      - image: circleci/postgres:11-alpine
-    steps:
-      - checkout
-      - run: bundle install
-      - run: bundle exec appraisal rails-6.0 bundle install
-      - run: bundle exec appraisal rails-6.0 rake
+      - run: bundle exec appraisal << parameters.gemfile >> bundle install
+      - run: bundle exec appraisal << parameters.gemfile >> rspec
 
 workflows:
   version: 2
+
   test:
-    jobs:
-      - rails-5.2
-      - rails-6.0
-      - rails-master
+    jobs: &jobs
+      - run_rspec:
+          gemfile: rails-5.2
+      - run_rspec:
+          gemfile: rails-6.0
+      - run_rspec:
+          gemfile: rails-master
 
   daily_test:
     triggers:
@@ -47,7 +39,4 @@ workflows:
             branches:
               only:
                 - master
-    jobs:
-      - rails-5.2
-      - rails-6.0
-      - rails-master
+    jobs: *jobs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,18 @@ executors:
       - image: ruby:2.5.3
       - image: circleci/postgres:11-alpine
 
-jobs:
+  ruby_2_6:
+    docker:
+      - image: ruby:2.6.6
+      - image: circleci/postgres:11-alpine
+
+  ruby_2_7:
+    docker:
+      - image: ruby:2.7.1
+      - image: circleci/postgres:11-alpine
+
+commands:
   run_rspec:
-    executor: ruby_2_5
     parameters:
       gemfile:
         type: string
@@ -19,17 +28,75 @@ jobs:
       - run: bundle exec appraisal << parameters.gemfile >> bundle install
       - run: bundle exec appraisal << parameters.gemfile >> rspec
 
+jobs:
+  ruby_2_5_rails_5_2:
+    executor: ruby_2_5
+    steps:
+      - run_rspec:
+          gemfile: rails-5.2
+
+  ruby_2_5_rails_6_0:
+    executor: ruby_2_5
+    steps:
+      - run_rspec:
+          gemfile: rails-6.0
+
+  ruby_2_5_rails_master:
+    executor: ruby_2_5
+    steps:
+      - run_rspec:
+          gemfile: rails-master
+
+  ruby_2_6_rails_5_2:
+    executor: ruby_2_6
+    steps:
+      - run_rspec:
+          gemfile: rails-5.2
+
+  ruby_2_6_rails_6_0:
+    executor: ruby_2_6
+    steps:
+      - run_rspec:
+          gemfile: rails-6.0
+
+  ruby_2_6_rails_master:
+    executor: ruby_2_6
+    steps:
+      - run_rspec:
+          gemfile: rails-master
+
+  ruby_2_7_rails_5_2:
+    executor: ruby_2_7
+    steps:
+      - run_rspec:
+          gemfile: rails-5.2
+
+  ruby_2_7_rails_6_0:
+    executor: ruby_2_7
+    steps:
+      - run_rspec:
+          gemfile: rails-6.0
+
+  ruby_2_7_rails_master:
+    executor: ruby_2_7
+    steps:
+      - run_rspec:
+          gemfile: rails-master
+
 workflows:
   version: 2
 
   test:
     jobs: &jobs
-      - run_rspec:
-          gemfile: rails-5.2
-      - run_rspec:
-          gemfile: rails-6.0
-      - run_rspec:
-          gemfile: rails-master
+      - ruby_2_5_rails_5_2
+      - ruby_2_5_rails_6_0
+      - ruby_2_5_rails_master
+      - ruby_2_6_rails_5_2
+      - ruby_2_6_rails_6_0
+      - ruby_2_6_rails_master
+      - ruby_2_7_rails_5_2
+      - ruby_2_7_rails_6_0
+      - ruby_2_7_rails_master
 
   daily_test:
     triggers:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord-bitemporal!
   appraisal
-  bundler (~> 1.16)
+  bundler
   database_cleaner
   pg
   pry
@@ -75,4 +75,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   1.17.0
+   2.1.4

--- a/activerecord-bitemporal.gemspec
+++ b/activerecord-bitemporal.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activerecord", ">= 5.2"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pg"


### PR DESCRIPTION
Build CI to run tests, each with a different version of ruby and rails :)
Supported versions are followings.

- Ruby: `2.5, 2.6, 2.7`
- Rails: `5.2, 6.0, master`

Other changes.

- Remove version lock of bundler for v2.0

---

continuation from https://github.com/kufu/activerecord-bitemporal/pull/58#issuecomment-657381785