### PR TITLE
Drop Support Ruby 2.6 & Update CI workflow config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,9 @@ workflows:
       - ruby_3_0_rails_6_1
       - ruby_3_0_rails_7_0
       - ruby_3_0_rails_main
+      - ruby_3_1_rails_6_1
+      - ruby_3_1_rails_7_0
+      - ruby_3_1_rails_main
 
   daily_test:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,6 @@
 version: 2.1
 
 executors:
-  ruby_2_6:
-    docker:
-      - image: ruby:2.6.9
-      - image: circleci/postgres:11-alpine
-
   ruby_2_7:
     docker:
       - image: ruby:2.7.5
@@ -34,24 +29,6 @@ commands:
       - run: bundle exec appraisal << parameters.gemfile >> rspec
 
 jobs:
-  ruby_2_6_rails_5_2:
-    executor: ruby_2_6
-    steps:
-      - run_rspec:
-          gemfile: rails-5.2
-
-  ruby_2_6_rails_6_0:
-    executor: ruby_2_6
-    steps:
-      - run_rspec:
-          gemfile: rails-6.0
-
-  ruby_2_6_rails_6_1:
-    executor: ruby_2_6
-    steps:
-      - run_rspec:
-          gemfile: rails-6.1
-
   ruby_2_7_rails_5_2:
     executor: ruby_2_7
     steps:
@@ -123,9 +100,6 @@ workflows:
 
   test:
     jobs: &jobs
-      - ruby_2_6_rails_5_2
-      - ruby_2_6_rails_6_0
-      - ruby_2_6_rails_6_1
       - ruby_2_7_rails_5_2
       - ruby_2_7_rails_6_0
       - ruby_2_7_rails_6_1


### PR DESCRIPTION
## Description
From #86, Ruby 3.1 config has been added to CI.
However, workflows config have not been updated and CI is not running.

Also, Ruby 2.6 is no longer supported.

## Changes
* Drop Support Ruby 2.6
* Added ruby 3.1 workflow config