### PR TITLE
[Proposal] Changed `valid_in` to exclude `valid_from = to` and `valid_to = from`

### DIFF
--- a/spec/activerecord-bitemporal/scopes_spec.rb
+++ b/spec/activerecord-bitemporal/scopes_spec.rb
@@ -138,15 +138,15 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         it { is_expected.not_to match %r/"employees"."valid_from"/ }
       end
 
-      context "with (.._01_30)" do
-        let(:relation) { Employee.valid_in(.._01_30) }
+      context "with (..._01_30)" do
+        let(:relation) { Employee.valid_in(..._01_30) }
 
         it { is_expected.not_to match %r/"employees"."valid_to"/ }
         it { is_expected.to match %r/"employees"."valid_from" < '2019-01-29 15:00:00'/ }
       end
 
-      context "with (..._01_30)" do
-        let(:relation) { Employee.valid_in(..._01_30) }
+      context "with (.._01_30)" do
+        let(:relation) { Employee.valid_in(.._01_30) }
 
         it { is_expected.not_to match %r/"employees"."valid_to"/ }
         it { is_expected.to match %r/"employees"."valid_from" <= '2019-01-29 15:00:00'/ }

--- a/spec/activerecord-bitemporal/scopes_spec.rb
+++ b/spec/activerecord-bitemporal/scopes_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
     context "2019/1/20 - 2019/1/30" do
       let(:from) { "2019/1/20" }
       let(:to) { "2019/1/30" }
-      it { is_expected.to contain_exactly("Homu", "Jane", "Mami", "Tom", "Kevin", "Mado") }
+      it { is_expected.to contain_exactly("Mami", "Tom") }
     end
 
     describe ".to_sql" do
@@ -83,19 +83,84 @@ RSpec.describe ActiveRecord::Bitemporal::Scope do
         Time.zone = "Tokyo"
       end
       after { Time.zone = @old_time_zone }
-      let(:from) { "2019/1/20" }
-      let(:to) { "2019/1/30" }
-      subject { Employee.valid_in(from: from, to: to).to_sql }
-      it { is_expected.to match %r/"employees"."valid_to" >= '2019-01-19 15:00:00'/ }
-      it { is_expected.to match %r/"employees"."valid_from" <= '2019-01-29 15:00:00'/ }
+
+      let(:_01_20) { "2019/01/20" }
+      let(:_01_30) { "2019/01/30" }
+
+      subject { relation.to_sql }
+
+      context "with from: _01_20, to: _01_30" do
+        let(:relation) { Employee.valid_in(from: _01_20, to: _01_30) }
+
+        it { is_expected.to match %r/"employees"."valid_to" > '2019-01-19 15:00:00'/ }
+        it { is_expected.to match %r/"employees"."valid_from" < '2019-01-29 15:00:00'/ }
+      end
+
+      context "with from: _01_30, to: _01_20" do
+        let(:relation) { Employee.valid_in(from: _01_30, to: _01_20) }
+
+        it { is_expected.to match %r/"employees"."valid_to" > '2019-01-29 15:00:00'/ }
+        it { is_expected.to match %r/"employees"."valid_from" < '2019-01-19 15:00:00'/ }
+      end
+
+      context "with from: _01_20" do
+        let(:relation) { Employee.valid_in(from: _01_20) }
+
+        it { is_expected.to match %r/"employees"."valid_to" > '2019-01-19 15:00:00'/ }
+        it { is_expected.not_to match %r/"employees"."valid_from"/ }
+      end
+
+      context "with to: _01_30" do
+        let(:relation) { Employee.valid_in(to: _01_30) }
+
+        it { is_expected.not_to match %r/"employees"."valid_to"/ }
+        it { is_expected.to match %r/"employees"."valid_from" < '2019-01-29 15:00:00'/ }
+      end
+
+      context "with (_01_20..._01_30)" do
+        let(:relation) { Employee.valid_in(_01_20..._01_30) }
+
+        it { is_expected.to match %r/"employees"."valid_to" > '2019-01-19 15:00:00'/ }
+        it { is_expected.to match %r/"employees"."valid_from" < '2019-01-29 15:00:00'/ }
+      end
+
+      context "with (_01_20.._01_30)" do
+        let(:relation) { Employee.valid_in(_01_20.._01_30) }
+
+        it { is_expected.to match %r/"employees"."valid_to" > '2019-01-19 15:00:00'/ }
+        it { is_expected.to match %r/"employees"."valid_from" <= '2019-01-29 15:00:00'/ }
+      end
+
+      context "with (_01_20..)" do
+        let(:relation) { Employee.valid_in(_01_20..) }
+
+        it { is_expected.to match %r/"employees"."valid_to" > '2019-01-19 15:00:00'/ }
+        it { is_expected.not_to match %r/"employees"."valid_from"/ }
+      end
+
+      context "with (.._01_30)" do
+        let(:relation) { Employee.valid_in(.._01_30) }
+
+        it { is_expected.not_to match %r/"employees"."valid_to"/ }
+        it { is_expected.to match %r/"employees"."valid_from" < '2019-01-29 15:00:00'/ }
+      end
+
+      context "with (..._01_30)" do
+        let(:relation) { Employee.valid_in(..._01_30) }
+
+        it { is_expected.not_to match %r/"employees"."valid_to"/ }
+        it { is_expected.to match %r/"employees"."valid_from" <= '2019-01-29 15:00:00'/ }
+      end
     end
 
     describe ".arel.to_sql" do
       let(:from) { "2019/1/20" }
       let(:to) { "2019/1/30" }
+
       subject { Employee.valid_in(from: from, to: to).arel.to_sql }
-      it { is_expected.to match %r/"employees"."valid_to" >= \$3/ }
-      it { is_expected.to match %r/"employees"."valid_from" <= \$4/ }
+
+      it { is_expected.to match %r/"employees"."valid_to" > \$3/ }
+      it { is_expected.to match %r/"employees"."valid_from" < \$4/ }
     end
   end
 


### PR DESCRIPTION
## Summary

`valid_in` include `valid_from = to` and `valid_to = from`.

```
Code:  valid_in(from: 02/01, to: 05/01)
Query: from <= valid_to AND valid_from <= to

01/01         02/01         03/01         04/01         05/01         06/01
  |*************|*************|*************|*************|*************|
               ↑                                        ↑
              from(02/01)                                to(05/01)
```

However, in real-world use cases, you may not want to include `valid_from = to` and `valid_to = from`.
e.g. https://github.com/kufu/activerecord-bitemporal/pull/93/files#diff-77aac43b146505859dd74b1fd3e151c0e94174f5abc85475fe1dfba10a5c64bfR513

## Proposal

Changed `valid_in` to exclude `valid_from = to` and `valid_to = from`.

```
Code:  valid_in(from: 02/01, to: 05/01)
Query: from < valid_to AND valid_from < to

01/01         02/01         03/01         04/01         05/01         06/01
  |-------------|*************|*************|*************|-------------|
               ↑                                        ↑
              from(02/01)                                to(05/01)
```

Also, `Range` can be passed as an argument.
It behaves differently for `(from...to)` and `(from..to)`.

```
Code:  valid_in(02/01...05/01)
Query: from < valid_to AND valid_from < to

01/01         02/01         03/01         04/01         05/01         06/01
  |-------------|*************|*************|*************|-------------|
               ↑                                        ↑
              from(02/01)                                to(05/01)
```


```
Code:  valid_in(02/01..05/01)
Query: from < valid_to AND valid_from <= to

01/01         02/01         03/01         04/01         05/01         06/01
  |-------------|*************|*************|*************|*************|
               ↑                                        ↑
              from(02/01)                                to(05/01)
```
