### PR TITLE
Drop ruby 2.5 and update ruby versions in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,17 +3,17 @@ version: 2.1
 executors:
   ruby_2_6:
     docker:
-      - image: ruby:2.6.6
+      - image: ruby:2.6.7
       - image: circleci/postgres:11-alpine
 
   ruby_2_7:
     docker:
-      - image: ruby:2.7.2
+      - image: ruby:2.7.3
       - image: circleci/postgres:11-alpine
 
   ruby_3_0:
     docker:
-      - image: ruby:3.0.0
+      - image: ruby:3.0.1
       - image: circleci/postgres:11-alpine
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,6 @@
 version: 2.1
 
 executors:
-  ruby_2_5:
-    docker:
-      - image: ruby:2.5.8
-      - image: circleci/postgres:11-alpine
-
   ruby_2_6:
     docker:
       - image: ruby:2.6.6
@@ -34,24 +29,6 @@ commands:
       - run: bundle exec appraisal << parameters.gemfile >> rspec
 
 jobs:
-  ruby_2_5_rails_5_2:
-    executor: ruby_2_5
-    steps:
-      - run_rspec:
-          gemfile: rails-5.2
-
-  ruby_2_5_rails_6_0:
-    executor: ruby_2_5
-    steps:
-      - run_rspec:
-          gemfile: rails-6.0
-
-  ruby_2_5_rails_6_1:
-    executor: ruby_2_5
-    steps:
-      - run_rspec:
-          gemfile: rails-6.1
-
   ruby_2_6_rails_5_2:
     executor: ruby_2_6
     steps:
@@ -111,9 +88,6 @@ workflows:
 
   test:
     jobs: &jobs
-      - ruby_2_5_rails_5_2
-      - ruby_2_5_rails_6_0
-      - ruby_2_5_rails_6_1
       - ruby_2_6_rails_5_2
       - ruby_2_6_rails_6_0
       - ruby_2_6_rails_6_1


### PR DESCRIPTION
Drop ruby 2.5 in CI becuase ruby 2.5 is EOL.
And update ruby versions.