### PR TITLE
Add support `bitemporal_callbacks`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## Unreleased
+
+### Breaking Changed
+
+### Added
+
+- [Add support `bitemporal_callbacks`](https://github.com/kufu/activerecord-bitemporal/pull/123)
+
+  ```rb
+  class Employee < ActiveRecord::Base
+    include ActiveRecord::Bitemporal
+  
+    after_bitemporal_create :log_create
+    after_bitemporal_update :log_update
+    after_bitemporal_destroy :log_destroy
+  
+    private
+    
+    def log_create
+      puts "employee created"
+    end
+
+    def log_update
+      puts "employee updated"
+    end
+
+    def log_destroy
+      puts "employee destroyed"
+    end
+  end
+  
+  employee = Employee.create!(...) # => "employee created"
+  employee.update!(...) # => "employee updated"
+  employee.destroy! # => "employee destroyed"
+  ```
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+
 ## 3.0.0
 
 ### Breaking Changed

--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -7,6 +7,7 @@ require "activerecord-bitemporal/scope"
 require "activerecord-bitemporal/patches"
 require "activerecord-bitemporal/version"
 require "activerecord-bitemporal/visualizer"
+require "activerecord-bitemporal/callbacks"
 
 module ActiveRecord::Bitemporal
   DEFAULT_VALID_FROM = Time.utc(1900, 12, 31).in_time_zone.freeze
@@ -123,6 +124,7 @@ module ActiveRecord::Bitemporal::Bitemporalize
     extend ClassMethods
     include InstanceMethods
     include ActiveRecord::Bitemporal::Scope
+    include ActiveRecord::Bitemporal::Callbacks
 
     if enable_merge_with_except_bitemporal_default_scope
       relation_delegate_class(ActiveRecord::Relation).prepend ActiveRecord::Bitemporal::Relation::MergeWithExceptBitemporalDefaultScope

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -317,9 +317,9 @@ module ActiveRecord
         # MEMO: このメソッドに来るまでに validation が発動しているので、以後 validate は考慮しなくて大丈夫
         ActiveRecord::Base.transaction(requires_new: true) do
           current_valid_record&.update_transaction_to(current_valid_record.transaction_to)
-          before_instance&.save!(validate: false)
+          before_instance&.save_without_bitemporal_callbacks!(validate: false)
           # NOTE: after_instance always exists
-          after_instance.save!(validate: false)
+          after_instance.save_without_bitemporal_callbacks!(validate: false)
 
           # update 後に新しく生成したインスタンスのデータを移行する
           @_swapped_id_previously_was = swapped_id
@@ -350,7 +350,7 @@ module ActiveRecord
             # 削除時の状態を履歴レコードとして保存する
             duplicated_instance.valid_to = target_datetime
             duplicated_instance.transaction_from = current_time
-            duplicated_instance.save!(validate: false)
+            duplicated_instance.save_without_bitemporal_callbacks!(validate: false)
             if @destroyed
               @_swapped_id_previously_was = swapped_id
               @_swapped_id = duplicated_instance.swapped_id

--- a/lib/activerecord-bitemporal/callbacks.rb
+++ b/lib/activerecord-bitemporal/callbacks.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module ActiveRecord::Bitemporal
+  module Callbacks
+    extend ActiveSupport::Concern
+
+    included do
+      define_model_callbacks :bitemporal_create
+      define_model_callbacks :bitemporal_update
+      define_model_callbacks :bitemporal_destroy
+    end
+
+    def destroy
+      perform_bitemporal_callbacks? ? run_callbacks(:bitemporal_destroy) { super } : super
+    end
+
+    def save_without_bitemporal_callbacks!(...)
+      with_bitemporal_option(ignore_bitemporal_callbacks: true) {
+        save!(...)
+      }
+    end
+
+    private
+
+    def _create_record
+      perform_bitemporal_callbacks? ? run_callbacks(:bitemporal_create) { super } : super
+    end
+
+    def _update_record(*)
+      perform_bitemporal_callbacks? ? run_callbacks(:bitemporal_update) { super } : super
+    end
+
+    def perform_bitemporal_callbacks?
+      bitemporal_option[:ignore_bitemporal_callbacks] != true
+    end
+  end
+end

--- a/spec/activerecord-bitemporal/callbacks_spec.rb
+++ b/spec/activerecord-bitemporal/callbacks_spec.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+ActiveRecord::Schema.define(version: 1) do
+  create_table :job_titles, force: true do |t|
+    t.string :name
+
+    t.integer :employee_id
+
+    t.integer :bitemporal_id
+    t.datetime :valid_from
+    t.datetime :valid_to
+    t.datetime :deleted_at
+    t.datetime :transaction_from
+    t.datetime :transaction_to
+
+    t.timestamps
+  end
+end
+
+module BitemporalCallbacksLoggable
+  extend ActiveSupport::Concern
+
+  included do
+    attr_accessor :log
+    after_initialize { @log = [] }
+
+    [:before_bitemporal_create, :after_bitemporal_create,
+     :before_bitemporal_update, :after_bitemporal_update,
+     :before_bitemporal_destroy, :after_bitemporal_destroy
+    ].each do |callback_method|
+      send(callback_method, Proc.new { |model| model.log << callback_method })
+    end
+  end
+
+  def clear_log
+    @log.clear
+  end
+end
+
+class JobTitle < ActiveRecord::Base
+  include ActiveRecord::Bitemporal
+  include BitemporalCallbacksLoggable
+
+  belongs_to :employee
+end
+
+class EmployeeWithBitemporalCallbacksLog < Employee
+  include BitemporalCallbacksLoggable
+  has_one :job_title, foreign_key: :employee_id, dependent: :destroy
+  accepts_nested_attributes_for :job_title, allow_destroy: true
+end
+
+RSpec.describe ActiveRecord::Bitemporal::Callbacks do
+  describe "bitemporal_create" do
+    let(:employee) { EmployeeWithBitemporalCallbacksLog.new(name: "Jane") }
+    subject { employee.save! }
+
+    context 'without option `ignore_bitemporal_callbacks`' do
+      it { expect { subject }.to change(employee, :log).from([]).to(%i[before_bitemporal_create after_bitemporal_create]) }
+    end
+
+    context 'with option `ignore_bitemporal_callbacks: false`' do
+      before { employee.bitemporal_option_merge!(ignore_bitemporal_callbacks: false) }
+      it { expect { subject }.to change(employee, :log).from([]).to(%i[before_bitemporal_create after_bitemporal_create]) }
+    end
+
+    context 'with option `ignore_bitemporal_callbacks: true`' do
+      before { employee.bitemporal_option_merge!(ignore_bitemporal_callbacks: true) }
+      it { expect { subject }.not_to change(employee, :log) }
+    end
+
+    context 'nested_attributes' do
+      before { employee.build_job_title(name: "CEO") }
+
+      context 'without option `ignore_bitemporal_callbacks`' do
+        it { expect { subject }.to change(employee, :log).from([]).to(%i[before_bitemporal_create after_bitemporal_create]) }
+        it { expect { subject }.to change { employee.job_title.log }.from([]).to(%i[before_bitemporal_create after_bitemporal_create]) }
+      end
+
+      context 'employee with option `ignore_bitemporal_callbacks: true`' do
+        before { employee.bitemporal_option_merge!(ignore_bitemporal_callbacks: true) }
+        it { expect { subject }.not_to change(employee, :log) }
+        it { expect { subject }.to change { employee.job_title.log }.from([]).to(%i[before_bitemporal_create after_bitemporal_create]) }
+      end
+
+      context 'job_title with option `ignore_bitemporal_callbacks: true`' do
+        before { employee.job_title.bitemporal_option_merge!(ignore_bitemporal_callbacks: true) }
+        it { expect { subject }.to change(employee, :log).from([]).to(%i[before_bitemporal_create after_bitemporal_create]) }
+        it { expect { subject }.not_to change { employee.job_title.log } }
+      end
+    end
+  end
+
+  describe "bitemporal_update" do
+    let(:employee) { EmployeeWithBitemporalCallbacksLog.create!(name: "Jane").tap(&:clear_log) }
+    subject { employee.update!(name: "Tom") }
+
+    context 'without option `ignore_bitemporal_callbacks`' do
+      it { expect { subject }.to change(employee, :log).from([]).to(%i[before_bitemporal_update after_bitemporal_update]) }
+    end
+
+    context 'with option `ignore_bitemporal_callbacks: false`' do
+      before { employee.bitemporal_option_merge!(ignore_bitemporal_callbacks: false) }
+      it { expect { subject }.to change(employee, :log).from([]).to(%i[before_bitemporal_update after_bitemporal_update]) }
+    end
+
+    context 'with option `ignore_bitemporal_callbacks: true`' do
+      before { employee.bitemporal_option_merge!(ignore_bitemporal_callbacks: true) }
+      it { expect { subject }.not_to change(employee, :log) }
+    end
+
+    context 'has_one relation' do
+      let(:employee) {
+        EmployeeWithBitemporalCallbacksLog.create!(name: "Jane").tap { |e|
+          e.create_job_title!(name: "CEO").tap(&:clear_log)
+          e.clear_log
+        }
+      }
+
+      context 'with assign_nested_attributes' do
+        subject {
+          employee.assign_attributes({ name: "Tom", job_title_attributes: { id: employee.job_title.id, name: "COO" } })
+          employee.save!
+        }
+
+        context 'without option `ignore_bitemporal_callbacks`' do
+          it { expect { subject }.to change(employee, :log).from([]).to(%i[before_bitemporal_update after_bitemporal_update]) }
+          it { expect { subject }.to change { employee.job_title.log }.from([]).to(%i[before_bitemporal_update after_bitemporal_update]) }
+        end
+
+        context 'employee with option `ignore_bitemporal_callbacks: true`' do
+          before { employee.bitemporal_option_merge!(ignore_bitemporal_callbacks: true) }
+          it { expect { subject }.not_to change(employee, :log) }
+          it { expect { subject }.not_to change { employee.job_title.log } }
+        end
+
+        context 'job_title with option `ignore_bitemporal_callbacks: true`' do
+          before { employee.job_title.bitemporal_option_merge!(ignore_bitemporal_callbacks: true) }
+          it { expect { subject }.to change(employee, :log).from([]).to(%i[before_bitemporal_update after_bitemporal_update]) }
+          it { expect { subject }.not_to change { employee.job_title.log } }
+        end
+      end
+
+      context 'with _assign_attribute' do
+        subject {
+          employee.name = "Tom"
+          employee.job_title.name = "COO"
+          employee.save!
+        }
+
+        context 'without option `ignore_bitemporal_callbacks`' do
+          it { expect { subject }.to change(employee, :log).from([]).to(%i[before_bitemporal_update after_bitemporal_update]) }
+          it { expect { subject }.to change { employee.job_title.log }.from([]).to(%i[before_bitemporal_update after_bitemporal_update]) }
+        end
+
+        context 'employee with option `ignore_bitemporal_callbacks: true`' do
+          before { employee.bitemporal_option_merge!(ignore_bitemporal_callbacks: true) }
+          it { expect { subject }.not_to change(employee, :log) }
+          it { expect { subject }.to change { employee.job_title.log }.from([]).to(%i[before_bitemporal_update after_bitemporal_update]) }
+        end
+
+        context 'job_title with option `ignore_bitemporal_callbacks: true`' do
+          before { employee.job_title.bitemporal_option_merge!(ignore_bitemporal_callbacks: true) }
+          it { expect { subject }.to change(employee, :log).from([]).to(%i[before_bitemporal_update after_bitemporal_update]) }
+          it { expect { subject }.not_to change { employee.job_title.log } }
+        end
+      end
+    end
+  end
+
+  describe "bitemporal_destroy" do
+    let(:employee) { EmployeeWithBitemporalCallbacksLog.create!(name: "Jane").tap(&:clear_log) }
+    subject { employee.destroy! }
+
+    context 'without option `ignore_bitemporal_callbacks`' do
+      it { expect { subject }.to change(employee, :log).from([]).to(%i[before_bitemporal_destroy after_bitemporal_destroy]) }
+    end
+
+    context 'with option `ignore_bitemporal_callbacks: false`' do
+      before { employee.bitemporal_option_merge!(ignore_bitemporal_callbacks: false) }
+      it { expect { subject }.to change(employee, :log).from([]).to(%i[before_bitemporal_destroy after_bitemporal_destroy]) }
+    end
+
+    context 'with option `ignore_bitemporal_callbacks: true`' do
+      before { employee.bitemporal_option_merge!(ignore_bitemporal_callbacks: true) }
+      it { expect { subject }.not_to change(employee, :log) }
+    end
+
+    context 'has_one relation' do
+      let(:employee) {
+        EmployeeWithBitemporalCallbacksLog.create!(name: "Jane").tap { |e|
+          e.create_job_title!(name: "CEO").tap(&:clear_log)
+          e.clear_log
+        }
+      }
+
+      context 'with `dependent: :destroy`' do
+        subject { employee.destroy! }
+
+        context 'without option `ignore_bitemporal_callbacks`' do
+          it { expect { subject }.to change(employee, :log).from([]).to(%i[before_bitemporal_destroy after_bitemporal_destroy]) }
+          it { expect { subject }.to change { employee.job_title.log }.from([]).to(%i[before_bitemporal_destroy after_bitemporal_destroy]) }
+        end
+
+        context 'employee with option `ignore_bitemporal_callbacks: true`' do
+          before { employee.bitemporal_option_merge!(ignore_bitemporal_callbacks: true) }
+          it { expect { subject }.not_to change(employee, :log) }
+          it { expect { subject }.to change { employee.job_title.log }.from([]).to(%i[before_bitemporal_destroy after_bitemporal_destroy]) }
+        end
+
+        context 'job_title with option `ignore_bitemporal_callbacks: true`' do
+          before { employee.job_title.bitemporal_option_merge!(ignore_bitemporal_callbacks: true) }
+          it { expect { subject }.to change(employee, :log).from([]).to(%i[before_bitemporal_destroy after_bitemporal_destroy]) }
+          it { expect { subject }.not_to change { employee.job_title.log } }
+        end
+      end
+
+      context 'with nested_attributes' do
+        subject {
+          employee.assign_attributes({ job_title_attributes: { id: employee.job_title.id, _destroy: true } })
+          employee.save!
+        }
+
+        context 'without option `ignore_bitemporal_callbacks`' do
+          it { expect { subject }.to change { employee.job_title.log }.from([]).to(%i[before_bitemporal_destroy after_bitemporal_destroy]) }
+        end
+
+        context 'employee with option `ignore_bitemporal_callbacks: true`' do
+          before { employee.bitemporal_option_merge!(ignore_bitemporal_callbacks: true) }
+          it { expect { subject }.to change { employee.job_title.log }.from([]).to(%i[before_bitemporal_destroy after_bitemporal_destroy]) }
+        end
+
+        context 'job_title with option `ignore_bitemporal_callbacks: true`' do
+          before { employee.job_title.bitemporal_option_merge!(ignore_bitemporal_callbacks: true) }
+          it { expect { subject }.not_to change { employee.job_title.log } }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

When using `ActiveRecord::Callbacks`, create callback is also called on `#update` and `#destroy` because there is an implicit record creation process in `ActievRecord::Bitemporal`.

This PR adds bitemporal callbacks like `after_bitemporal_create`, `after_bitemporal_update` and `after_bitemporal_destroy` that does not call create callback on `#update` and `#destroy`.

Below is a sample code.

## Sample Code

### when use `ActiveRecord::Callbacks`

```rb
class Company < ActiveRecord::Base
  include ActiveRecord::Bitemporal

  [:after_create, :after_update, :after_destroy].each do |callback_method|
    send(callback_method, Proc.new { pp callback_method })
  end
end

company = Company.create!(name: "A")
# => :after_create

company.update!(name: "B")
# => :after_create
#    :after_create
#    :after_update

company.destroy!
# => :after_create
#    :after_destroy
```

### when use `ActiveRecord::Bitemporal::Callbacks`

```rb
class Company < ActiveRecord::Base
  include ActiveRecord::Bitemporal

  [:after_bitemporal_create, :after_bitemporal_update, :after_bitemporal_destroy].each do |callback_method|
    send(callback_method, Proc.new { pp callback_method })
  end
end

company = Company.create!(name: "A")
# => :after_bitemporal_create

company.update!(name: "B")
# => :after_bitemporal_update

company.destroy!
# => :after_bitemporal_destroy
```