### PR TITLE
Fixed a bug that prevented rollback on destroy.

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -434,7 +434,7 @@ module ActiveRecord
 
         duplicated_instance = self.class.find_at_time(target_datetime, self.id).dup
 
-        ActiveRecord::Base.transaction(requires_new: true) do
+        ActiveRecord::Base.transaction(requires_new: true, joinable: false) do
           @destroyed = false
           _run_destroy_callbacks {
             @destroyed = update_transaction_to(current_time)

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -1013,6 +1013,15 @@ RSpec.describe ActiveRecord::Bitemporal do
         before { allow_any_instance_of(Employee).to receive('save!').and_raise(ActiveRecord::RecordNotSaved) }
 
         it_behaves_like "return false and #destroyed? to be false"
+
+        context "with transaction" do
+          subject { -> {
+            ActiveRecord::Base.transaction {
+              Timecop.freeze(destroyed_time) { employee.destroy }
+            }
+          } }
+          it_behaves_like "return false and #destroyed? to be false"
+        end
       end
 
       context "at `before_destroy`" do
@@ -1035,6 +1044,12 @@ RSpec.describe ActiveRecord::Bitemporal do
 
           it_behaves_like "return false and #destroyed? to be false"
         end
+      end
+
+      context "`destroyed_time` is earlier than `created_time`" do
+        let(:destroyed_time) { created_time - 10.second }
+        subject { -> { ActiveRecord::Bitemporal.valid_at(destroyed_time) { employee.destroy } } }
+        it_behaves_like "return false and #destroyed? to be false"
       end
     end
 


### PR DESCRIPTION
bug in nested `transaction` that prevents rollback if the `destroy` fails.

```ruby
company = Company.create(name: "Hoge")

ActiveRecord::Base.transaction do
  # NOTE: If specify a time earlier than the generation time, the deletion will fail.
  ActiveRecord::Bitemporal.valid_at("2021/01/01") {
    pp company.destroy
    # => false
  }
end

# I want it to be rollback, but it's not.
pp Company.ignore_valid_datetime.count
# Expected => 1
# Actual   => 0

pp Company.ignore_valid_datetime.within_deleted.find(company.id).deleted_at
# Expected => nil
# Actual   => 2021-03-17 01:32:29.613348 UTC
```

I fixed it.