### PR TITLE
Make all generated queries boundable

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -253,7 +253,7 @@ module ActiveRecord
             .tap { |relation| break relation.where_bind("valid_to", :lteq, to.in_time_zone.to_datetime) if to }
         }
         scope :where_bind, -> (attr_name, operator, value) {
-          where(arel_attribute(attr_name).public_send(operator, predicate_builder.build_bind_attribute(attr_name, value)))
+          where(table[attr_name].public_send(operator, predicate_builder.build_bind_attribute(attr_name, value)))
         }
       end
 

--- a/spec/activerecord-bitemporal/relation_spec.rb
+++ b/spec/activerecord-bitemporal/relation_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe "Relation" do
     it { is_expected.to have_attributes count: 5 }
     it do
       Timecop.freeze(Time.utc(2018, 12, 25).in_time_zone) {
-        expect(subject.to_sql).to match /"employees"."valid_from" <= '2018-12-25 00:00:00' AND "employees"."valid_to" > '2018-12-25 00:00:00'/
+        expect(subject.to_sql).to match %r/"employees"."valid_from" <= '2018-12-25 00:00:00' AND "employees"."valid_to" > '2018-12-25 00:00:00'/
+        expect(subject.arel.to_sql).to match %r/"employees"."valid_from" <= \$1 AND "employees"."valid_to" > \$2/
       }
     end
 
@@ -77,7 +78,8 @@ RSpec.describe "Relation" do
     it { is_expected.to have_attributes count: 2 }
     it do
       Timecop.freeze(Time.utc(2018, 12, 25).in_time_zone) {
-        expect(subject.to_sql).to match /"employees"."valid_from" <= '2018-12-25 00:00:00' AND "employees"."valid_to" > '2018-12-25 00:00:00'/
+        expect(subject.to_sql).to match %r/"employees"."valid_from" <= '2018-12-25 00:00:00' AND "employees"."valid_to" > '2018-12-25 00:00:00'/
+        expect(subject.arel.to_sql).to match %r/"employees"."valid_from" <= \$1 AND "employees"."valid_to" > \$2/
       }
     end
 
@@ -149,7 +151,7 @@ RSpec.describe "Relation" do
 
   describe ".ignore_valid_datetime" do
     subject { Company.ignore_valid_datetime.to_sql }
-    it { is_expected.to match /"companies"."deleted_at" IS NULL/ }
+    it { is_expected.to match %r/"companies"."deleted_at" IS NULL/ }
   end
 
   describe "preload" do

--- a/spec/activerecord-bitemporal/scopes_spec.rb
+++ b/spec/activerecord-bitemporal/scopes_spec.rb
@@ -84,8 +84,16 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
       let(:from) { "2019/1/20" }
       let(:to) { "2019/1/30" }
       subject { Employee.valid_in(from: from, to: to).to_sql }
-      it { is_expected.to match /"employees"."valid_to" >= '2019-01-19 15:00:00'/ }
-      it { is_expected.to match /"employees"."valid_from" <= '2019-01-29 15:00:00'/ }
+      it { is_expected.to match %r/"employees"."valid_to" >= '2019-01-19 15:00:00'/ }
+      it { is_expected.to match %r/"employees"."valid_from" <= '2019-01-29 15:00:00'/ }
+    end
+
+    describe ".arel.to_sql" do
+      let(:from) { "2019/1/20" }
+      let(:to) { "2019/1/30" }
+      subject { Employee.valid_in(from: from, to: to).arel.to_sql }
+      it { is_expected.to match %r/"employees"."valid_to" >= \$1/ }
+      it { is_expected.to match %r/"employees"."valid_from" <= \$2/ }
     end
   end
 
@@ -150,8 +158,16 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
       let(:from) { "2019/1/20" }
       let(:to) { "2019/1/30" }
       subject { Employee.valid_allin(from: from, to: to).to_sql }
-      it { is_expected.to match /"employees"."valid_from" >= '2019-01-19 15:00:00'/ }
-      it { is_expected.to match /"employees"."valid_to" <= '2019-01-29 15:00:00'/ }
+      it { is_expected.to match %r/"employees"."valid_from" >= '2019-01-19 15:00:00'/ }
+      it { is_expected.to match %r/"employees"."valid_to" <= '2019-01-29 15:00:00'/ }
+    end
+
+    describe ".arel.to_sql" do
+      let(:from) { "2019/1/20" }
+      let(:to) { "2019/1/30" }
+      subject { Employee.valid_allin(from: from, to: to).arel.to_sql }
+      it { is_expected.to match %r/"employees"."valid_from" >= \$1/ }
+      it { is_expected.to match %r/"employees"."valid_to" <= \$2/ }
     end
   end
 

--- a/spec/activerecord-bitemporal/through_spec.rb
+++ b/spec/activerecord-bitemporal/through_spec.rb
@@ -184,14 +184,14 @@ RSpec.describe "has_xxx with through" do
 
     describe "default scope" do
       let(:relation) { blog.users }
-      it { is_expected.to match /articles"."valid_from" <= '2018-12-31 15:00:00' AND "articles"."valid_to" > '2018-12-31 15:00:00'/ }
-      it { is_expected.to match /"users"."valid_from" <= '2018-12-31 15:00:00' AND "users"."valid_to" > '2018-12-31 15:00:00'/ }
+      it { is_expected.to match %r/articles"."valid_from" <= '2018-12-31 15:00:00' AND "articles"."valid_to" > '2018-12-31 15:00:00'/ }
+      it { is_expected.to match %r/"users"."valid_from" <= '2018-12-31 15:00:00' AND "users"."valid_to" > '2018-12-31 15:00:00'/ }
     end
 
     context "with valid_at" do
       let(:relation) { blog.users.valid_at("2019/2/2") }
-      it { is_expected.to match /articles"."valid_from" <= '2019-02-01 15:00:00' AND "articles"."valid_to" > '2019-02-01 15:00:00'/ }
-      it { is_expected.to match /"users"."valid_from" <= '2019-02-01 15:00:00' AND "users"."valid_to" > '2019-02-01 15:00:00'/ }
+      it { is_expected.to match %r/articles"."valid_from" <= '2019-02-01 15:00:00' AND "articles"."valid_to" > '2019-02-01 15:00:00'/ }
+      it { is_expected.to match %r/"users"."valid_from" <= '2019-02-01 15:00:00' AND "users"."valid_to" > '2019-02-01 15:00:00'/ }
     end
 
     context "with ignore_valid_datetime" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ Bundler.require(:default, :development)
 
 dbconfig = YAML::load(IO.read(File.join(File.dirname(__FILE__), "database.yml")))["test"]
 ActiveRecord::Base.establish_connection(dbconfig.merge(database: 'postgres'))
+# ActiveRecord::Base.logger = Logger.new(STDOUT)
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,6 @@ Bundler.require(:default, :development)
 
 dbconfig = YAML::load(IO.read(File.join(File.dirname(__FILE__), "database.yml")))["test"]
 ActiveRecord::Base.establish_connection(dbconfig.merge(database: 'postgres'))
-# ActiveRecord::Base.logger = Logger.new(STDOUT)
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
If `prepared_statements: true` (it is by default for postgresql and
sqlite3 adapters), generated queries will be used as a cache key for
statement handle cache.

https://github.com/rails/rails/blob/b6081f36347f563fa6eec4b4edd15bf4f76ddea4/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L732-L742

Unless making generated queries boundable, statement handle cache will
not be useful (the cache hit rate will be reduced).

This makes all generated queries in this gem boundable.

Before:

```sql
SELECT "employees"."name" FROM "employees" WHERE "employees"."deleted_at" IS NULL AND "employees"."valid_to" >= '2019-01-05 00:00:00' AND "employees"."valid_from" <= '2019-01-25 00:00:00'
```

After:

```sql
SELECT "employees"."name" FROM "employees" WHERE "employees"."deleted_at" IS NULL AND "employees"."valid_to" >= $1 AND "employees"."valid_from" <= $2  [["valid_to", "2019-01-05 00:00:00"], ["valid_from", "2019-01-25 00:00:00"]]
```