### PR TITLE
Add bitemporal data structure visualizer

### DIFF
--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -6,6 +6,7 @@ require "activerecord-bitemporal/bitemporal"
 require "activerecord-bitemporal/scope"
 require "activerecord-bitemporal/patches"
 require "activerecord-bitemporal/version"
+require "activerecord-bitemporal/visualizer"
 
 module ActiveRecord::Bitemporal
   DEFAULT_VALID_FROM = Time.utc(1900, 12, 31).in_time_zone.freeze

--- a/lib/activerecord-bitemporal/visualizer.rb
+++ b/lib/activerecord-bitemporal/visualizer.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+module ActiveRecord::Bitemporal
+  module Visualizer
+    # Figure is a two-dimensional array holding plotted lines and columns
+    class Figure < Array
+      def print(str, line: 0, column: 0)
+        self[line] ||= []
+        str.each_char.with_index(column) do |c, i|
+          # The `#` represents a zero-length rectangle and should not be overwritten with lines
+          next if self[line][i] == '#' && (c == '+' || c == '|' || c == '-')
+
+          self[line][i] = c
+        end
+      end
+
+      def to_s
+        map { |l| l&.map { |c| c || ' ' }&.join }.join("\n")
+      end
+    end
+
+    module_function
+
+    def visualize(record, height: 10, width: 40, highlight: true)
+      histories = record.class.ignore_bitemporal_datetime.bitemporal_for(record).order(:transaction_from, :valid_from)
+
+      if highlight
+        visualize_records(histories, [record], height: height, width: width)
+      else
+        visualize_records(histories, height: height, width: width)
+      end
+    end
+
+    # e.g. visualize_records(ActiveRecord::Relation, ActiveRecord::Relation)
+    def visualize_records(*relations, height: 10, width: 40)
+      raise 'More than 3 relations are not supported' if relations.size >= 3
+      records = relations.flatten
+
+      valid_times = (records.map(&:valid_from) + records.map(&:valid_to)).sort.uniq
+      transaction_times = (records.map(&:transaction_from) + records.map(&:transaction_to)).sort.uniq
+  
+      time_length = Time.zone.now.strftime('%F %T.%3N').length
+  
+      columns = compute_positions(valid_times, length: width, left_margin: time_length + 1, outlier: ActiveRecord::Bitemporal::DEFAULT_VALID_TO)
+      lines = compute_positions(transaction_times, length: height, outlier: ActiveRecord::Bitemporal::DEFAULT_TRANSACTION_TO)
+  
+      headers = Figure.new
+      valid_times.each_with_object([]).with_index do |(valid_time, prev_valid_times), line|
+        prev_valid_times.each do |valid_time|
+          headers.print('|', line: line, column: columns[valid_time])
+        end
+        headers.print("| #{valid_time.strftime('%F %T.%3N')}", line: line, column: columns[valid_time])
+        prev_valid_times << valid_time
+      end
+  
+      body = Figure.new
+      relations.each.with_index do |relation, idx|
+        filler = idx == 0 ? ' ' : '*'
+
+        relation.each do |record|
+          line = lines[record.transaction_from]
+          column = columns[record.valid_from]
+    
+          width = columns[record.valid_to] - columns[record.valid_from] - 1
+          height = lines[record.transaction_to] - lines[record.transaction_from] - 1
+    
+          body.print("#{record.transaction_from.strftime('%F %T.%3N')} ", line: line)
+          if width > 0
+            if height > 0
+              body.print('+' + '-' * width + '+', line: line, column: column)
+            else
+              body.print('|' + '#' * width + '|', line: line, column: column)
+            end
+          else
+            body.print('#', line: line, column: column)
+          end
+
+          1.upto(height) do |i|
+            if width > 0
+              body.print('|' + filler * width + '|', line: line + i, column: column)
+            else
+              body.print('#', line: line + i, column: column)
+            end
+          end
+
+          body.print("#{record.transaction_to.strftime('%F %T.%3N')} ", line: line + height + 1)
+          if width > 0
+            body.print('+' + '-' * width + '+', line: line + height + 1, column: column)
+          else
+            body.print('#', line: line + height + 1, column: column)
+          end
+        end
+      end
+  
+      "#{headers.to_s}\n#{body.to_s}"
+    end
+  
+    # Compute a dictionary of where each time should be plotted.
+    # The position is normalized to the actual length of time.
+    #
+    # Example:
+    #
+    #   t1     t2     t3                t4
+    #   |------|------|-----------------|
+    #
+    #   f(t1, t2, t3, t4) -> { t1 => 0, t2 => 2, t3 => 4, t4 => 10 }
+    #
+    def compute_positions(times, length:, left_margin: 0, outlier: nil)
+      lengths_from_beginning = compute_lengths_from_beginning(times, outlier: outlier)
+      # times must be sorted in ascending order. This is caller's responsibility.
+      # In that case, the last of lengths_from_beginning is equal to the total length.
+      total = lengths_from_beginning.values.last
+  
+      times.each_with_object({}) do |time, ret|
+        prev = ret.values.last
+        pos = (lengths_from_beginning[time] / total * length).to_i + left_margin
+  
+        if prev
+          # If the difference of times is too short, a position that have already been plotted may be computed.
+          # But we still want to plot the time, so allocate the required number to plot the smallest area.
+          if pos <= prev
+            # | -> |*|
+            #       ^^ 2 columns
+            pos = prev + 2
+          elsif pos == prev + 1
+            # || -> |*|
+            #        ^ 1 column
+            pos += 1
+          end
+        end
+        ret[time] = pos
+      end
+    end
+  
+    # Example:
+    #
+    #   t1          t2          t3          t4
+    #   |-----------|-----------|-----------|
+    #   <-----------> l1
+    #   <-----------------------> l2
+    #   <-----------------------------------> l3
+    #
+    #   f([t1, t2, t3, t4]) -> { t1 => 0, t2 => l1, t3 => l2, t4 => l3 }
+    #
+    def compute_lengths_from_beginning(times, outlier: nil)
+      times.each_with_object({}) do |time, ret|
+        ret[time] = if time == outlier && times.size > 2
+                      # If it contains an extremely large value such as 9999-12-31,
+                      # that point will have a large effect on the visualization,
+                      # so adjust the length so that it is half of the whole.
+                      ret.values.last * 2
+                    else
+                      time - times.min
+                    end
+      end
+    end
+  end
+end

--- a/spec/activerecord-bitemporal/visualizer_spec.rb
+++ b/spec/activerecord-bitemporal/visualizer_spec.rb
@@ -1,0 +1,342 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ActiveRecord::Bitemporal::Visualizer do
+  describe 'visuablize' do
+    let(:time) { '2022-05-23 18:06:06.712' }
+    around { |e| Timecop.freeze(time) { e.run } }
+    subject(:figure) { described_class.visualize(employee) }
+
+    context 'when it has never been updated' do
+      let(:employee) { Employee.create! }
+
+      it 'is a square' do
+        expect(figure).to eq <<~EOS.chomp
+                        | 2022-05-23 18:06:06.712
+                        |                                       | 9999-12-31 00:00:00.000
+2022-05-23 18:06:06.712 +---------------------------------------+
+                        |***************************************|
+                        |***************************************|
+                        |***************************************|
+                        |***************************************|
+                        |***************************************|
+                        |***************************************|
+                        |***************************************|
+                        |***************************************|
+                        |***************************************|
+9999-12-31 00:00:00.000 +---------------------------------------+
+EOS
+      end
+    end
+
+    context 'when it has been updated once' do
+      let(:employee) do
+        employee = Employee.create!
+        Timecop.freeze '2022-06-23 18:06:06.712' do
+          employee.update!(name: 'Jane')
+          employee.reload
+        end
+      end
+
+      it 'is 3 squares' do
+        expect(figure).to eq <<~EOS.chomp
+                        | 2022-05-23 18:06:06.712
+                        |                   | 2022-06-23 18:06:06.712
+                        |                   |                   | 9999-12-31 00:00:00.000
+2022-05-23 18:06:06.712 +---------------------------------------+
+                        |                                       |
+                        |                                       |
+                        |                                       |
+                        |                                       |
+2022-06-23 18:06:06.712 +-------------------+-------------------+
+                        |                   |*******************|
+                        |                   |*******************|
+                        |                   |*******************|
+                        |                   |*******************|
+9999-12-31 00:00:00.000 +-------------------+-------------------+
+EOS
+      end
+    end
+
+    context 'when it has been updated twice' do
+      let(:employee) do
+        employee = Employee.create!
+        Timecop.freeze '2022-06-01 18:06:06.712' do
+          employee.update!(name: 'Jane')
+        end
+
+        Timecop.freeze '2022-06-23 18:06:06.712' do
+          employee.update!(name: 'Mike')
+          employee.reload
+        end
+      end
+
+      it 'is 5 squares' do
+        expect(figure).to eq <<~EOS.chomp
+                        | 2022-05-23 18:06:06.712
+                        |    | 2022-06-01 18:06:06.712
+                        |    |              | 2022-06-23 18:06:06.712
+                        |    |              |                   | 9999-12-31 00:00:00.000
+2022-05-23 18:06:06.712 +---------------------------------------+
+                        |                                       |
+2022-06-01 18:06:06.712 +----+----------------------------------+
+                        |    |                                  |
+                        |    |                                  |
+2022-06-23 18:06:06.712 |    +--------------+-------------------+
+                        |    |              |*******************|
+                        |    |              |*******************|
+                        |    |              |*******************|
+                        |    |              |*******************|
+9999-12-31 00:00:00.000 +----+--------------+-------------------+
+EOS
+      end
+    end
+
+    context 'if it has been updated at very short intervals' do
+      let(:employee) do
+        employee = Employee.create!
+        Timecop.freeze '2022-05-23 18:06:06.831' do
+          employee.update!(name: 'Jane')
+        end
+
+        Timecop.freeze '2022-05-23 18:06:07.939' do
+          employee.update!(name: 'Mike')
+        end
+
+        Timecop.freeze '2030-05-23 18:06:07.939' do
+          employee.update!(name: 'John')
+          employee.reload
+        end
+      end
+
+      it 'is plotted in the smallest area' do
+        expect(figure).to eq <<~EOS.chomp
+                        | 2022-05-23 18:06:06.712
+                        | | 2022-05-23 18:06:06.831
+                        | | | 2022-05-23 18:06:07.939
+                        | | |               | 2030-05-23 18:06:07.939
+                        | | |               |                   | 9999-12-31 00:00:00.000
+2022-05-23 18:06:06.712 +---------------------------------------+
+                        |                                       |
+2022-05-23 18:06:06.831 +-+-------------------------------------+
+                        | |                                     |
+2022-05-23 18:06:07.939 | +-+-----------------------------------+
+                        | | |                                   |
+2030-05-23 18:06:07.939 | | +---------------+-------------------+
+                        | | |               |*******************|
+                        | | |               |*******************|
+                        | | |               |*******************|
+9999-12-31 00:00:00.000 +-+-+---------------+-------------------+
+EOS
+      end
+    end
+
+    context 'when it has been updated as zero length (valid_from == valid_to || transaction_from == transaction_to)' do
+      let(:employee) do
+        employee = Employee.create!
+        Timecop.freeze '2022-06-01 18:06:06.712' do
+          employee.update!(name: 'Jane')
+        end
+
+        Timecop.freeze '2022-06-23 18:06:06.712' do
+          employee.update!(name: 'Mike')
+
+          first, second = Employee.ignore_valid_datetime.bitemporal_for(employee).order(:valid_from)
+          first.update_columns(valid_to: first.valid_from)
+          second.update_columns(valid_from: first.valid_from)
+
+          first, second = Employee.ignore_transaction_datetime.bitemporal_for(employee).order(:transaction_from)
+          first.update_columns(transaction_to: first.transaction_from)
+          second.update_columns(transaction_from: first.transaction_from)
+
+          employee.reload
+        end
+      end
+
+      it 'is plotted as zero length history' do
+        expect(figure).to eq <<~EOS.chomp
+                        | 2022-05-23 18:06:06.712
+                        |    | 2022-06-01 18:06:06.712
+                        |    |              | 2022-06-23 18:06:06.712
+                        |    |              |                   | 9999-12-31 00:00:00.000
+2022-05-23 18:06:06.712 +#######################################+
+                             |                                  |
+2022-06-01 18:06:06.712 #    |                                  |
+                        #    |                                  |
+                        #    |                                  |
+2022-06-23 18:06:06.712 #-------------------+-------------------+
+                        #                   |*******************|
+                        #                   |*******************|
+                        #                   |*******************|
+                        #                   |*******************|
+9999-12-31 00:00:00.000 #-------------------+-------------------+
+EOS
+      end
+    end
+
+    context 'when it has been updated as zero area (valid_from == valid_to && transaction_from == transaction_to)' do
+      let(:employee) do
+        employee = Employee.create!
+        Timecop.freeze '2022-06-01 18:06:06.712' do
+          employee.update!(name: 'Jane')
+
+          first, second, third = Employee.ignore_bitemporal_datetime.bitemporal_for(employee).order(:transaction_from, :valid_from)
+          first.update_columns(valid_to: first.valid_from, transaction_to: first.transaction_from)
+          second.update_columns(transaction_from: first.transaction_from)
+          third.update_columns(transaction_from: first.transaction_from)
+
+          employee.reload
+        end
+      end
+
+      it 'is plotted as zero area history' do
+        expect(figure).to eq <<~EOS.chomp
+                        | 2022-05-23 18:06:06.712
+                        |                   | 2022-06-01 18:06:06.712
+                        |                   |                   | 9999-12-31 00:00:00.000
+2022-05-23 18:06:06.712 #-------------------+-------------------+
+                        |                   |*******************|
+                        |                   |*******************|
+                        |                   |*******************|
+                        |                   |*******************|
+                        |                   |*******************|
+                        |                   |*******************|
+                        |                   |*******************|
+                        |                   |*******************|
+                        |                   |*******************|
+9999-12-31 00:00:00.000 +-------------------+-------------------+
+EOS
+      end
+    end
+
+    context 'when it has been updated twice with other valid times' do
+      let(:employee) do
+        employee = Employee.create!
+        Timecop.freeze '2022-06-01 18:06:06.712' do
+          ActiveRecord::Bitemporal.valid_at '2022-04-23 18:06:06.712' do
+            employee.update!(name: 'Jane')
+          end
+        end
+
+        Timecop.freeze '2022-06-23 18:06:06.712' do
+          ActiveRecord::Bitemporal.valid_at '2022-05-01 18:06:06.712' do
+            employee.reload.update!(name: 'Mike')
+            employee.reload
+          end
+        end
+      end
+
+      it 'is 4 squares' do
+        expect(figure).to eq <<~EOS.chomp
+                        | 2022-04-23 18:06:06.712
+                        |    | 2022-05-01 18:06:06.712
+                        |    |              | 2022-05-23 18:06:06.712
+                        |    |              |                   | 9999-12-31 00:00:00.000
+2022-05-23 18:06:06.712                     +-------------------+
+                                            |                   |
+2022-06-01 18:06:06.712 +-------------------+                   |
+                        |                   |                   |
+                        |                   |                   |
+2022-06-23 18:06:06.712 +----+--------------+                   |
+                        |    |**************|                   |
+                        |    |**************|                   |
+                        |    |**************|                   |
+                        |    |**************|                   |
+9999-12-31 00:00:00.000 +----+--------------+-------------------+
+EOS
+      end
+    end
+
+    context 'when it has been updated so that it is not continuous' do
+      let(:employee) do
+        employee = Employee.create!
+
+        Timecop.freeze '2022-06-23 18:06:06.712' do
+          employee.update!(name: 'Jane')
+          employee.reload
+
+          employee.update_columns(valid_from: employee.valid_from + 1.second, transaction_from: employee.transaction_from + 1.second)
+          employee
+        end
+      end
+
+      it 'is 3 squares with blanks' do
+        expect(figure).to eq <<~EOS.chomp
+                        | 2022-05-23 18:06:06.712
+                        |                  | 2022-06-23 18:06:06.712
+                        |                  | | 2022-06-23 18:06:07.712
+                        |                  | |                  | 9999-12-31 00:00:00.000
+2022-05-23 18:06:06.712 +---------------------------------------+
+                        |                                       |
+                        |                                       |
+                        |                                       |
+2022-06-23 18:06:06.712 +------------------+--------------------+
+                        |                  |
+2022-06-23 18:06:07.712 |                  | +------------------+
+                        |                  | |******************|
+                        |                  | |******************|
+                        |                  | |******************|
+9999-12-31 00:00:00.000 +------------------+ +------------------+
+EOS
+      end
+    end
+
+    context 'when it has been deleted' do
+      let(:employee) do
+        employee = Employee.create!
+        Timecop.freeze '2022-06-23 18:06:06.712' do
+          employee.destroy!
+          employee
+        end
+      end
+
+      it 'is 2 squares' do
+        expect(figure).to eq <<~EOS.chomp
+                        | 2022-05-23 18:06:06.712
+                        |                   | 2022-06-23 18:06:06.712
+                        |                   |                   | 9999-12-31 00:00:00.000
+2022-05-23 18:06:06.712 +---------------------------------------+
+                        |***************************************|
+                        |***************************************|
+                        |***************************************|
+                        |***************************************|
+2022-06-23 18:06:06.712 +---------------------------------------+
+                        |                   |
+                        |                   |
+                        |                   |
+                        |                   |
+9999-12-31 00:00:00.000 +-------------------+
+EOS
+      end
+    end
+
+    context 'whe it has been force updated' do
+      let(:employee) do
+        employee = Employee.create!
+        Timecop.freeze '2022-06-23 18:06:06.712' do
+          employee.force_update { |employee| employee.update!(name: 'Jane') }
+          employee.reload
+        end
+      end
+
+      it 'is 2 squares' do
+        expect(figure).to eq <<~EOS.chomp
+                        | 2022-05-23 18:06:06.712
+                        |                                       | 9999-12-31 00:00:00.000
+2022-05-23 18:06:06.712 +---------------------------------------+
+                        |                                       |
+                        |                                       |
+                        |                                       |
+                        |                                       |
+2022-06-23 18:06:06.712 +---------------------------------------+
+                        |***************************************|
+                        |***************************************|
+                        |***************************************|
+                        |***************************************|
+9999-12-31 00:00:00.000 +---------------------------------------+
+EOS
+      end
+    end
+  end
+end


### PR DESCRIPTION
Although the Bi-temporal data model is a good data structure, it has a difficult problem to intuitively understand the data structure that has two times, valid time and transaction time.

This PR introduces a visualizer that plots multiple histories on a two-dimensional figure to help you understand the data structure. This visualizer draws the following history as follows:

|valid_from|valid_to|transaction_from|transaction_to|
|---|---|---|---|
| 2020-07-31 01:43:17.119 | 9999-12-31 09:00:00.000 | 2020-07-31 01:43:17.120 | 2020-07-31 01:43:18.243 |
| 2020-07-31 01:43:17.119 | 2020-07-31 01:43:18.243 | 2020-07-31 01:43:18.243 | 9999-12-31 09:00:00.000 |
| 2020-07-31 01:43:18.243 | 9999-12-31 09:00:00.000 | 2020-07-31 01:43:18.243 | 2020-07-31 01:43:18.324 |
| 2020-07-31 01:43:18.243 | 2020-07-31 01:43:18.324 | 2020-07-31 01:43:18.324 | 9999-12-31 09:00:00.000 |
| 2020-07-31 01:43:18.324 | 9999-12-31 09:00:00.000 | 2020-07-31 01:43:18.324 | 9999-12-31 09:00:00.000 |

```
[98] pry(main)> puts ActiveRecord::Bitemporal::Visualizer.visualize(employee)

                        | 2020-07-31 01:43:17.119
                        |                 | 2020-07-31 01:43:18.243
                        |                 | | 2020-07-31 01:43:18.324
                        |                 | |                   | 9999-12-31 09:00:00.000
2020-07-31 01:43:17.120 +---------------------------------------+
                        |                                       |
                        |                                       |
                        |                                       |
2020-07-31 01:43:18.243 +-----------------+---------------------+
                        |                 |                     |
2020-07-31 01:43:18.324 |                 +-+-------------------+
                        |                 | |*******************|
                        |                 | |*******************|
                        |                 | |*******************|
9999-12-31 09:00:00.000 +-----------------+-+-------------------+
```

The area filled with `*` is the duration of the instance passed to `visualize`. This makes it easier to understand where the history in the overall history.

Apart from `visualize`, `visualize_records` is also provided as a lower-level interface. This method allows you to pass histories and another history to highlight. The following is example:

```
ActiveRecord::Bitemporal::Visualizer.visualize_records(Employy.ignore_bitemporal_datetime.where("'2019-01-12' < valid_from"), [employee])
```

In the above example, unlike `visualize`, you can only draw histories after 2019-01-12, not all history. Alternatively, you can draw the temporal relationships of different associations.

```
ActiveRecord::Bitemporal::Visualizer.visualize_records(Employee.ignore_bitemporal_datetime, [department])
```