### PR TITLE
Bump up version to v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2.3.0
+
+### Breaking Changed
+
+### Added
+- [Add `InstanceMethods#swapped_id_previously_was`](https://github.com/kufu/activerecord-bitemporal/pull/114)
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
 ## 2.2.0
 
 ### Breaking Changed

--- a/lib/activerecord-bitemporal/version.rb
+++ b/lib/activerecord-bitemporal/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   module Bitemporal
-    VERSION = "2.2.0"
+    VERSION = "2.3.0"
   end
 end


### PR DESCRIPTION
## 2.3.0

### Breaking Changed

### Added
- [Add `InstanceMethods#swapped_id_previously_was`](https://github.com/kufu/activerecord-bitemporal/pull/114)

### Changed

### Deprecated

### Removed

### Fixed
