### PR TITLE
Fix scope of through association for not BTDM

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,8 @@ services:
     image: postgres:latest
     ports:
       - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
     tmpfs:
       - /var/lib/postgresql/data

--- a/lib/activerecord-bitemporal/patches.rb
+++ b/lib/activerecord-bitemporal/patches.rb
@@ -84,6 +84,8 @@ module ActiveRecord::Bitemporal
     module ThroughAssociation
       def target_scope
         scope = super
+        return scope unless scope.bi_temporal_model?
+
         reflection.chain.drop(1).each do |reflection|
           klass = reflection.klass&.scope_for_association&.klass
           next unless klass&.bi_temporal_model?

--- a/spec/activerecord-bitemporal/through_spec.rb
+++ b/spec/activerecord-bitemporal/through_spec.rb
@@ -45,12 +45,21 @@ ActiveRecord::Schema.define(version: 1) do
 
     t.timestamps
   end
+
+  create_table :comments, force: true do |t|
+    t.string :body
+
+    t.integer :article_id
+
+    t.timestamps
+  end
 end
 
 class Blog < ActiveRecord::Base
   include ActiveRecord::Bitemporal
   has_many :articles
   has_many :users, through: :articles
+  has_many :comments, through: :articles
 end
 
 class User < ActiveRecord::Base
@@ -62,18 +71,24 @@ class Article < ActiveRecord::Base
   include ActiveRecord::Bitemporal
   belongs_to :blog
   belongs_to :user
+  has_many :comments
 end
 
+class Comment < ActiveRecord::Base
+  belongs_to :article
+end
 
 RSpec.describe "has_xxx with through" do
   describe "created" do
     let!(:blog) { Blog.create!(name: "tabelog").tap { |it| it.update(name: "sushilog") } }
     let!(:user) { User.create!(name: "Jane").tap { |it| it.update(name: "Tom") } }
     let!(:article) { user.articles.create!(title: "yakiniku", blog: blog).tap { |it| it.update(title: "sushi") } }
+    let!(:comment) { article.comments.create!(body: "nice") }
 
     it { expect(blog.users.count).to eq 1 }
     it { expect(blog.articles.count).to eq 1 }
     it { expect(user.articles.count).to eq 1 }
+    it { expect(blog.comments.count).to eq 1 }
     it { expect(article.blog).to eq blog }
     it { expect(article.user).to eq user }
 


### PR DESCRIPTION
Thanks for the nice gem!

I fixed the scope of Through Association for models that are not BTDM.
The check for `scope.bi_temporal_model?` was omitted.