### PR TITLE
replace postgres docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,17 +4,17 @@ executors:
   ruby_2_7:
     docker:
       - image: ruby:2.7.5
-      - image: circleci/postgres:11-alpine
+      - image: cimg/postgres:11.16
 
   ruby_3_0:
     docker:
       - image: ruby:3.0.3
-      - image: circleci/postgres:11-alpine
+      - image: cimg/postgres:11.16
 
   ruby_3_1:
     docker:
       - image: ruby:3.1.0
-      - image: circleci/postgres:11-alpine
+      - image: cimg/postgres:11.16
 
 commands:
   run_rspec:


### PR DESCRIPTION
## Description
`circleci/*` docker image is deprecated.
However, this project still uses `circleci/postgres` image.

## Changes
* Update CircleCI config
  * Use `cimg/postgres` image instead of `circleci/postgres` image

## Reference
https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034