### PR TITLE
Add transaction_at support methods.

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -144,7 +144,6 @@ module ActiveRecord
 
       def load
         return super if loaded?
-        valid_datetime_ = valid_datetime
 
         # このタイミングで先読みしているアソシエーションが読み込まれるので時間を固定
         records = ActiveRecord::Bitemporal.with_bitemporal_option(**bitemporal_option) { super }

--- a/lib/activerecord-bitemporal/patches.rb
+++ b/lib/activerecord-bitemporal/patches.rb
@@ -57,12 +57,21 @@ module ActiveRecord::Bitemporal
         scope = super
         return scope unless scope.bi_temporal_model?
 
-        if owner.class&.bi_temporal_model? && owner.valid_datetime
-          valid_datetime = owner.valid_datetime
-          scope = scope.valid_at(valid_datetime)
-          scope.merge!(scope.bitemporal_value[:through].valid_at(valid_datetime)) if scope.bitemporal_value[:through]
+        scope_ = scope
+        if owner.class&.bi_temporal_model?
+          if owner.valid_datetime
+            valid_datetime = owner.valid_datetime
+            scope_ = scope_.valid_at(valid_datetime)
+            scope_.merge!(scope_.bitemporal_value[:through].valid_at(valid_datetime)) if scope_.bitemporal_value[:through]
+          end
+
+          if owner.transaction_datetime
+            transaction_datetime = owner.transaction_datetime
+            scope_ = scope_.transaction_at(transaction_datetime)
+            scope_.merge!(scope_.bitemporal_value[:through].transaction_at(transaction_datetime)) if scope_.bitemporal_value[:through]
+          end
         end
-        return scope
+        return scope_
       end
 
       private

--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -88,7 +88,8 @@ module ActiveRecord::Bitemporal
             transaction_from: transaction_from,
             transaction_to: transaction_to,
             transaction_datetime: transaction_from == transaction_to ? transaction_from : nil,
-            ignore_valid_datetime: valid_from.nil? && valid_to.nil? ? true : false
+            ignore_valid_datetime: valid_from.nil? && valid_to.nil? ? true : false,
+            ignore_transaction_datetime: transaction_from.nil? && transaction_to.nil? ? true : false
           }
         end
       end
@@ -195,6 +196,14 @@ module ActiveRecord::Bitemporal
 
           def ignore_valid_datetime?
             bitemporal_option_storage[:ignore_valid_datetime]
+          end
+
+          def force_transaction_datetime?
+            bitemporal_option_storage[:force_transaction_datetime]
+          end
+
+          def ignore_transaction_datetime?
+            bitemporal_option_storage[:ignore_transaction_datetime]
           end
         end
       }
@@ -353,6 +362,9 @@ module ActiveRecord::Bitemporal
 
       # transaction_from <= datetime && datetime < transaction_to
       scope :transaction_at, -> (datetime) {
+        if ActiveRecord::Bitemporal.force_transaction_datetime?
+          datetime = ActiveRecord::Bitemporal.transaction_datetime
+        end
         datetime = Time.current if datetime.nil?
         transaction_from_lteq(datetime).transaction_to_gt(datetime).with_transaction_datetime
       }
@@ -360,7 +372,7 @@ module ActiveRecord::Bitemporal
         ignore_transaction_from.ignore_transaction_to.without_transaction_datetime
       }
       scope :except_transaction_datetime, -> {
-        except_transaction_from.except_transaction_to.without_transaction_datetime
+        except_transaction_from.except_transaction_to.tap { |relation| relation.bitemporal_value.except! :with_transaction_datetime }
       }
 
       scope :bitemporal_at, -> (datetime) {
@@ -382,19 +394,29 @@ module ActiveRecord::Bitemporal
         datetime = Time.current
         relation = self
 
-        # Calling scope was slow, so don't call scope
-        relation.unscope_values += [
-          { where: "#{table.name}.transaction_from" },
-          { where: "#{table.name}.transaction_to" }
-        ]
-        relation = relation
-          ._transaction_from_lteq(datetime, without_ignore: true)
-          ._transaction_to_gt(datetime, without_ignore: true)
-          .without_transaction_datetime
+        if !ActiveRecord::Bitemporal.ignore_transaction_datetime?
+          if ActiveRecord::Bitemporal.transaction_datetime
+            transaction_datetime = ActiveRecord::Bitemporal.transaction_datetime
+            relation.bitemporal_value[:with_transaction_datetime] = :default_scope_with_transaction_datetime
+          else
+            relation.bitemporal_value[:with_transaction_datetime] = :default_scope
+          end
+
+          # Calling scope was slow, so don't call scope
+          relation.unscope_values += [
+            { where: "#{table.name}.transaction_from" },
+            { where: "#{table.name}.transaction_to" }
+          ]
+          relation = relation
+            ._transaction_from_lteq(transaction_datetime || datetime, without_ignore: true)
+            ._transaction_to_gt(transaction_datetime || datetime, without_ignore: true)
+        else
+          relation.tap { |relation| relation.without_transaction_datetime unless ActiveRecord::Bitemporal.transaction_datetime }
+        end
 
         if !ActiveRecord::Bitemporal.ignore_valid_datetime?
           if ActiveRecord::Bitemporal.valid_datetime
-            datetime = ActiveRecord::Bitemporal.valid_datetime
+            valid_datetime = ActiveRecord::Bitemporal.valid_datetime
             relation.bitemporal_value[:with_valid_datetime] = :default_scope_with_valid_datetime
           else
             relation.bitemporal_value[:with_valid_datetime] = :default_scope
@@ -405,8 +427,8 @@ module ActiveRecord::Bitemporal
             { where: "#{table.name}.valid_to" }
           ]
           relation = relation
-            ._valid_from_lteq(datetime, without_ignore: true)
-            ._valid_to_gt(datetime, without_ignore: true)
+            ._valid_from_lteq(valid_datetime || datetime, without_ignore: true)
+            ._valid_to_gt(valid_datetime || datetime, without_ignore: true)
         else
           relation.tap { |relation| relation.without_valid_datetime unless ActiveRecord::Bitemporal.valid_datetime }
         end
@@ -417,7 +439,7 @@ module ActiveRecord::Bitemporal
       scope :except_bitemporal_default_scope, -> {
         scope = all
         scope = scope.except_valid_datetime if bitemporal_value[:with_valid_datetime] == :default_scope || bitemporal_value[:with_valid_datetime] == :default_scope_with_valid_datetime
-        scope = scope.except_transaction_datetime unless bitemporal_value[:with_transaction_datetime]
+        scope = scope.except_transaction_datetime if bitemporal_value[:with_transaction_datetime] == :default_scope || bitemporal_value[:with_transaction_datetime] == :default_scope_with_transaction_datetime
         scope
       }
 

--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -377,11 +377,17 @@ module ActiveRecord::Bitemporal
 
       scope :bitemporal_at, -> (datetime) {
         datetime = Time.current if datetime.nil?
-        if ActiveRecord::Bitemporal.ignore_valid_datetime?
-          transaction_at(datetime)
-        else
-          transaction_at(datetime).valid_at(ActiveRecord::Bitemporal.valid_datetime || datetime)
+        relation = self
+
+        if !ActiveRecord::Bitemporal.ignore_transaction_datetime?
+          relation = relation.transaction_at(ActiveRecord::Bitemporal.transaction_datetime || datetime)
         end
+
+        if !ActiveRecord::Bitemporal.ignore_valid_datetime?
+          relation = relation.valid_at(ActiveRecord::Bitemporal.valid_datetime || datetime)
+        end
+
+        relation
       }
       scope :ignore_bitemporal_datetime, -> {
         ignore_transaction_datetime.ignore_valid_datetime

--- a/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
@@ -739,7 +739,10 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         it { is_expected.to have_bitemporal_at(time_current, table: "users") }
 
         context "with .valid_at" do
-          it { is_expected.to have_bitemporal_at(time_current, table: "users") }
+          let(:user_valid_datetime) { "2016/01/05".in_time_zone }
+          let(:relation) { ActiveRecord::Bitemporal.valid_at!(valid_datetime) { User.valid_at(user_valid_datetime) } }
+          it { is_expected.to have_valid_at(time_current, table: "users") }
+          it { is_expected.to have_transaction_at(time_current, table: "users") }
         end
       end
 
@@ -826,7 +829,10 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         it { is_expected.to have_bitemporal_at(time_current, table: "users") }
 
         context "with .transaction_at" do
-          it { is_expected.to have_bitemporal_at(time_current, table: "users") }
+          let(:user_transaction_datetime) { "2016/01/05".in_time_zone }
+          let(:relation) { ActiveRecord::Bitemporal.transaction_at!(transaction_datetime) { User.transaction_at(user_transaction_datetime) } }
+          it { is_expected.to have_valid_at(time_current, table: "users") }
+          it { is_expected.to have_transaction_at(time_current, table: "users") }
         end
       end
 

--- a/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
@@ -722,7 +722,7 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
 
       describe "ActiveRecord::Bitemporal.valid_at!" do
         let(:valid_datetime2) { "2019/06/06".in_time_zone }
-        let(:relation) { ActiveRecord::Bitemporal.valid_at(valid_datetime) { ActiveRecord::Bitemporal.valid_at(valid_datetime2) { User.all } } }
+        let(:relation) { ActiveRecord::Bitemporal.valid_at(valid_datetime) { ActiveRecord::Bitemporal.valid_at!(valid_datetime2) { User.all } } }
         it { is_expected.to have_valid_at(valid_datetime2, table: "users") }
         it { is_expected.to have_transaction_at(time_current, table: "users") }
       end
@@ -809,7 +809,7 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
 
       describe "ActiveRecord::Bitemporal.transaction_at!" do
         let(:transaction_datetime2) { "2019/06/06".in_time_zone }
-        let(:relation) { ActiveRecord::Bitemporal.transaction_at(transaction_datetime) { ActiveRecord::Bitemporal.transaction_at(transaction_datetime2) { User.all } } }
+        let(:relation) { ActiveRecord::Bitemporal.transaction_at(transaction_datetime) { ActiveRecord::Bitemporal.transaction_at!(transaction_datetime2) { User.all } } }
         it { is_expected.to have_valid_at(time_current, table: "users") }
         it { is_expected.to have_transaction_at(transaction_datetime2, table: "users") }
       end

--- a/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
@@ -278,12 +278,12 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
       end
 
       describe ".ignore_bitemporal_datetime" do
-        let(:relation) { User.bitemporal_at("2019/01/01").ignore_bitemporal_datetime }
+        let(:relation) { User.bitemporal_at(bitemporal_datetime).ignore_bitemporal_datetime }
         it { is_expected.to not_have_transaction_at(table: "users") }
       end
 
       describe ".except_bitemporal_datetime" do
-        let(:relation) { User.bitemporal_at("2019/01/01").ignore_bitemporal_datetime }
+        let(:relation) { User.bitemporal_at(bitemporal_datetime).ignore_bitemporal_datetime }
         it { is_expected.to not_have_transaction_at(table: "users") }
       end
 
@@ -291,6 +291,32 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         let(:bitemporal_datetime) { "2019/01/01".in_time_zone }
         let(:relation) { User.bitemporal_at("2019/05/05").bitemporal_at(bitemporal_datetime) }
         it { is_expected.to have_bitemporal_at(bitemporal_datetime, table: "users") }
+      end
+
+      context "ActiveRecord::Bitemporal.valid_at" do
+        let(:valid_datetime) { "2017/04/01".in_time_zone }
+        let(:relation) { ActiveRecord::Bitemporal.valid_at(valid_datetime) { User.bitemporal_at(bitemporal_datetime) } }
+        it { is_expected.to have_valid_at(valid_datetime, table: "users") }
+        it { is_expected.to have_transaction_at(bitemporal_datetime, table: "users") }
+      end
+
+      context "ActiveRecord::Bitemporal.ignore_valid_datetime" do
+        let(:relation) { ActiveRecord::Bitemporal.ignore_valid_datetime { User.bitemporal_at(bitemporal_datetime) } }
+        it { is_expected.to not_have_valid_at(table: "users") }
+        it { is_expected.to have_transaction_at(bitemporal_datetime, table: "users") }
+      end
+
+      context "ActiveRecord::Bitemporal.transaction_at" do
+        let(:transaction_datetime) { "2017/04/01".in_time_zone }
+        let(:relation) { ActiveRecord::Bitemporal.transaction_at(transaction_datetime) { User.bitemporal_at(bitemporal_datetime) } }
+        it { is_expected.to have_valid_at(bitemporal_datetime, table: "users") }
+        it { is_expected.to have_transaction_at(transaction_datetime, table: "users") }
+      end
+
+      context "ActiveRecord::Bitemporal.ignore_transaction_datetime" do
+        let(:relation) { ActiveRecord::Bitemporal.ignore_transaction_datetime { User.bitemporal_at(bitemporal_datetime) } }
+        it { is_expected.to have_valid_at(bitemporal_datetime, table: "users") }
+        it { is_expected.to not_have_transaction_at(table: "users") }
       end
     end
 

--- a/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
@@ -744,7 +744,7 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
       end
 
       describe ".valid_at" do
-        let(:user_valid_datetime) { "2019/05/05".in_time_zone }
+        let(:user_valid_datetime) { "2016/01/05".in_time_zone }
         let(:relation) { ActiveRecord::Bitemporal.valid_at!(valid_datetime) { User.valid_at(user_valid_datetime) } }
         it { is_expected.to have_valid_at(valid_datetime, table: "users") }
         it { is_expected.to have_transaction_at(time_current, table: "users") }
@@ -831,7 +831,7 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
       end
 
       describe ".transaction_at" do
-        let(:user_transaction_datetime) { "2019/05/05".in_time_zone }
+        let(:user_transaction_datetime) { "2016/01/05".in_time_zone }
         let(:relation) { ActiveRecord::Bitemporal.transaction_at!(transaction_datetime) { User.transaction_at(user_transaction_datetime) } }
         it { is_expected.to have_valid_at(time_current, table: "users") }
         it { is_expected.to have_transaction_at(transaction_datetime, table: "users") }

--- a/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_scope_spec.rb
@@ -777,6 +777,93 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
       end
     end
 
+    describe "ActiveRecord::Bitemporal.transaction_at" do
+      let(:transaction_datetime) { "2019/05/05".in_time_zone }
+      let(:relation) { ActiveRecord::Bitemporal.transaction_at(transaction_datetime) { User.all } }
+      it { is_expected.to have_valid_at(time_current, table: "users") }
+      it { is_expected.to have_transaction_at(transaction_datetime, table: "users") }
+
+      context "transaction_datetime is nil" do
+        let(:transaction_datetime) { nil }
+        it { is_expected.to have_bitemporal_at(time_current, table: "users") }
+      end
+
+      describe ".transaction_at" do
+        let(:user_transaction_datetime) { "2019/05/05".in_time_zone }
+        let(:relation) { ActiveRecord::Bitemporal.transaction_at(transaction_datetime) { User.transaction_at(user_transaction_datetime) } }
+        it { is_expected.to have_valid_at(time_current, table: "users") }
+        it { is_expected.to have_transaction_at(user_transaction_datetime, table: "users") }
+      end
+
+      context "with ActiveRecord::Bitemporal.ignore_transaction_datetime" do
+        let(:relation) { ActiveRecord::Bitemporal.transaction_at(transaction_datetime) { ActiveRecord::Bitemporal.ignore_transaction_datetime { User.all } } }
+        it { is_expected.to have_valid_at(time_current, table: "users") }
+        it { is_expected.to not_have_transaction_at(table: "users") }
+      end
+
+      context ".ignore_transaction_datetime" do
+        let(:relation) { ActiveRecord::Bitemporal.transaction_at(transaction_datetime) { User.ignore_transaction_datetime } }
+        it { is_expected.to have_valid_at(time_current, table: "users") }
+        it { is_expected.to not_have_transaction_at(table: "users") }
+      end
+
+      describe "ActiveRecord::Bitemporal.transaction_at!" do
+        let(:transaction_datetime2) { "2019/06/06".in_time_zone }
+        let(:relation) { ActiveRecord::Bitemporal.transaction_at(transaction_datetime) { ActiveRecord::Bitemporal.transaction_at(transaction_datetime2) { User.all } } }
+        it { is_expected.to have_valid_at(time_current, table: "users") }
+        it { is_expected.to have_transaction_at(transaction_datetime2, table: "users") }
+      end
+    end
+
+    describe "ActiveRecord::Bitemporal.transaction_at!" do
+      let(:transaction_datetime) { "2019/05/05".in_time_zone }
+      let(:relation) { ActiveRecord::Bitemporal.transaction_at!(transaction_datetime) { User.all } }
+      it { is_expected.to have_valid_at(time_current, table: "users") }
+      it { is_expected.to have_transaction_at(transaction_datetime, table: "users") }
+
+      context "transaction_datetime is nil" do
+        let(:transaction_datetime) { nil }
+        it { is_expected.to have_bitemporal_at(time_current, table: "users") }
+
+        context "with .transaction_at" do
+          it { is_expected.to have_bitemporal_at(time_current, table: "users") }
+        end
+      end
+
+      describe ".transaction_at" do
+        let(:user_transaction_datetime) { "2019/05/05".in_time_zone }
+        let(:relation) { ActiveRecord::Bitemporal.transaction_at!(transaction_datetime) { User.transaction_at(user_transaction_datetime) } }
+        it { is_expected.to have_valid_at(time_current, table: "users") }
+        it { is_expected.to have_transaction_at(transaction_datetime, table: "users") }
+      end
+
+      context ".ignore_transaction_datetime" do
+        let(:relation) { ActiveRecord::Bitemporal.transaction_at!(transaction_datetime) { User.ignore_transaction_datetime } }
+        it { is_expected.to have_valid_at(time_current, table: "users") }
+        it { is_expected.to not_have_transaction_at(table: "users") }
+      end
+    end
+
+    describe "ActiveRecord::Bitemporal.ignore_transaction_datetime" do
+      let(:relation) { ActiveRecord::Bitemporal.ignore_transaction_datetime { User.all } }
+      it { is_expected.to have_valid_at(time_current, table: "users") }
+      it { is_expected.to not_have_transaction_at(table: "users") }
+
+      context "with ActiveRecord::Bitemporal.transaction_at" do
+        let(:transaction_datetime) { "2019/05/05".in_time_zone }
+        let(:relation) { ActiveRecord::Bitemporal.ignore_transaction_datetime { ActiveRecord::Bitemporal.transaction_at(transaction_datetime) { User.all } } }
+        it { is_expected.to have_valid_at(time_current, table: "users") }
+        it { is_expected.to have_transaction_at(transaction_datetime, table: "users") }
+      end
+
+      context "with .transaction_at" do
+        let(:transaction_datetime) { "2019/05/05".in_time_zone }
+        let(:relation) { ActiveRecord::Bitemporal.ignore_transaction_datetime { User.transaction_at(transaction_datetime) } }
+        it { is_expected.to have_valid_at(time_current, table: "users") }
+        it { is_expected.to have_transaction_at(transaction_datetime, table: "users") }
+      end
+    end
+
     describe ".unscoped" do
       let(:relation) { User.unscoped { User.all } }
       it { is_expected.not_to scan_once("valid_from") }
@@ -823,6 +910,29 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
           it { is_expected.to have_transaction_at(time_current, table: "blogs") }
           it { is_expected.to have_valid_at(valid_datetime, table: "articles") }
           it { is_expected.to have_transaction_at(time_current, table: "articles") }
+        end
+
+        context "with call to_sql in `ActiveRecord::Bitemporal.transaction_at`" do
+          let(:transaction_datetime) { "2019/01/01".in_time_zone }
+          let(:sql) { ActiveRecord::Bitemporal.transaction_at(transaction_datetime) { Blog.joins(:articles).to_sql } }
+          it { is_expected.to have_valid_at(time_current, table: "blogs") }
+          it { is_expected.to have_transaction_at(transaction_datetime, table: "blogs") }
+          it { is_expected.to have_valid_at(time_current, table: "articles") }
+          it { is_expected.to have_transaction_at(transaction_datetime, table: "articles") }
+        end
+
+        context "with call to_sql in `ActiveRecord::Bitemporal.valid_at` and `ActiveRecord::Bitemporal.transaction_at`" do
+          let(:valid_datetime) { "2019/01/01".in_time_zone }
+          let(:transaction_datetime) { "2019/02/01".in_time_zone }
+          let(:sql) {
+            ActiveRecord::Bitemporal.valid_at(valid_datetime) {
+              ActiveRecord::Bitemporal.transaction_at(transaction_datetime) { Blog.joins(:articles).to_sql }
+            }
+          }
+          it { is_expected.to have_valid_at(valid_datetime, table: "blogs") }
+          it { is_expected.to have_transaction_at(transaction_datetime, table: "blogs") }
+          it { is_expected.to have_valid_at(valid_datetime, table: "articles") }
+          it { is_expected.to have_transaction_at(transaction_datetime, table: "articles") }
         end
 
         describe ".merge" do
@@ -873,6 +983,17 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
             it { is_expected.to have_transaction_at(time_current, table: "blogs") }
             it { is_expected.to have_transaction_at(time_current, table: "articles") }
           end
+
+          context "with call to_sql in `ActiveRecord::Bitemporal.transaction_at`" do
+            let(:transaction_datetime) { "2019/01/01".in_time_zone }
+            let(:sql) { ActiveRecord::Bitemporal.transaction_at(transaction_datetime) { relation.to_sql } }
+
+            it { is_expected.to have_valid_at(time_current, table: "blogs") }
+            it { is_expected.to have_valid_at(time_current, table: "articles") }
+
+            it { is_expected.to have_transaction_at(transaction_datetime, table: "blogs") }
+            it { is_expected.to have_transaction_at(transaction_datetime, table: "articles") }
+          end
         end
 
         # The behavior of `.josins.left_joins` has changed in Rails 6.0
@@ -892,6 +1013,14 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
               it { is_expected.to have_valid_at(valid_datetime, table: "articles_blogs") }
               it { is_expected.to have_transaction_at(time_current, table: "articles_blogs") }
             end
+
+            context "with call to_sql in `ActiveRecord::Bitemporal.transaction_at`" do
+              let(:transaction_datetime) { "2019/01/01".in_time_zone }
+              let(:sql) { ActiveRecord::Bitemporal.transaction_at(transaction_datetime) { relation.to_sql } }
+
+              it { is_expected.to have_valid_at(time_current, table: "articles_blogs") }
+              it { is_expected.to have_transaction_at(transaction_datetime, table: "articles_blogs") }
+            end
           end
         end
       end
@@ -905,6 +1034,18 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
           let(:relation) { Blog.create.articles.valid_at(valid_datetime) }
           it { is_expected.to have_valid_at(valid_datetime, table: "articles") }
           it { is_expected.to have_transaction_at(time_current, table: "articles") }
+        end
+
+        context "with .ignore_bitemporal_datetime" do
+          let(:relation) { Blog.create.articles.ignore_bitemporal_datetime }
+          it { is_expected.to not_have_bitemporal_at(table: "articles") }
+        end
+
+        context "with .transaction_at" do
+          let(:transaction_datetime) { "2019/01/01".in_time_zone }
+          let(:relation) { Blog.create.articles.transaction_at(transaction_datetime) }
+          it { is_expected.to have_valid_at(time_current, table: "articles") }
+          it { is_expected.to have_transaction_at(transaction_datetime, table: "articles") }
         end
 
         context "with .ignore_bitemporal_datetime" do
@@ -932,6 +1073,19 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
 
         context "with .ignore_bitemporal_datetime" do
           let(:valid_datetime) { "2019/01/01".in_time_zone }
+          let(:relation) { association_scope.ignore_bitemporal_datetime }
+          it { is_expected.to not_have_bitemporal_at(table: "blogs") }
+        end
+
+        context "with .transaction_at" do
+          let(:transaction_datetime) { "2019/01/01".in_time_zone }
+          let(:relation) { association_scope.transaction_at(transaction_datetime) }
+          it { is_expected.to have_valid_at(time_current, table: "blogs") }
+          it { is_expected.to have_transaction_at(transaction_datetime, table: "blogs") }
+        end
+
+        context "with .ignore_bitemporal_datetime" do
+          let(:transaction_datetime) { "2019/01/01".in_time_zone }
           let(:relation) { association_scope.ignore_bitemporal_datetime }
           it { is_expected.to not_have_bitemporal_at(table: "blogs") }
         end
@@ -973,6 +1127,15 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
 
         it { is_expected.to have_transaction_at(time_current, table: "users") }
         it { is_expected.to have_transaction_at(time_current, table: "articles") }
+      end
+
+      context ".ignore_transaction_datetime" do
+        let(:relation) { blog.users.ignore_transaction_datetime }
+        it { is_expected.to have_valid_at(time_current, table: "users") }
+        it { is_expected.to have_valid_at(time_current, table: "articles") }
+
+        it { is_expected.to not_have_transaction_at(table: "users") }
+        it { is_expected.to not_have_transaction_at(table: "articles") }
       end
 
       context ".transaction_at" do
@@ -1036,6 +1199,14 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
             it { is_expected.to have_transaction_at(time_current, table: "users") }
           end
 
+          context "with .transaction_at" do
+            let(:transaction_datetime) { "2019/04/1".in_time_zone }
+            let(:relation) { User.transaction_at(transaction_datetime) }
+
+            it { is_expected.to have_valid_at(scoping_valid_datetime, table: "users") }
+            it { is_expected.to have_transaction_at(transaction_datetime, table: "users") }
+          end
+
           context "other model query" do
             let(:relation) { Article.all }
 
@@ -1056,6 +1227,69 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
 
             it { is_expected.to have_valid_at(valid_datetime, table: "users") }
             it { is_expected.to have_transaction_at(time_current, table: "users") }
+          end
+
+          context "with .transaction_at" do
+            let(:transaction_datetime) { "2019/04/1".in_time_zone }
+            let(:relation) { User.transaction_at(transaction_datetime) }
+
+            it { is_expected.to not_have_valid_at(table: "users") }
+            it { is_expected.to have_transaction_at(transaction_datetime, table: "users") }
+          end
+        end
+
+        describe "with .transaction_at" do
+          let(:relation) { User.all }
+          let(:scoping_transaction_datetime) { "2019/01/1".in_time_zone }
+          around { |e| User.transaction_at(scoping_transaction_datetime).scoping { e.run } }
+
+          it { is_expected.to have_valid_at(time_current, table: "users") }
+          it { is_expected.to have_transaction_at(scoping_transaction_datetime, table: "users") }
+
+          context "with .valid_at" do
+            let(:valid_datetime) { "2019/04/1".in_time_zone }
+            let(:relation) { User.valid_at(valid_datetime) }
+
+            it { is_expected.to have_valid_at(valid_datetime, table: "users") }
+            it { is_expected.to have_transaction_at(scoping_transaction_datetime, table: "users") }
+          end
+
+          context "with .transaction_at" do
+            let(:transaction_datetime) { "2019/04/1".in_time_zone }
+            let(:relation) { User.transaction_at(transaction_datetime) }
+
+            it { is_expected.to have_valid_at(time_current, table: "users") }
+            it { is_expected.to have_transaction_at(transaction_datetime, table: "users") }
+          end
+
+          context "other model query" do
+            let(:relation) { Article.all }
+
+            it { is_expected.to have_bitemporal_at(time_current, table: "articles") }
+          end
+        end
+
+        describe "with .ignore_transaction_datetime" do
+          let(:relation) { User.all }
+          around { |e| User.ignore_transaction_datetime.scoping { e.run } }
+
+          it { is_expected.to have_valid_at(time_current, table: "users") }
+          it { is_expected.to not_have_transaction_at(table: "users") }
+
+          context "with .valid_at" do
+            let(:valid_datetime) { "2019/04/1".in_time_zone }
+            let(:relation) { User.valid_at(valid_datetime) }
+
+            it { is_expected.to have_valid_at(valid_datetime, table: "users") }
+            it { is_expected.to not_have_transaction_at(table: "users") }
+          end
+
+          context "with .transaction_at" do
+            let(:transaction_datetime) { "2019/04/1".in_time_zone }
+            let(:relation) { User.transaction_at(transaction_datetime) }
+
+            it { is_expected.to have_valid_at(time_current, table: "users") }
+            it { is_expected.to have_transaction_at(transaction_datetime, table: "users") }
           end
         end
 
@@ -1101,6 +1335,14 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
           it { is_expected.to not_have_transaction_at(table: "users") }
         end
 
+        context "with .transaction_at" do
+          let(:transaction_datetime) { "2019/04/1".in_time_zone }
+          let(:relation) { User.transaction_at(transaction_datetime) }
+
+          it { is_expected.to not_have_valid_at(table: "users") }
+          it { is_expected.to have_transaction_at(transaction_datetime, table: "users") }
+        end
+
         context "other model query" do
           let(:relation) { Article.all }
 
@@ -1133,7 +1375,7 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
       define_method(:articles_sql) { |matcher| satisfy { |_, sql| expect(sql).to matcher } }
 
       let(:sql) { Array(sql_log { relation.to_a.first.articles.load }.split("\n")) }
-      before { Blog.create(valid_from: "2000/01/01").articles.create(valid_from: "2000/01/01") }
+      before { Blog.create(valid_from: "2000/01/01", transaction_from: "2000/01/01").articles.create(valid_from: "2000/01/01", transaction_from: "2000/01/01") }
 
       context ".joins" do
         let(:relation) { Blog.joins(:articles) }
@@ -1178,6 +1420,37 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
           # load association
           it { is_expected.to articles_sql have_valid_at(valid_datetime, table: "articles") }
           it { is_expected.to articles_sql have_transaction_at(time_current, table: "articles") }
+        end
+
+        context "with `ignore_transaction_datetime`" do
+          let(:relation) { Blog.ignore_transaction_datetime.joins(:articles) }
+
+          # INNER JOIN
+          it { is_expected.to blogs_sql scan_once 'INNER JOIN "articles"' }
+          it { is_expected.to blogs_sql have_valid_at(time_current, table: "articles") }
+          it { is_expected.to blogs_sql not_have_transaction_at(table: "articles") }
+          # WHERE
+          it { is_expected.to blogs_sql have_valid_at(time_current, table: "blogs") }
+          it { is_expected.to blogs_sql not_have_transaction_at(table: "blogs") }
+          # load association
+          it { is_expected.to articles_sql have_valid_at(time_current, table: "articles") }
+          it { is_expected.to articles_sql have_transaction_at(time_current, table: "articles") }
+        end
+
+        context "with `transaction_at`" do
+          let(:transaction_datetime) { "2019/01/01".in_time_zone }
+          let(:relation) { Blog.transaction_at(transaction_datetime).joins(:articles) }
+
+          # INNER JOIN
+          it { is_expected.to blogs_sql scan_once 'INNER JOIN "articles"' }
+          it { is_expected.to blogs_sql have_valid_at(time_current, table: "articles") }
+          it { is_expected.to blogs_sql have_transaction_at(transaction_datetime, table: "articles") }
+          # WHERE
+          it { is_expected.to blogs_sql have_valid_at(time_current, table: "blogs") }
+          it { is_expected.to blogs_sql have_transaction_at(transaction_datetime, table: "blogs") }
+          # load association
+          it { is_expected.to articles_sql have_valid_at(time_current, table: "articles") }
+          it { is_expected.to articles_sql have_transaction_at(transaction_datetime, table: "articles") }
         end
       end
 
@@ -1225,6 +1498,37 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
           it { is_expected.to articles_sql have_valid_at(valid_datetime, table: "articles") }
           it { is_expected.to articles_sql have_transaction_at(time_current, table: "articles") }
         end
+
+        context "with `ignore_transaction_datetime`" do
+          let(:relation) { Blog.ignore_transaction_datetime.left_joins(:articles) }
+
+          # LEFT OUTER JOIN
+          it { is_expected.to blogs_sql scan_once 'LEFT OUTER JOIN "articles"' }
+          it { is_expected.to blogs_sql have_valid_at(time_current, table: "articles") }
+          it { is_expected.to blogs_sql not_have_transaction_at(table: "articles") }
+          # WHERE
+          it { is_expected.to blogs_sql have_valid_at(time_current, table: "blogs") }
+          it { is_expected.to blogs_sql not_have_transaction_at(table: "blogs") }
+          # load association
+          it { is_expected.to articles_sql have_valid_at(time_current, table: "articles") }
+          it { is_expected.to articles_sql have_transaction_at(time_current, table: "articles") }
+        end
+
+        context "with `transaction_at`" do
+          let(:transaction_datetime) { "2019/01/01".in_time_zone }
+          let(:relation) { Blog.transaction_at(transaction_datetime).left_joins(:articles) }
+
+          # INNER JOIN
+          it { is_expected.to blogs_sql scan_once 'LEFT OUTER JOIN "articles"' }
+          it { is_expected.to blogs_sql have_valid_at(time_current, table: "articles") }
+          it { is_expected.to blogs_sql have_transaction_at(transaction_datetime, table: "articles") }
+          # WHERE
+          it { is_expected.to blogs_sql have_valid_at(time_current, table: "blogs") }
+          it { is_expected.to blogs_sql have_transaction_at(transaction_datetime, table: "blogs") }
+          # load association
+          it { is_expected.to articles_sql have_valid_at(time_current, table: "articles") }
+          it { is_expected.to articles_sql have_transaction_at(transaction_datetime, table: "articles") }
+        end
       end
 
       context ".preload" do
@@ -1258,6 +1562,29 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
           # load association
           it { is_expected.to articles_sql have_valid_at(valid_datetime, table: "articles") }
           it { is_expected.to articles_sql have_transaction_at(time_current, table: "articles") }
+        end
+
+        context "with `ignore_transaction_datetime`" do
+          let(:relation) { Blog.ignore_transaction_datetime.preload(:articles) }
+
+          # WHERE
+          it { is_expected.to blogs_sql have_valid_at(time_current, table: "blogs") }
+          it { is_expected.to blogs_sql not_have_transaction_at(table: "blogs") }
+          # load association
+          it { is_expected.to articles_sql have_valid_at(time_current, table: "articles") }
+          it { is_expected.to articles_sql not_have_transaction_at(table: "articles") }
+        end
+
+        context "with `transaction_at`" do
+          let(:transaction_datetime) { "2019/01/01".in_time_zone }
+          let(:relation) { Blog.transaction_at(transaction_datetime).preload(:articles) }
+
+          # WHERE
+          it { is_expected.to blogs_sql have_valid_at(time_current, table: "blogs") }
+          it { is_expected.to blogs_sql have_transaction_at(transaction_datetime, table: "blogs") }
+          # load association
+          it { is_expected.to articles_sql have_valid_at(time_current, table: "articles") }
+          it { is_expected.to articles_sql have_transaction_at(transaction_datetime, table: "articles") }
         end
       end
 
@@ -1305,6 +1632,34 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
           # load association
           it { is_expected.to blogs_sql have_valid_at(valid_datetime, table: "articles") }
           it { is_expected.to blogs_sql have_transaction_at(time_current, table: "articles") }
+        end
+
+        context "with `ignore_transaction_datetime`" do
+          define_method(:not_have_transaction_at) { |datetime = Time.current, table:|
+                 not_scan(%{"#{table}"."transaction_from" <= '#{datetime.to_s(:db)}'})
+            .and not_scan(%{"#{table}"."transaction_to" > '#{datetime.to_s(:db)}'})
+          }
+
+          let(:relation) { Blog.ignore_transaction_datetime.eager_load(:articles) }
+
+          # WHERE
+          it { is_expected.to blogs_sql have_valid_at(time_current, table: "blogs") }
+          it { is_expected.to blogs_sql not_have_transaction_at(time_current, table: "blogs") }
+          # load association
+          it { is_expected.to blogs_sql have_valid_at(time_current, table: "articles") }
+          it { is_expected.to blogs_sql not_have_transaction_at(time_current, table: "articles") }
+        end
+
+        context "with `transaction_at`" do
+          let(:transaction_datetime) { "2019/01/01".in_time_zone }
+          let(:relation) { Blog.transaction_at(transaction_datetime).eager_load(:articles) }
+
+          # WHERE
+          it { is_expected.to blogs_sql have_valid_at(time_current, table: "blogs") }
+          it { is_expected.to blogs_sql have_transaction_at(transaction_datetime, table: "blogs") }
+          # load association
+          it { is_expected.to blogs_sql have_valid_at(time_current, table: "articles") }
+          it { is_expected.to blogs_sql have_transaction_at(transaction_datetime, table: "articles") }
         end
       end
     end
@@ -1518,6 +1873,30 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
       it { is_expected.to include(valid_datetime: time_current, transaction_datetime: transaction_datetime) }
     end
 
+    context "ActiveRecord::Bitemporal.transaction_at" do
+      let(:transaction_datetime) { "2019/01/1".in_time_zone }
+      let(:relation) { ActiveRecord::Bitemporal.transaction_at(transaction_datetime) { Blog.all } }
+      it { is_expected.to include(valid_datetime: time_current, transaction_datetime: transaction_datetime) }
+
+      context ".transaction_at" do
+        let(:transaction_datetime) { "2019/01/1".in_time_zone }
+        let(:relation) { ActiveRecord::Bitemporal.transaction_at("1999/01/01") { Blog.transaction_at(transaction_datetime) } }
+        it { is_expected.to include(valid_datetime: time_current, transaction_datetime: transaction_datetime) }
+      end
+    end
+
+    context "ActiveRecord::Bitemporal.transaction_at!" do
+      let(:transaction_datetime) { "2019/01/1".in_time_zone }
+      let(:relation) { ActiveRecord::Bitemporal.transaction_at!(transaction_datetime) { Blog.all } }
+      it { is_expected.to include(valid_datetime: time_current, transaction_datetime: transaction_datetime) }
+
+      context ".transaction_at" do
+        let(:transaction_datetime) { "2019/01/1".in_time_zone }
+        let(:relation) { ActiveRecord::Bitemporal.transaction_at!(transaction_datetime) { Blog.transaction_at("1999/01/01") } }
+        it { is_expected.to include(valid_datetime: time_current, transaction_datetime: transaction_datetime) }
+      end
+    end
+
     context "with `.ignore_transaction_datetime`" do
       let(:relation) { Blog.ignore_transaction_datetime }
       it { is_expected.to include(valid_datetime: time_current) }
@@ -1625,6 +2004,19 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         end
       end
 
+      context ".transaction_at" do
+        let(:transaction_datetime) { "2019/01/1".in_time_zone }
+        let(:relation) { Blog.transaction_at(transaction_datetime) }
+        it { is_expected.to include(transaction_datetime: transaction_datetime) }
+      end
+
+      context "#transaction_at" do
+        let(:transaction_datetime) { "2019/01/1".in_time_zone }
+        let(:relation) { Blog.all }
+        let(:bitemporal_option) { Timecop.freeze(time_current) { record.transaction_at(transaction_datetime) { |it| it.bitemporal_option } } }
+        it { is_expected.to include(transaction_datetime: transaction_datetime) }
+      end
+
       describe "association" do
         let!(:blog) { Blog.create(valid_from: "1999/01/01", transaction_from: "1999/01/01") }
         let!(:article) { blog.articles.create(valid_from: "1999/01/01", transaction_from: "1999/01/01") }
@@ -1654,6 +2046,25 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
           let(:valid_datetime) { "2019/01/1".in_time_zone }
           let(:relation) { Blog.all.first.articles.valid_at(valid_datetime) }
           it { is_expected.to include(valid_datetime: valid_datetime) }
+        end
+
+        context "owner.transaction_at" do
+          let(:transaction_datetime) { "2019/01/1".in_time_zone }
+          let(:owner) { Blog.transaction_at(transaction_datetime).first }
+          let(:relation) { owner.articles }
+          it { is_expected.to include(transaction_datetime: transaction_datetime) }
+
+          context "with association.transaction_at" do
+            let(:association_transaction_datetime) { "2019/05/1".in_time_zone }
+            let(:relation) { owner.articles.transaction_at(association_transaction_datetime) }
+            it { is_expected.to include(transaction_datetime: association_transaction_datetime) }
+          end
+        end
+
+        context "association.transaction_at" do
+          let(:transaction_datetime) { "2019/01/1".in_time_zone }
+          let(:relation) { Blog.all.first.articles.transaction_at(transaction_datetime) }
+          it { is_expected.to include(transaction_datetime: transaction_datetime) }
         end
       end
     end
@@ -1883,7 +2294,7 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
 
     context "default scope" do
       let(:relation) { Blog.all }
-      it { is_expected.to be_falsey }
+      it { is_expected.to eq :default_scope }
     end
 
     context "with .transaction_at" do
@@ -1904,6 +2315,146 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
     context "with ignore_transaction_datetime.transaction_at" do
       let(:relation) { Blog.ignore_transaction_datetime.transaction_at("04/01") }
       it { is_expected.to be_truthy }
+    end
+
+    context "with ActiveRecord::Bitemporal.transaction_at" do
+      let(:relation) { ActiveRecord::Bitemporal.transaction_at("04/01") { Blog.all } }
+      it { is_expected.to eq :default_scope_with_transaction_datetime }
+    end
+
+    context "with ActiveRecord::Bitemporal.ignore_transaction_datetime" do
+      let(:relation) { ActiveRecord::Bitemporal.ignore_transaction_datetime { Blog.all } }
+      it { is_expected.to be_falsey }
+    end
+
+    context "with ActiveRecord::Bitemporal.transaction_at -> .ignore_transaction_datetime" do
+      let(:relation) { ActiveRecord::Bitemporal.transaction_at("04/01") { Blog.ignore_transaction_datetime } }
+      it { is_expected.to be_falsey }
+    end
+
+    context "with ActiveRecord::Bitemporal.transaction_at -> ActiveRecord::Bitemporal.ignore_transaction_datetime" do
+      let(:relation) { ActiveRecord::Bitemporal.transaction_at("04/01") { ActiveRecord::Bitemporal.ignore_transaction_datetime { Blog.all } } }
+      it { is_expected.to be_falsey }
+    end
+
+    context "with ActiveRecord::Bitemporal.ignore_transaction_datetime -> .transaction_at" do
+      let(:relation) { ActiveRecord::Bitemporal.ignore_transaction_datetime { Blog.transaction_at("04/01") } }
+      it { is_expected.to be_truthy }
+    end
+
+    context "with ActiveRecord::Bitemporal.ignore_transaction_datetime -> ActiveRecord::Bitemporal.transaction_at" do
+      let(:relation) { ActiveRecord::Bitemporal.ignore_transaction_datetime { ActiveRecord::Bitemporal.transaction_at("04/01") { Blog.all } } }
+      it { is_expected.to be_truthy }
+    end
+
+    context "create association when after record loaded" do
+      let!(:blog) { Blog.create; Blog.first }
+      it { expect { Article.create(blog_id: blog.id) }.to change { blog.articles.count }.by(1) }
+    end
+
+    context ".except_transaction_datetime" do
+      let(:relation) { Blog.all.except_transaction_datetime }
+      it { expect(relation.bitemporal_value).not_to include(:with_transaction_datetime) }
+    end
+
+    context ".ignore_transaction_datetime.except_transaction_datetime" do
+      let(:relation) { Blog.ignore_transaction_datetime.except_transaction_datetime }
+      it { expect(relation.bitemporal_value).not_to include(:with_transaction_datetime) }
+    end
+
+    context ".except_transaction_datetime.ignore_transaction_datetime" do
+      let(:relation) { Blog.except_transaction_datetime.ignore_transaction_datetime }
+      it { expect(relation.bitemporal_value).to include(with_transaction_datetime: false) }
+    end
+
+    context ".transaction_at" do
+      let(:relation) { Blog.transaction_at("2020/10/01") }
+      it { expect(relation.bitemporal_value).to include(with_transaction_datetime: true) }
+    end
+
+    xcontext ".transaction_at.except_transaction_datetime" do
+      let(:relation) { Blog.transaction_at("2020/10/01").except_transaction_datetime }
+      it { expect(relation.bitemporal_value).to include(with_transaction_datetime: true) }
+    end
+
+    context ".merge(.)" do
+      let(:relation) { Blog.all.merge(User.all) }
+      it { expect(relation.bitemporal_value).to include(with_transaction_datetime: :default_scope) }
+    end
+
+    context ".merge(.transaction_at)" do
+      let(:relation) { Blog.all.merge(User.transaction_at("2020/01/01")) }
+      it { expect(relation.bitemporal_value).to include(with_transaction_datetime: true) }
+    end
+
+    context ".merge(.ignore_transaction_datetime)" do
+      let(:relation) { Blog.all.merge(User.ignore_transaction_datetime) }
+      it { expect(relation.bitemporal_value).to include(with_transaction_datetime: false) }
+    end
+
+    context ".merge(.except_transaction_datetime)" do
+      let(:relation) { Blog.all.merge(User.except_transaction_datetime) }
+      it { expect(relation.bitemporal_value).to include(with_transaction_datetime: :default_scope) }
+    end
+
+    context ".transaction_at.merge(.)" do
+      let(:relation) { Blog.transaction_at("2020/10/01").merge(User.all) }
+      it { expect(relation.bitemporal_value).to include(with_transaction_datetime: :default_scope) }
+    end
+
+    context ".transaction_at.merge(.transaction_at)" do
+      let(:relation) { Blog.transaction_at("2020/10/01").merge(User.transaction_at("2020/01/01")) }
+      it { expect(relation.bitemporal_value).to include(with_transaction_datetime: true) }
+    end
+
+    context ".transaction_at.merge(.ignore_transaction_datetime)" do
+      let(:relation) { Blog.transaction_at("2020/10/01").merge(User.ignore_transaction_datetime) }
+      it { expect(relation.bitemporal_value).to include(with_transaction_datetime: false) }
+    end
+
+    context ".transaction_at.merge(.except_transaction_datetime)" do
+      let(:relation) { Blog.transaction_at("2020/10/01").merge(User.except_transaction_datetime) }
+      it { expect(relation.bitemporal_value).to include(with_transaction_datetime: true) }
+    end
+
+    context ".ignore_transaction_datetime.merge(.)" do
+      let(:relation) { Blog.ignore_transaction_datetime.merge(User.all) }
+      it { expect(relation.bitemporal_value).to include(with_transaction_datetime: :default_scope) }
+    end
+
+    context ".ignore_transaction_datetime.merge(.transaction_at)" do
+      let(:relation) { Blog.ignore_transaction_datetime.merge(User.transaction_at("2020/01/01")) }
+      it { expect(relation.bitemporal_value).to include(with_transaction_datetime: true) }
+    end
+
+    context ".ignore_transaction_datetime.merge(.ignore_transaction_datetime)" do
+      let(:relation) { Blog.ignore_transaction_datetime.merge(User.ignore_transaction_datetime) }
+      it { expect(relation.bitemporal_value).to include(with_transaction_datetime: false) }
+    end
+
+    context ".ignore_transaction_datetime.merge(.except_transaction_datetime)" do
+      let(:relation) { Blog.ignore_transaction_datetime.merge(User.except_transaction_datetime) }
+      it { expect(relation.bitemporal_value).to include(with_transaction_datetime: false) }
+    end
+
+    context ".except_transaction_datetime.merge(.)" do
+      let(:relation) { Blog.except_transaction_datetime.merge(User.all) }
+      it { expect(relation.bitemporal_value).to include(with_transaction_datetime: :default_scope) }
+    end
+
+    context ".except_transaction_datetime.merge(.transaction_at)" do
+      let(:relation) { Blog.except_transaction_datetime.merge(User.transaction_at("2020/01/01")) }
+      it { expect(relation.bitemporal_value).to include(with_transaction_datetime: true) }
+    end
+
+    context ".except_transaction_datetime.merge(.ignore_transaction_datetime)" do
+      let(:relation) { Blog.except_transaction_datetime.merge(User.ignore_transaction_datetime) }
+      it { expect(relation.bitemporal_value).to include(with_transaction_datetime: false) }
+    end
+
+    context ".except_transaction_datetime.merge(.except_transaction_datetime)" do
+      let(:relation) { Blog.except_transaction_datetime.merge(User.except_transaction_datetime) }
+      it { expect(relation.bitemporal_value).not_to include(:with_transaction_datetime) }
     end
   end
 end


### PR DESCRIPTION
Add `transaction_at` support methods.


## Add methods

* `ActiveRecord::Bitemporal.transaction_at`
* `ActiveRecord::Bitemporal.transaction_at!`
* `ActiveRecord::Bitemporal.transaction_datetime`
* `ActiveRecord::Bitemporal.ignore_transaction_datetime`

```ruby
# transaction_at with 2020/01/01
ActiveRecord::Bitemporal.transaction_at("2020/01/01") {
  pp ActiveRecord::Bitemporal.transaction_datetime.to_time
  # => "2020/01/01"

  pp Company.all.transaction_datetime.to_time
  # => "2020/01/01"

  puts Company.all.to_sql
  # => SELECT "companies".*
  #      FROM "companies"
  #     WHERE "companies"."transaction_from" <= '2020-01-01 00:00:00'
  #       AND "companies"."transaction_to"   >  '2020-01-01 00:00:00'
  #       AND "companies"."valid_from"       <= '2021-09-14 03:55:50.230146'
  #       AND "companies"."valid_to"         >  '2021-09-14 03:55:50.230146'

  # except transaction_at
  ActiveRecord::Bitemporal.ignore_transaction_datetime {
    pp ActiveRecord::Bitemporal.transaction_datetime
    # => nil

    pp Company.all.transaction_datetime
    # => nil

    puts Company.all.to_sql
    # => SELECT "companies".*
    #      FROM "companies"
    #     WHERE "companies"."valid_from" <= '2021-09-14 08:27:50.043817'
    #       AND "companies"."valid_to"   >  '2021-09-14 08:27:50.043817'
  }
}
```

and, instance obj has `transaction_datetime`

## before

```ruby
company = Company.transaction_at("2023/01/01").first
pp company.bitemporal_option
# => {}

puts company.employees.to_sql
# => SELECT "employees".*
#      FROM "employees"
#     WHERE "employees"."transaction_from" <= '2021-09-14 08:39:24.990540'
#       AND "employees"."transaction_to"   >  '2021-09-14 08:39:24.990540'
#       AND "employees"."valid_from"       <= '2021-09-14 08:39:24.990540'
#       AND "employees"."valid_to"         >  '2021-09-14 08:39:24.990540'
#       AND "employees"."company_id"       =  1
```

## after

```ruby
company = Company.transaction_at("2023/01/01").first
pp company.bitemporal_option
# => {:transaction_datetime=>Sun, 01 Jan 2023 00:00:00.000000000 UTC +00:00}

puts company.employees.to_sql
# => SELECT "employees".*
#      FROM "employees"
#     WHERE "employees"."transaction_from" <= '2021-09-08 08:50:45.514063'
#       AND "employees"."transaction_to"   >  '2021-09-08 08:50:45.514063'
#       AND "employees"."company_id"       =  1
#       AND "employees"."valid_from"       <= '2023-01-01 00:00:00'
#       AND "employees"."valid_to"         >  '2023-01-01 00:00:00'
```

