### PR TITLE
:tada: Bump v2.0.1 :tada: 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.0.1
+
+### Breaking Changed
+
+### Added
+- [Update valid_to after #update](https://github.com/kufu/activerecord-bitemporal/pull/105)
+- [Add GitHub Actions workflow to release to RubyGems.org](https://github.com/kufu/activerecord-bitemporal/pull/104)
+- [migrate Scheduled workflows in CircleCI](https://github.com/kufu/activerecord-bitemporal/pull/106)
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
 ## 2.0.0
 
 ### Breaking Changed

--- a/lib/activerecord-bitemporal/version.rb
+++ b/lib/activerecord-bitemporal/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   module Bitemporal
-    VERSION = "2.0.0"
+    VERSION = "2.0.1"
   end
 end


### PR DESCRIPTION
## 2.0.1

### Breaking Changed

### Added
- [Update valid_to after #update](https://github.com/kufu/activerecord-bitemporal/pull/105)
- [Add GitHub Actions workflow to release to RubyGems.org](https://github.com/kufu/activerecord-bitemporal/pull/104)
- [migrate Scheduled workflows in CircleCI](https://github.com/kufu/activerecord-bitemporal/pull/106)

### Changed

### Deprecated

### Removed

### Fixed