### PR TITLE
Support for `inverse_of` of Rails 6.1 or higher

### DIFF
--- a/lib/activerecord-bitemporal/patches.rb
+++ b/lib/activerecord-bitemporal/patches.rb
@@ -79,6 +79,18 @@ module ActiveRecord::Bitemporal
       def bi_temporal_model?
         owner.class.bi_temporal_model? && klass&.bi_temporal_model?
       end
+
+      def matches_foreign_key?(record)
+        return super unless owner.class.bi_temporal_model?
+
+        begin
+          original_owner_id = owner.id
+          owner.id = owner.read_attribute(owner.class.bitemporal_id_key)
+          super
+        ensure
+          owner.id = original_owner_id
+        end
+      end
     end
 
     module ThroughAssociation

--- a/spec/activerecord-bitemporal/association_spec.rb
+++ b/spec/activerecord-bitemporal/association_spec.rb
@@ -95,6 +95,24 @@ RSpec.describe "Association" do
         end
       end
     end
+
+    describe "inverse_of" do
+      let(:company) do
+        Class.new(Company) {
+          has_many :employee_without_bitemporals, foreign_key: :company_id, inverse_of: :company
+
+          def self.name
+            "CompanyWithInverseOf"
+          end
+        }.create!(name: "Company")
+      end
+      before do
+        company.update(name: "Company2")
+        company.employee_without_bitemporals.create!(name: "Jane")
+      end
+
+      it { expect(company.reload.employee_without_bitemporals.first.company).to be company }
+    end
   end
 
   describe "non BTDM has many BTDM" do
@@ -254,6 +272,24 @@ RSpec.describe "Association" do
         it { is_expected.to change { employee2.reload.company_id }.from(company.id).to(nil) }
       end
     end
+
+    describe "inverse_of" do
+      let(:company) do
+        Class.new(CompanyWithoutBitemporal) {
+          has_many :employees, foreign_key: :company_id, inverse_of: :company
+
+          def self.name
+            'CompanyWithInverseOf'
+          end
+        }.create!(name: "Company")
+      end
+      before do
+        employee = company.employees.create!(name: "Jane")
+        employee.update!(name: "Tom")
+      end
+
+      it { expect(company.reload.employees.first.company).to be company }
+    end
   end
 
   describe "BTDM has many BTDM" do
@@ -354,6 +390,25 @@ RSpec.describe "Association" do
         end
       end
     end
+
+    describe "inverse_of" do
+      let(:company) do
+        Class.new(Company) {
+          has_many :employees, foreign_key: :company_id, inverse_of: :company
+
+          def self.name
+            "CompanyWithInverseOf"
+          end
+        }.create!(name: "Company")
+      end
+      before do
+        company.update!(name: "Company2")
+        employee = company.employees.create!(name: "Jane")
+        employee.update!(name: "Tom")
+      end
+
+      it { expect(company.reload.employees.first.company).to be company }
+    end
   end
 
   describe "non BTDM has one BTDM" do
@@ -371,6 +426,24 @@ RSpec.describe "Association" do
 
         it { is_expected.to change { employee.reload.company_id }.from(company.id).to(nil) }
       end
+    end
+
+    describe "inverse_of" do
+      let(:employee) do
+        Class.new(EmployeeWithoutBitemporal) {
+          has_one :address, foreign_key: :employee_id, inverse_of: :employee
+
+          def self.name
+            "EmployeeWithInverseOf"
+          end
+        }.create!(name: "Jane")
+      end
+      before do
+        address = employee.create_address!(city: "Tokyo")
+        address.update!(city: "Osaka")
+      end
+
+      it { expect(employee.reload.address.employee).to be employee }
     end
   end
 
@@ -393,6 +466,27 @@ RSpec.describe "Association" do
           it { expect(addresses.loaded?).to eq true }
         end
       end
+    end
+  end
+
+  describe "BTDM has one BTDM" do
+    describe "inverse_of" do
+      let(:employee) do
+        Class.new(Employee) {
+          has_one :address, foreign_key: :employee_id, inverse_of: :employee
+
+          def self.name
+            "EmployeeWithInverseOf"
+          end
+        }.create!(name: "Jane")
+      end
+      before do
+        employee.update!(name: "Tom")
+        employee.create_address!(city: "Tokyo")
+          .update!(city: "Osaka") # create history
+      end
+
+      it { expect(employee.reload.address.employee).to be employee }
     end
   end
 end


### PR DESCRIPTION
## Summary

Support `inverse_of` of Rails 6.1 or higher.

`matches_foreign_key?` method was introduced in Rails 6.1 to check for `inserve`.
refs: https://github.com/rails/rails/pull/40042

At the time this method was called, before `owner` called `after_find (swap_id!)`, `id` was not `bitemporal_id` but the `id` column on DB was stored as is. Therefore, the value did not match the foreign key of `record` and was out of the scope of `inverse`.

## Expected behavior

```rb
employee = Employee.create!(name: "Alice")
employee.update!(name: "Bob")
Address.create!(employee: employee, city: "Tokyo")

address = Address.find_by(employee: employee)
# returns same object
p address.__id__ == address.employee.address.__id__ # => true
```

## Actual behavior

```rb
employee = Employee.create!(name: "Alice")
employee.update!(name: "Bob")
Address.create!(employee: employee, city: "Tokyo")

address = Address.find_by(employee: employee)
# returns different object
p address.__id__ == address.employee.address.__id__ # => false
```