### PR TITLE
Add supoprt Ruby 3.1 x Rails 7.0.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,12 +106,11 @@ jobs:
       - run_rspec:
           gemfile: rails-6.1
 
-  # Rails 7.0.0 does not yet support Ruby 3.1
-  # ruby_3_1_rails_7_0:
-  #   executor: ruby_3_1
-  #   steps:
-  #     - run_rspec:
-  #         gemfile: rails-7.0
+  ruby_3_1_rails_7_0:
+    executor: ruby_3_1
+    steps:
+      - run_rspec:
+          gemfile: rails-7.0
 
   ruby_3_1_rails_main:
     executor: ruby_3_1

--- a/Appraisals
+++ b/Appraisals
@@ -17,5 +17,5 @@ appraise "rails-6.1" do
 end
 
 appraise "rails-7.0" do
-  gem "rails", "~> 7.0"
+  gem "rails", "~> 7.0.1"
 end

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "appraisal"
-gem "rails", "~> 7.0"
+gem "rails", "~> 7.0.1"
 
 gemspec path: "../"


### PR DESCRIPTION
Add Ruby 3.1 x Rails 7.0 tests because Ruby 3.1 is now supported in Rails 7.0.1.
see: https://rubyonrails.org/2022/1/6/Rails-7-0-1-has-been-released