### PR TITLE
Bump up version to v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 3.0.0
+
+### Breaking Changed
+- [Assign updated bitemporal times to the receiver after update/destroy](https://github.com/kufu/activerecord-bitemporal/pull/118)
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
 ## 2.3.0
 
 ### Breaking Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,18 @@
 PATH
   remote: .
   specs:
-    activerecord-bitemporal (0.1.0)
+    activerecord-bitemporal (3.0.0)
       activerecord (>= 5.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.0.4.1)
-      activesupport (= 7.0.4.1)
-    activerecord (7.0.4.1)
-      activemodel (= 7.0.4.1)
-      activesupport (= 7.0.4.1)
-    activesupport (7.0.4.1)
+    activemodel (7.0.4.2)
+      activesupport (= 7.0.4.2)
+    activerecord (7.0.4.2)
+      activemodel (= 7.0.4.2)
+      activesupport (= 7.0.4.2)
+    activesupport (7.0.4.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -23,7 +23,7 @@ GEM
       thor (>= 0.14.0)
     byebug (10.0.2)
     coderay (1.1.2)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.0)
     database_cleaner (1.7.0)
     diff-lcs (1.3)
     i18n (1.12.0)
@@ -53,7 +53,7 @@ GEM
     rspec-support (3.8.0)
     thor (0.20.3)
     timecop (0.9.1)
-    tzinfo (2.0.5)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 
 PLATFORMS

--- a/lib/activerecord-bitemporal/version.rb
+++ b/lib/activerecord-bitemporal/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   module Bitemporal
-    VERSION = "2.3.0"
+    VERSION = "3.0.0"
   end
 end


### PR DESCRIPTION
## 3.0.0

### Breaking Changed
- [Assign updated bitemporal times to the receiver after update/destroy](https://github.com/kufu/activerecord-bitemporal/pull/118)

### Added

### Changed

### Deprecated

### Removed

### Fixed