### PR TITLE
fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Timecop.freeze("2019/1/10") {
 
 | id | bitemporal_id | emp_code | name | valid_from | valid_to | transaction_from | transaction_to |
 |  --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | 1 | 001 | Jane | 2019-01-10 | 9999-12-31 | 2019-01-10 | 2019-01-15 |
+| 1 | 1 | 001 | Jane | 2019-01-10 | 9999-12-31 | 2019-01-10 | 9999-12-31 |
 
 そのモデルに対して更新を行うと
 


### PR DESCRIPTION
README.mdの修理依頼です。

最初にデータを登録する時（emp_code: "001", name: "Jane"のデータを登録する時）、`transaction_to`が`2019-01-15`になると記載されていますが、私が確認した時は`9999-12-31`となりました。

正しいのは`9999-12-31`だと思ったのですがいかがでしょうか。

ご確認よろしくおねがいします。
