### PR TITLE
Bump up version to v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 4.1.0
+
+### Added
+- [add label option #127](https://github.com/kufu/activerecord-bitemporal/pull/127)
+
+### Changed
+- [Support for inverse_of of Rails 6.1 or higher #130](https://github.com/kufu/activerecord-bitemporal/pull/130)
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
 ## 4.0.0
 
 ### Breaking Changed

--- a/lib/activerecord-bitemporal/version.rb
+++ b/lib/activerecord-bitemporal/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   module Bitemporal
-    VERSION = "4.0.0"
+    VERSION = "4.1.0"
   end
 end


### PR DESCRIPTION
## 4.1.0

### Added
- [add label option #127](https://github.com/kufu/activerecord-bitemporal/pull/127)

### Changed
- [Support for inverse_of of Rails 6.1 or higher #130](https://github.com/kufu/activerecord-bitemporal/pull/130)

### Deprecated

### Removed

### Fixed
