### PR TITLE
Add CI for ruby3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,11 @@ executors:
       - image: ruby:2.7.2
       - image: circleci/postgres:11-alpine
 
+  ruby_3_0:
+    docker:
+      - image: ruby:3.0.0
+      - image: circleci/postgres:11-alpine
+
 commands:
   run_rspec:
     parameters:
@@ -101,6 +106,18 @@ jobs:
       - run_rspec:
           gemfile: rails-main
 
+  ruby_3_0_rails_6_1:
+    executor: ruby_3_0
+    steps:
+      - run_rspec:
+          gemfile: rails-6.1
+
+  ruby_3_0_rails_main:
+    executor: ruby_3_0
+    steps:
+      - run_rspec:
+          gemfile: rails-main
+
 workflows:
   version: 2
 
@@ -118,6 +135,8 @@ workflows:
       - ruby_2_7_rails_6_0
       - ruby_2_7_rails_6_1
       - ruby_2_7_rails_main
+      - ruby_3_0_rails_6_1
+      - ruby_3_0_rails_main
 
   daily_test:
     triggers:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     method_source (0.9.0)
-    minitest (5.14.1)
+    minitest (5.14.3)
     pg (1.1.3)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -75,4 +75,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -327,7 +327,7 @@ module ActiveRecord
           end
         end
 
-        refine Object do
+        refine ActiveRecord::Base do
           # MEMO: Do not copy `swapped_id`
           def dup(*)
             super.tap { |itself|


### PR DESCRIPTION
Add ruby 3.0 support 🎉 

- NOTE: Ruby 3.0 works fine on only `>= 6.1.0`
- Update minitest because old version doesn't support ruby3.0
- Change refinements for `#dup` method

### why I changed refinements for `#dup` 

In the case of using ruby3.0 & rails6.1.0, when you call `ActiveRecord::Base.establish_connection`, the process will freeze and stop working. I investigated this issue, I found that refinements for `#dup` causes this problem. 
I think that Ruby is not tested well enough for refinements because the override `#dup` with refinements is not recommended way.

related: https://bugs.ruby-lang.org/issues/17494