### PR TITLE
add label option

### DIFF
--- a/lib/activerecord-bitemporal/visualizer.rb
+++ b/lib/activerecord-bitemporal/visualizer.rb
@@ -21,18 +21,18 @@ module ActiveRecord::Bitemporal
 
     module_function
 
-    def visualize(record, height: 10, width: 40, highlight: true, label: false)
+    def visualize(record, height: 10, width: 40, highlight: true)
       histories = record.class.ignore_bitemporal_datetime.bitemporal_for(record).order(:transaction_from, :valid_from)
 
       if highlight
-        visualize_records(histories, [record], height: height, width: width, label: label)
+        visualize_records(histories, [record], height: height, width: width)
       else
-        visualize_records(histories, height: height, width: width, label: label)
+        visualize_records(histories, height: height, width: width)
       end
     end
 
     # e.g. visualize_records(ActiveRecord::Relation, ActiveRecord::Relation)
-    def visualize_records(*relations, height: 10, width: 40, label: false)
+    def visualize_records(*relations, height: 10, width: 40)
       raise 'More than 3 relations are not supported' if relations.size >= 3
       records = relations.flatten
 
@@ -92,17 +92,16 @@ module ActiveRecord::Bitemporal
         end
       end
 
-      if label
-        transaction_label = 'transaction_datetime'
-        right_margin = time_length + 1 - transaction_label.size
-        if right_margin >= 0
-          "#{transaction_label + ' ' * right_margin}| valid_datetime\n#{headers.to_s}\n#{body.to_s}"
-        else
-          "#{transaction_label[0...right_margin]}| valid_datetime\n#{headers.to_s}\n#{body.to_s}"
-        end
+      transaction_label = 'transaction_datetime'
+      right_margin = time_length + 1 - transaction_label.size
+
+      label = if right_margin >= 0
+        "#{transaction_label + ' ' * right_margin}| valid_datetime"
       else
-        "#{headers.to_s}\n#{body.to_s}"
+        "#{transaction_label[0...right_margin]}| valid_datetime"
       end
+
+      "#{label}\n#{headers.to_s}\n#{body.to_s}"
     end
   
     # Compute a dictionary of where each time should be plotted.

--- a/lib/activerecord-bitemporal/visualizer.rb
+++ b/lib/activerecord-bitemporal/visualizer.rb
@@ -21,18 +21,18 @@ module ActiveRecord::Bitemporal
 
     module_function
 
-    def visualize(record, height: 10, width: 40, highlight: true)
+    def visualize(record, height: 10, width: 40, highlight: true, label: false)
       histories = record.class.ignore_bitemporal_datetime.bitemporal_for(record).order(:transaction_from, :valid_from)
 
       if highlight
-        visualize_records(histories, [record], height: height, width: width)
+        visualize_records(histories, [record], height: height, width: width, label: label)
       else
-        visualize_records(histories, height: height, width: width)
+        visualize_records(histories, height: height, width: width, label: label)
       end
     end
 
     # e.g. visualize_records(ActiveRecord::Relation, ActiveRecord::Relation)
-    def visualize_records(*relations, height: 10, width: 40)
+    def visualize_records(*relations, height: 10, width: 40, label: false)
       raise 'More than 3 relations are not supported' if relations.size >= 3
       records = relations.flatten
 
@@ -91,8 +91,18 @@ module ActiveRecord::Bitemporal
           end
         end
       end
-  
-      "#{headers.to_s}\n#{body.to_s}"
+
+      if label
+        transaction_label = 'transaction_datetime'
+        right_margin = time_length + 1 - transaction_label.size
+        if right_margin >= 0
+          "#{transaction_label + ' ' * right_margin}| valid_datetime\n#{headers.to_s}\n#{body.to_s}"
+        else
+          "#{transaction_label[0...right_margin]}| valid_datetime\n#{headers.to_s}\n#{body.to_s}"
+        end
+      else
+        "#{headers.to_s}\n#{body.to_s}"
+      end
     end
   
     # Compute a dictionary of where each time should be plotted.

--- a/spec/activerecord-bitemporal/visualizer_spec.rb
+++ b/spec/activerecord-bitemporal/visualizer_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe ActiveRecord::Bitemporal::Visualizer do
 
       it 'is a square' do
         expect(figure).to eq <<~EOS.chomp
+transaction_datetime    | valid_datetime
                         | 2022-05-23 18:06:06.712
                         |                                       | 9999-12-31 00:00:00.000
 2022-05-23 18:06:06.712 +---------------------------------------+
@@ -41,6 +42,7 @@ EOS
 
       it 'is 3 squares' do
         expect(figure).to eq <<~EOS.chomp
+transaction_datetime    | valid_datetime
                         | 2022-05-23 18:06:06.712
                         |                   | 2022-06-23 18:06:06.712
                         |                   |                   | 9999-12-31 00:00:00.000
@@ -74,6 +76,7 @@ EOS
 
       it 'is 5 squares' do
         expect(figure).to eq <<~EOS.chomp
+transaction_datetime    | valid_datetime
                         | 2022-05-23 18:06:06.712
                         |    | 2022-06-01 18:06:06.712
                         |    |              | 2022-06-23 18:06:06.712
@@ -112,6 +115,7 @@ EOS
 
       it 'is plotted in the smallest area' do
         expect(figure).to eq <<~EOS.chomp
+transaction_datetime    | valid_datetime
                         | 2022-05-23 18:06:06.712
                         | | 2022-05-23 18:06:06.831
                         | | | 2022-05-23 18:06:07.939
@@ -156,6 +160,7 @@ EOS
 
       it 'is plotted as zero length history' do
         expect(figure).to eq <<~EOS.chomp
+transaction_datetime    | valid_datetime
                         | 2022-05-23 18:06:06.712
                         |    | 2022-06-01 18:06:06.712
                         |    |              | 2022-06-23 18:06:06.712
@@ -192,6 +197,7 @@ EOS
 
       it 'is plotted as zero area history' do
         expect(figure).to eq <<~EOS.chomp
+transaction_datetime    | valid_datetime
                         | 2022-05-23 18:06:06.712
                         |                   | 2022-06-01 18:06:06.712
                         |                   |                   | 9999-12-31 00:00:00.000
@@ -229,6 +235,7 @@ EOS
 
       it 'is 4 squares' do
         expect(figure).to eq <<~EOS.chomp
+transaction_datetime    | valid_datetime
                         | 2022-04-23 18:06:06.712
                         |    | 2022-05-01 18:06:06.712
                         |    |              | 2022-05-23 18:06:06.712
@@ -263,6 +270,7 @@ EOS
 
       it 'is 3 squares with blanks' do
         expect(figure).to eq <<~EOS.chomp
+transaction_datetime    | valid_datetime
                         | 2022-05-23 18:06:06.712
                         |                  | 2022-06-23 18:06:06.712
                         |                  | | 2022-06-23 18:06:07.712
@@ -293,6 +301,7 @@ EOS
 
       it 'is 2 squares' do
         expect(figure).to eq <<~EOS.chomp
+transaction_datetime    | valid_datetime
                         | 2022-05-23 18:06:06.712
                         |                   | 2022-06-23 18:06:06.712
                         |                   |                   | 9999-12-31 00:00:00.000
@@ -322,6 +331,7 @@ EOS
 
       it 'is 2 squares' do
         expect(figure).to eq <<~EOS.chomp
+transaction_datetime    | valid_datetime
                         | 2022-05-23 18:06:06.712
                         |                                       | 9999-12-31 00:00:00.000
 2022-05-23 18:06:06.712 +---------------------------------------+
@@ -335,37 +345,6 @@ EOS
                         |***************************************|
                         |***************************************|
 9999-12-31 00:00:00.000 +---------------------------------------+
-EOS
-      end
-    end
-
-    describe 'label' do
-      subject(:figure) { described_class.visualize(employee, label: true) }
-      let(:employee) do
-        employee = Employee.create!
-        Timecop.freeze '2022-06-23 18:06:06.712' do
-          employee.update!(name: 'Jane')
-          employee.reload
-        end
-      end
-
-      it 'has label' do
-        expect(figure).to eq <<~EOS.chomp
-transaction_datetime    | valid_datetime
-                        | 2022-05-23 18:06:06.712
-                        |                   | 2022-06-23 18:06:06.712
-                        |                   |                   | 9999-12-31 00:00:00.000
-2022-05-23 18:06:06.712 +---------------------------------------+
-                        |                                       |
-                        |                                       |
-                        |                                       |
-                        |                                       |
-2022-06-23 18:06:06.712 +-------------------+-------------------+
-                        |                   |*******************|
-                        |                   |*******************|
-                        |                   |*******************|
-                        |                   |*******************|
-9999-12-31 00:00:00.000 +-------------------+-------------------+
 EOS
       end
     end

--- a/spec/activerecord-bitemporal/visualizer_spec.rb
+++ b/spec/activerecord-bitemporal/visualizer_spec.rb
@@ -338,5 +338,36 @@ EOS
 EOS
       end
     end
+
+    describe 'label' do
+      subject(:figure) { described_class.visualize(employee, label: true) }
+      let(:employee) do
+        employee = Employee.create!
+        Timecop.freeze '2022-06-23 18:06:06.712' do
+          employee.update!(name: 'Jane')
+          employee.reload
+        end
+      end
+
+      it 'has label' do
+        expect(figure).to eq <<~EOS.chomp
+transaction_datetime    | valid_datetime
+                        | 2022-05-23 18:06:06.712
+                        |                   | 2022-06-23 18:06:06.712
+                        |                   |                   | 9999-12-31 00:00:00.000
+2022-05-23 18:06:06.712 +---------------------------------------+
+                        |                                       |
+                        |                                       |
+                        |                                       |
+                        |                                       |
+2022-06-23 18:06:06.712 +-------------------+-------------------+
+                        |                   |*******************|
+                        |                   |*******************|
+                        |                   |*******************|
+                        |                   |*******************|
+9999-12-31 00:00:00.000 +-------------------+-------------------+
+EOS
+      end
+    end
   end
 end


### PR DESCRIPTION
Thank you for great gem!
This is a proposal and pull request at once.

### Summary
Added option to display labels in `ActiveRecord::Bitemporal::Visualizer`

### Sample code
```ruby
# frozen_string_literal: true

require 'bundler/inline'

gemfile(true) do
  source 'https://rubygems.org'

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem 'rails', '7.0.1'
  gem 'activerecord-bitemporal', path: '../activerecord-bitemporal'
  gem 'sqlite3'
  gem 'timecop'
end

require 'active_record'
require 'active_support/all'
require 'activerecord-bitemporal'

ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')

ActiveRecord::Schema.define do
  create_table :companies, force: true do |t|
    t.integer :bitemporal_id

    t.string :name

    t.datetime :valid_from, precision: 6
    t.datetime :valid_to, precision: 6
    t.datetime :deleted_at, precision: 6
    t.datetime :transaction_from, precision: 6
    t.datetime :transaction_to, precision: 6

    t.timestamps
  end
end

Time.zone = 'UTC'

class Company < ActiveRecord::Base
  include ActiveRecord::Bitemporal
end

company = nil
Timecop.freeze('2023-02-28') do
  ActiveRecord::Bitemporal.valid_at('2000/01/01') do
    company = Company.create!(name: 'A')
  end
end

Timecop.freeze('2023-03-1') do
  ActiveRecord::Bitemporal.valid_at('2020/07/01') do
    company.reload.update!(name: 'C')
  end
end

puts ActiveRecord::Bitemporal::Visualizer.visualize(company, label: true)
```

output

```
 > ruby test.rb
Fetching gem metadata from https://rubygems.org/...........
~~ snip ~~
transaction_datetime    | valid_datetime
                        | 2000-01-01 00:00:00.000
                        |                   | 2020-07-01 00:00:00.000
                        |                   |                   | 9999-12-31 00:00:00.000
2023-02-28 00:00:00.000 +---------------------------------------+
                        |                                       |
                        |                                       |
                        |                                       |
                        |                                       |
2023-03-01 00:00:00.000 +-------------------+-------------------+
                        |                   |*******************|
                        |                   |*******************|
                        |                   |*******************|
                        |                   |*******************|
9999-12-31 00:00:00.000 +-------------------+-------------------+
```