### PR TITLE
Add error info when updated.

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -445,14 +445,14 @@ module ActiveRecord
 
             # 以前の履歴データは valid_to を詰めて保存
             before_instance.valid_to = target_datetime
-            raise ActiveRecord::Rollback if before_instance.valid_from_cannot_be_greater_equal_than_valid_to
+            raise ActiveRecord::RecordInvalid.new(before_instance) if before_instance.valid_from_cannot_be_greater_equal_than_valid_to
             before_instance.transaction_from = current_time
             before_instance.save!(validate: false)
 
             # 以降の履歴データは valid_from と valid_to を調整して保存する
             after_instance.valid_from = target_datetime
             after_instance.valid_to = current_valid_record.valid_to
-            raise ActiveRecord::Rollback if after_instance.valid_from_cannot_be_greater_equal_than_valid_to
+            raise ActiveRecord::RecordInvalid.new(after_instance) if after_instance.valid_from_cannot_be_greater_equal_than_valid_to
             after_instance.transaction_from = current_time
             after_instance.save!(validate: false)
 
@@ -460,6 +460,10 @@ module ActiveRecord
           else
             # 一番近い未来にある Instance を取ってきて、その valid_from を valid_to に入れる
             nearest_instance = self.class.where(bitemporal_id: bitemporal_id).bitemporal_where_bind("valid_from", :gt, target_datetime).ignore_valid_datetime.order(valid_from: :asc).first
+            if nearest_instance.nil?
+              message = "Update failed: Couldn't find #{self.class} with 'bitemporal_id'=#{self.bitemporal_id} and 'valid_from' is greater than #{target_datetime}"
+              raise ActiveRecord::RecordNotFound.new(message, self.class, "bitemporal_id", self.bitemporal_id)
+            end
 
             # valid_from と valid_to を調整して保存する
             after_instance.valid_from = target_datetime

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -461,7 +461,7 @@ module ActiveRecord
             # 一番近い未来にある Instance を取ってきて、その valid_from を valid_to に入れる
             nearest_instance = self.class.where(bitemporal_id: bitemporal_id).bitemporal_where_bind("valid_from", :gt, target_datetime).ignore_valid_datetime.order(valid_from: :asc).first
             if nearest_instance.nil?
-              message = "Update failed: Couldn't find #{self.class} with 'bitemporal_id'=#{self.bitemporal_id} and 'valid_from' is greater than #{target_datetime}"
+              message = "Update failed: Couldn't find #{self.class} with 'bitemporal_id'=#{self.bitemporal_id} and 'valid_from' < #{target_datetime}"
               raise ActiveRecord::RecordNotFound.new(message, self.class, "bitemporal_id", self.bitemporal_id)
             end
 

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -811,7 +811,7 @@ RSpec.describe ActiveRecord::Bitemporal do
         before { company.destroy }
         it { is_expected.to raise_error(ActiveRecord::RecordNotFound) }
         it { is_expected.to raise_error { |e|
-          expect(e.message).to eq "Update failed: Couldn't find Company with 'bitemporal_id'=#{company.bitemporal_id} and 'valid_from' is greater than #{datetime}"
+          expect(e.message).to eq "Update failed: Couldn't find Company with 'bitemporal_id'=#{company.bitemporal_id} and 'valid_from' < #{datetime}"
         } }
       end
     end


### PR DESCRIPTION
Add error info when updated.

## Before

```ruby
company = Company.create(name: "Company", valid_from: "2020/01/01")
ActiveRecord::Bitemporal.valid_at("2020/01/01") do
  p company.update!(name: "Company2")
rescue => e
  pp e
  # => #<ActiveRecord::RecordNotSaved: Failed to save the record>
end
```

```ruby
company = Company.create(name: "Company", valid_from: "2020/01/01", valid_to: "2020/04/01")
begin
  company.update!(name: "Company2")
rescue => e
  pp e
  # => #<NoMethodError: undefined method `valid_from' for nil:NilClass>
end
```


## After

```ruby
company = Company.create(name: "Company", valid_from: "2020/01/01")
ActiveRecord::Bitemporal.valid_at("2020/01/01") do
  p company.update!(name: "Company2")
rescue => e
  pp e
  # => #<ActiveRecord::RecordInvalid: Validation failed: Valid from can't be greater equal than valid_to>
end
```
```ruby
company = Company.create(name: "Company", valid_from: "2020/01/01", valid_to: "2020/04/01")
begin
  company.update!(name: "Company2")
rescue => e
  pp e
  # => #<ActiveRecord::RecordNotFound: Update failed: Couldn't find Company with 'bitemporal_id'=1 and 'valid_from' is greater than 2020-11-05 01:21:56 UTC>
end
```