### PR TITLE
Update `valid_to` after `#update`

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -321,6 +321,7 @@ module ActiveRecord
           # update 後に新しく生成したインスタンスのデータを移行する
           @_swapped_id = after_instance.swapped_id
           self.valid_from = after_instance.valid_from
+          self.valid_to = after_instance.valid_to
 
           1
         # MEMO: Must return false instead of nil, if `#_update_row` failure.

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -803,6 +803,22 @@ RSpec.describe ActiveRecord::Bitemporal do
       it { is_expected.not_to change(employee, :emp_code) }
     end
 
+    context 'when updated with valid_at in the past ' do
+      describe "changed `valid_to` columns" do
+        let(:employee) {
+          ActiveRecord::Bitemporal.valid_at("2019/05/01") {
+            Employee.create(name: "Jane", emp_code: "001")
+          }
+        }
+        subject { -> {
+          ActiveRecord::Bitemporal.valid_at("2019/04/01") { employee.update(name: "Tom") }
+        }}
+
+        it { is_expected.to change(employee, :valid_to).from(ActiveRecord::Bitemporal::DEFAULT_VALID_TO)
+                                                       .to(Time.utc(2019, 05, 01).in_time_zone) }
+      end
+    end
+
     context "in `#valid_at`" do
       describe "set transaction_to" do
         let(:employee) { Timecop.freeze("2019/1/1") { Employee.create!(name: "Jane") } }


### PR DESCRIPTION
Fixed `valid_from` is updated after `#update` but not `valid_to`.
As a use case, I'm thinking of referencing valid_to in the updated model callback(after_update) and saving it to another table.

```ruby
class Employee < ActiveRecord::Base
  include ActiveRecord::Bitemporal

  after_update do
    # save the valid_from / valid_to of the event after updating
    Event.create(event: :update, valid_from: valid_from, valid_to: valid_to)
  end
end

employee = nil

ActiveRecord::Bitemporal.valid_at("2019/05/01") {
  employee = Employee.create(name: "Jane")
}
ActiveRecord::Bitemporal.valid_at("2019/04/01") {
  employee.update(name: "Jane")
}

update_event = Event.where(event: :update).order(:created_at).last
# Not updated transaction_from
# Will be updated transaction_from, after fixed
pp update_event.valid_to.to_time
# Before => 9999-12-31 09:00:00 +0900
# After  => 2019-05-01 09:00:00 +0900
```