### PR TITLE
Add support changing swapped_id, when called `# destroy`.

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -345,10 +345,10 @@ module ActiveRecord
             duplicated_instance.valid_to = target_datetime
             duplicated_instance.transaction_from = current_time
             duplicated_instance.save!(validate: false)
+            @_swapped_id = duplicated_instance.swapped_id if @destroyed
           }
           raise ActiveRecord::RecordInvalid unless @destroyed
 
-          @_swapped_id = duplicated_instance.swapped_id
           self
         end
       rescue => e

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -348,6 +348,7 @@ module ActiveRecord
           }
           raise ActiveRecord::RecordInvalid unless @destroyed
 
+          @_swapped_id = duplicated_instance.swapped_id
           self
         end
       rescue => e

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -1042,6 +1042,7 @@ RSpec.describe ActiveRecord::Bitemporal do
     it { is_expected.not_to change(employee, :valid_to) }
     it { is_expected.to change(employee, :transaction_to).from(ActiveRecord::Bitemporal::DEFAULT_TRANSACTION_TO).to(destroyed_time) }
     it { is_expected.to change { Employee.ignore_valid_datetime.within_deleted.count }.by(1) }
+    it { is_expected.to change(employee, :swapped_id) }
     it { expect(subject.call).to eq employee }
 
     it do

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -1082,6 +1082,7 @@ RSpec.describe ActiveRecord::Bitemporal do
       shared_examples "return false and #destroyed? to be false" do
         it { is_expected.not_to change(employee, :destroyed?) }
         it { is_expected.not_to change { Employee.ignore_valid_datetime.count } }
+        it { is_expected.not_to change(employee, :swapped_id) }
         it { expect(subject.call).to eq false }
         it do
           subject.call


### PR DESCRIPTION
updated after `#destroy` but not `swapped_id`.
As a use case, I'm thinking of referencing swapped_id in the destroyed model callback(after_destroy) and saving it to another table.

```ruby
class Employee < ActiveRecord::Base
  include ActiveRecord::Bitemporal

  after_destroy do
    # save the swapped_id of the event after destroy
    Event.create(event: :destroy, after_swapped_id:  swapped_id)
  end
end

employee = nil

employee = Employee.create(name: "Jane")
pp employee.swapped_id
# => 1
employee.destroy
pp employee.swapped_id
# Before => 1
# After => 2