### PR TITLE
Improve exception when raised an error on destroy

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -448,8 +448,9 @@ module ActiveRecord
 
           self
         end
-      rescue
+      rescue => e
         @destroyed = false
+        @_association_destroy_exception = ActiveRecord::RecordNotDestroyed.new("Failed to destroy the record: class=#{e.class}, message=#{e.message}", self)
         false
       end
 

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -1051,6 +1051,14 @@ RSpec.describe ActiveRecord::Bitemporal do
         subject { -> { ActiveRecord::Bitemporal.valid_at(destroyed_time) { employee.destroy } } }
         it_behaves_like "return false and #destroyed? to be false"
       end
+
+      context "with `destory!`" do
+        subject { -> { Timecop.freeze(destroyed_time) { employee.destroy! } } }
+
+        before { allow_any_instance_of(Employee).to receive('save!').and_raise(ActiveRecord::RecordNotSaved.new("failed")) }
+
+        it { is_expected.to raise_error(ActiveRecord::RecordNotDestroyed, "Failed to destroy the record: class=ActiveRecord::RecordNotSaved, message=failed") }
+      end
     end
 
     context "with callback" do


### PR DESCRIPTION
`ActiveRecord::Bitemporal::Persistence#destroy` always returns whether the deletion succeeded instead of raising an exception to follow the design of the original class. However, since deletion means multiple operations in the bitemporal-gem, you may encounter more errors.

This PR makes it uses [Active Record's own exception propagation mechanism, `@_association_destroy_exception`](https://github.com/rails/rails/blob/v6.1.3.2/activerecord/lib/active_record/persistence.rb#L947-L952), to allow the error that occurred in destroy to be propagated to the caller:

```ruby
# before
model.destroy! # => ActiveRecord::RecordNotDestroyed, Failed to destroy the record

# after
model.destroy! # => ActiveRecord::RecordNotDestroyed, Failed to destroy the record: class=Foo, message=bar
```

Originally, this mechanism is used when an error occurs in callbacks:
https://github.com/rails/rails/blob/v6.1.3.2/activerecord/lib/active_record/callbacks.rb#L435-L445