### PR TITLE
Add required_ruby_version >= 2.7.0

### DIFF
--- a/activerecord-bitemporal.gemspec
+++ b/activerecord-bitemporal.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Enable ActiveRecord models to be handled as BiTemporal Data Model.}
   spec.homepage      = "https://github.com/kufu/activerecord-bitemporal"
   spec.license       = "Apache 2.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})


### PR DESCRIPTION
## Summary

Drop support for EOL Ruby versions.
CI had already dropped support for Ruby 2.6 https://github.com/kufu/activerecord-bitemporal/pull/91 .
