### PR TITLE
Use the latest version of Ruby 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
 
   ruby_2_7:
     docker:
-      - image: ruby:2.7.1
+      - image: ruby:2.7.2
       - image: circleci/postgres:11-alpine
 
 commands:


### PR DESCRIPTION
# Why?
It aims to maintain the CI environments.

# Changes
- User Ruby `2.7.2`

# Ref.
- https://www.ruby-lang.org/en/news/2020/10/02/ruby-2-7-2-released/