### PR TITLE
Update `transaction_from` after `#update`.

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -321,6 +321,7 @@ module ActiveRecord
           # update 後に新しく生成したインスタンスのデータを移行する
           @_swapped_id = after_instance.swapped_id
           self.valid_from = after_instance.valid_from
+          self.transaction_from = after_instance.transaction_from
 
           1
         # MEMO: Must return false instead of nil, if `#_update_row` failure.

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -793,11 +793,13 @@ RSpec.describe ActiveRecord::Bitemporal do
       end
     end
 
-    describe "changed `valid_from` columns" do
+    describe "changed `valid_from` and `transaction_from` columns" do
       let(:employee) { Employee.create(name: "Jane", emp_code: "001") }
-      subject { -> { employee.update(name: "Tom") } }
+      subject { -> { employee.update!(name: "Tom") } }
+
       it { is_expected.to change(employee, :name).from("Jane").to("Tom") }
       it { is_expected.to change(employee, :valid_from) }
+      it { is_expected.to change(employee, :transaction_from) }
       # valid_to is fixed "9999/12/31"
       it { is_expected.not_to change(employee, :valid_to) }
       it { is_expected.not_to change(employee, :emp_code) }


### PR DESCRIPTION
Fixed `valid_from` is updated after `#update` but not `transaction_from`.

```ruby
employee = nil

Timecop.freeze("2020/09/01") {
  valid_datetime = "2020/06/01"
  ActiveRecord::Bitemporal.valid_at("2020/06/01") {
    employee = Employee.create(name: "hoge")
  }
}

Timecop.freeze("2020/09/02") {
  ActiveRecord::Bitemporal.valid_at("2020/07/01") {
    pp employee.valid_from.to_time         # => 2020-06-01 09:00:00 +0900
    pp employee.transaction_from.to_time   # => 2020-09-01 09:00:00 +0900

    employee.update!(name: "foo")

    # Updated valid_from
    pp employee.valid_from.to_time         # => 2020-07-01 09:00:00 +0900

    # Not updated transaction_from
    # Will be updated transaction_from, after fixed
    pp employee.transaction_from.to_time
    # Before => 2020-09-01 09:00:00 +0900
    # After  => 2020-09-02 09:00:00 +0900
  }
}
```

Often there are cases where you want to get the actual system time of operation after an update.

```ruby
employee.update!(name: "foo")
# want to see when `employee` was updated.
Event.create(event: :update, operated_at: employee.transaction_from)
```