### PR TITLE
:tada: Bump v2.2.0 :tada:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Added
 - [replace postgres docker image](https://github.com/kufu/activerecord-bitemporal/pull/103)
 - [use Matrix Jobs in CircleCI](https://github.com/kufu/activerecord-bitemporal/pull/107)
-- [Add support changing swapped_id, when called # destroy](https://github.com/kufu/activerecord-bitemporal/pull/110)
+- [Add support changing swapped_id, when called #destroy](https://github.com/kufu/activerecord-bitemporal/pull/110)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.2.0
+
+### Breaking Changed
+
+### Added
+- [replace postgres docker image ](https://github.com/kufu/activerecord-bitemporal/pull/103)
+- [use Matrix Jobs in CircleCI](https://github.com/kufu/activerecord-bitemporal/pull/107)
+- [Add support changing swapped_id, when called # destroy](https://github.com/kufu/activerecord-bitemporal/pull/110)
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
 ## 2.1.0
 
 ### Breaking Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Breaking Changed
 
 ### Added
-- [replace postgres docker image ](https://github.com/kufu/activerecord-bitemporal/pull/103)
+- [replace postgres docker image](https://github.com/kufu/activerecord-bitemporal/pull/103)
 - [use Matrix Jobs in CircleCI](https://github.com/kufu/activerecord-bitemporal/pull/107)
 - [Add support changing swapped_id, when called # destroy](https://github.com/kufu/activerecord-bitemporal/pull/110)
 

--- a/lib/activerecord-bitemporal/version.rb
+++ b/lib/activerecord-bitemporal/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   module Bitemporal
-    VERSION = "2.1.0"
+    VERSION = "2.2.0"
   end
 end


### PR DESCRIPTION
## 2.2.0

### Breaking Changed

### Added
- [replace postgres docker image ](https://github.com/kufu/activerecord-bitemporal/pull/103)
- [use Matrix Jobs in CircleCI](https://github.com/kufu/activerecord-bitemporal/pull/107)
- [Add support changing swapped_id, when called # destroy](https://github.com/kufu/activerecord-bitemporal/pull/110)

### Changed

### Deprecated

### Removed

### Fixed