### PR TITLE
Fix for RSpec deprecated warning

### DIFF
--- a/spec/activerecord-bitemporal/association_spec.rb
+++ b/spec/activerecord-bitemporal/association_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe "Association" do
       let!(:employee) { Employee.create!(name: "Mami").tap { |it| it.update(name: "Jane") } }
       let!(:tokyo) { employee.address_without_bitemporal = AddressWithoutBitemporal.create!(city: "Tokyo") }
 
-      subject { -> { employee.update!(name: "Tom") } }
-      it { is_expected.to change { tokyo.reload.employee.name }.from("Jane").to("Tom") }
-      it { is_expected.to change { AddressWithoutBitemporal.find_by(city: "Tokyo").employee.name }.from("Jane").to("Tom") }
+      subject { employee.update!(name: "Tom") }
+      it { expect { subject }.to change { tokyo.reload.employee.name }.from("Jane").to("Tom") }
+      it { expect { subject }.to change { AddressWithoutBitemporal.find_by(city: "Tokyo").employee.name }.from("Jane").to("Tom") }
 
       context "any call" do
         it do
@@ -110,39 +110,39 @@ RSpec.describe "Association" do
     end
 
     describe "#create" do
-      subject { -> { company.employees.create(name: "Employee1") } }
+      subject { company.employees.create(name: "Employee1") }
 
-      it { is_expected.to change(company.employees, :count).by(1) }
-      it { is_expected.to change(company.employees, :first).from(nil).to(have_attributes name: "Employee1") }
-      it { is_expected.to change { company.employees.ignore_valid_datetime.count }.by(1) }
-      it { is_expected.to change { company.employees.find_by(name: "Employee1") }.from(nil).to(have_attributes name: "Employee1") }
+      it { expect { subject }.to change(company.employees, :count).by(1) }
+      it { expect { subject }.to change(company.employees, :first).from(nil).to(have_attributes name: "Employee1") }
+      it { expect { subject }.to change { company.employees.ignore_valid_datetime.count }.by(1) }
+      it { expect { subject }.to change { company.employees.find_by(name: "Employee1") }.from(nil).to(have_attributes name: "Employee1") }
     end
 
     describe "#update" do
       let!(:employee1) { company.employees.create(name: "Employee0").tap { |it| it.update(name: "Employee1") } }
-      subject { -> { employee1.update(name: "New") } }
+      subject { employee1.update(name: "New") }
 
-      it { is_expected.not_to change(company.employees, :count) }
-      it { is_expected.to change { company.employees.first.reload.name }.to("New") }
-      it { is_expected.to change { company.employees.ignore_valid_datetime.count }.by(1) }
+      it { expect { subject }.not_to change(company.employees, :count) }
+      it { expect { subject }.to change { company.employees.first.reload.name }.to("New") }
+      it { expect { subject }.to change { company.employees.ignore_valid_datetime.count }.by(1) }
     end
 
     describe "#force_update" do
       let!(:employee1) { company.employees.create(name: "Employee0").tap { |it| it.update(name: "Employee1") } }
-      subject { -> { employee1.force_update { |m| m.update(name: "New") } } }
+      subject { employee1.force_update { |m| m.update(name: "New") } }
 
-      it { is_expected.not_to change(company.employees, :count) }
-      it { is_expected.to change { company.employees.first.reload.name }.to("New") }
-      it { is_expected.to change { company.employees.ignore_valid_datetime.within_deleted.count }.by(1) }
+      it { expect { subject }.not_to change(company.employees, :count) }
+      it { expect { subject }.to change { company.employees.first.reload.name }.to("New") }
+      it { expect { subject }.to change { company.employees.ignore_valid_datetime.within_deleted.count }.by(1) }
     end
 
     describe "#destroy" do
       let!(:employee1) { company.employees.create(name: "Employee0").tap { |it| it.update(name: "Employee1") } }
-      subject { -> { employee1.destroy } }
+      subject { employee1.destroy }
 
-      it { is_expected.to change { company.employees.count }.by(-1) }
-      it { is_expected.to change(employee1, :destroyed?).from(false).to(true) }
-      it { is_expected.to change { company.employees.ignore_valid_datetime.within_deleted.count }.by(1) }
+      it { expect { subject }.to change { company.employees.count }.by(-1) }
+      it { expect { subject }.to change(employee1, :destroyed?).from(false).to(true) }
+      it { expect { subject }.to change { company.employees.ignore_valid_datetime.within_deleted.count }.by(1) }
     end
 
     describe "relations" do
@@ -221,19 +221,17 @@ RSpec.describe "Association" do
         let!(:employee2) { company.employees.create(name: "Homu").tap { |m| m.update!(name: "Mami") } }
 
         subject {
-          -> {
-            company.employees_attributes = [
-              { id: employee1.id, name: "Kevin" },
-              { id: employee2.id, name: "Mado" }
-            ]
-            company.save
-          }
+          company.employees_attributes = [
+            { id: employee1.id, name: "Kevin" },
+            { id: employee2.id, name: "Mado" }
+          ]
+          company.save
         }
 
-        it { is_expected.not_to change { Employee.count } }
-        it { is_expected.to change { Employee.ignore_valid_datetime.count }.by(2) }
-        it { is_expected.to change { employee1.reload.name }.from("Tom").to("Kevin") }
-        it { is_expected.to change { employee2.reload.name }.from("Mami").to("Mado") }
+        it { expect { subject }.not_to change { Employee.count } }
+        it { expect { subject }.to change { Employee.ignore_valid_datetime.count }.by(2) }
+        it { expect { subject }.to change { employee1.reload.name }.from("Tom").to("Kevin") }
+        it { expect { subject }.to change { employee2.reload.name }.from("Mami").to("Mado") }
       end
     end
 
@@ -248,10 +246,10 @@ RSpec.describe "Association" do
         let!(:employee1) { company.employees.create(name: "_").tap { |m| m.update(name: "Employee1") } }
         let!(:employee2) { company.employees.create(name: "_").tap { |m| m.update(name: "Employee2") } }
 
-        subject { -> { company.destroy } }
+        subject { company.destroy }
 
-        it { is_expected.to change { employee1.reload.company_id }.from(company.id).to(nil) }
-        it { is_expected.to change { employee2.reload.company_id }.from(company.id).to(nil) }
+        it { expect { subject }.to change { employee1.reload.company_id }.from(company.id).to(nil) }
+        it { expect { subject }.to change { employee2.reload.company_id }.from(company.id).to(nil) }
       end
     end
   end
@@ -268,19 +266,17 @@ RSpec.describe "Association" do
         let!(:employee2) { company.employees.create(name: "Homu").tap { |m| m.update(name: "Mami") } }
 
         subject {
-          -> {
-            company.employees_attributes = [
-              { id: employee1.id, name: "Kevin" },
-              { id: employee2.id, name: "Mado" }
-            ]
-            company.save
-          }
+          company.employees_attributes = [
+            { id: employee1.id, name: "Kevin" },
+            { id: employee2.id, name: "Mado" }
+          ]
+          company.save
         }
 
-        it { is_expected.not_to change { Employee.count } }
-        it { is_expected.to change { Employee.ignore_valid_datetime.count }.by(2) }
-        it { is_expected.to change { employee1.reload.name }.from("Tom").to("Kevin") }
-        it { is_expected.to change { employee2.reload.name }.from("Mami").to("Mado") }
+        it { expect { subject }.not_to change { Employee.count } }
+        it { expect { subject }.to change { Employee.ignore_valid_datetime.count }.by(2) }
+        it { expect { subject }.to change { employee1.reload.name }.from("Tom").to("Kevin") }
+        it { expect { subject }.to change { employee2.reload.name }.from("Mami").to("Mado") }
       end
     end
 
@@ -293,10 +289,10 @@ RSpec.describe "Association" do
         let(:company) { Company.new(name: "Company") }
 
         context "saving" do
-          subject { -> { company.save } }
-          it { is_expected.to change { employee1.valid_from } }
-          it { is_expected.to change { employee2.valid_from } }
-          it { is_expected.not_to change { employee3.valid_from } }
+          subject { company.save }
+          it { expect { subject }.to change { employee1.valid_from } }
+          it { expect { subject }.to change { employee2.valid_from } }
+          it { expect { subject }.not_to change { employee3.valid_from } }
         end
 
         context "saved" do
@@ -339,10 +335,10 @@ RSpec.describe "Association" do
         let(:company) { Company.create(name: "Company") }
 
         context "saving" do
-          subject { -> { company.save } }
-          it { is_expected.to change { employee1.valid_from } }
-          it { is_expected.to change { employee2.valid_from } }
-          it { is_expected.not_to change { employee3.valid_from } }
+          subject { company.save }
+          it { expect { subject }.to change { employee1.valid_from } }
+          it { expect { subject }.to change { employee2.valid_from } }
+          it { expect { subject }.not_to change { employee3.valid_from } }
         end
 
         context "saved" do
@@ -367,9 +363,9 @@ RSpec.describe "Association" do
         }
         let!(:employee) { Employee.create(name: "_", company_id: company.id).tap { |m| m.update(name: "Employee1") } }
 
-        subject { -> { company.destroy } }
+        subject { company.destroy }
 
-        it { is_expected.to change { employee.reload.company_id }.from(company.id).to(nil) }
+        it { expect { subject }.to change { employee.reload.company_id }.from(company.id).to(nil) }
       end
     end
   end

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe ActiveRecord::Bitemporal do
   describe ".create" do
     context "creating" do
       let(:attributes) { {} }
-      subject { -> { Employee.create!(name: "Tom", **attributes) } }
-      it { is_expected.to change(Employee, :call_after_save_count).by(1) }
+      subject { Employee.create!(name: "Tom", **attributes) }
+      it { expect { subject }.to change(Employee, :call_after_save_count).by(1) }
     end
 
     context "created" do
@@ -177,8 +177,8 @@ RSpec.describe ActiveRecord::Bitemporal do
     describe "non cache query" do
       let(:jojo) { -> { Employee.find_by(name: "JoJo") } }
       before { Employee.create(emp_code: "001", name: "JoJo") }
-      subject { -> { Employee.find_by(name: "JoJo").update(emp_code: "002") } }
-      it { is_expected.to change { jojo.call.emp_code }.from("001").to("002") }
+      subject { Employee.find_by(name: "JoJo").update(emp_code: "002") }
+      it { expect { subject }.to change { jojo.call.emp_code }.from("001").to("002") }
     end
   end
 
@@ -589,13 +589,13 @@ RSpec.describe ActiveRecord::Bitemporal do
     it { expect { employee.reload }.to change { employee.swapped_id_previously_was }.from(kind_of(Integer)).to(nil) }
 
     context "call #update" do
-      subject { -> { employee.update!(name: "Kevin") } }
-      it { is_expected.to change { employee.reload.swapped_id } }
+      subject { employee.update!(name: "Kevin") }
+      it { expect { subject }.to change { employee.reload.swapped_id } }
     end
 
     context "call .update" do
-      subject { -> { Employee.find(employee.id).update!(name: "Kevin") } }
-      it { is_expected.to change { employee.reload.swapped_id } }
+      subject { Employee.find(employee.id).update!(name: "Kevin") }
+      it { expect { subject }.to change { employee.reload.swapped_id } }
     end
 
     # TODO: Not yet supported
@@ -659,17 +659,17 @@ RSpec.describe ActiveRecord::Bitemporal do
       let(:old_jone) { Employee.ignore_valid_datetime.within_deleted.find_by(bitemporal_id: employee.id, name: "Jone") }
       let(:now) { time_current }
 
-      subject { -> { employee.update(name: "Tom") } }
+      subject { employee.update(name: "Tom") }
 
       shared_examples "updated Jone" do
         let(:jone) { Employee.ignore_valid_datetime.find_by(bitemporal_id: employee.id, name: "Jone") }
-        before { subject.call }
+        before { subject }
         it { expect(jone).to have_attributes valid_from: valid_from, valid_to: valid_to }
       end
 
       shared_examples "updated Tom" do
         let(:tom) { Employee.ignore_valid_datetime.find_by(bitemporal_id: employee.id, name: "Tom") }
-        before { subject.call }
+        before { subject }
         it { expect(tom).to have_attributes valid_from: valid_from, valid_to: valid_to }
       end
 
@@ -681,10 +681,10 @@ RSpec.describe ActiveRecord::Bitemporal do
       #                     |-----------|
       context "now time is in" do
         let(:now) { from + 5.days }
-        it { is_expected.to change(&count).by(1) }
-        it { is_expected.to change(employee, :name).from("Jone").to("Tom") }
-        it { is_expected.to change(employee, :swapped_id).from(swapped_id).to(kind_of(Integer)) }
-        it { is_expected.to change(employee, :swapped_id_previously_was).from(nil).to(swapped_id) }
+        it { expect { subject }.to change(&count).by(1) }
+        it { expect { subject }.to change(employee, :name).from("Jone").to("Tom") }
+        it { expect { subject }.to change(employee, :swapped_id).from(swapped_id).to(kind_of(Integer)) }
+        it { expect { subject }.to change(employee, :swapped_id_previously_was).from(nil).to(swapped_id) }
         it_behaves_like "updated Jone" do
           let(:valid_from) { from }
           let(:valid_to) { now }
@@ -704,10 +704,10 @@ RSpec.describe ActiveRecord::Bitemporal do
           Employee.create!(bitemporal_id: employee.bitemporal_id, valid_from: to + 5.days, valid_to: to + 10.days)
         end
         let(:now) { from - 5.days }
-        it { is_expected.to change(&count).by(1) }
-        it { is_expected.to change(employee, :name).from("Jone").to("Tom") }
-        it { is_expected.to change(employee, :swapped_id).from(swapped_id).to(kind_of(Integer)) }
-        it { is_expected.to change(employee, :swapped_id_previously_was).from(nil).to(swapped_id) }
+        it { expect { subject }.to change(&count).by(1) }
+        it { expect { subject }.to change(employee, :name).from("Jone").to("Tom") }
+        it { expect { subject }.to change(employee, :swapped_id).from(swapped_id).to(kind_of(Integer)) }
+        it { expect { subject }.to change(employee, :swapped_id_previously_was).from(nil).to(swapped_id) }
         it_behaves_like "updated Jone" do
           let(:valid_from) { from }
           let(:valid_to) { to }
@@ -770,7 +770,7 @@ RSpec.describe ActiveRecord::Bitemporal do
       let(:now) { -> { histories.call.first } }
       let(:old) { -> { histories.call.second } }
 
-      subject { -> { employee.update(emp_code: "002", name: "Tom") } }
+      subject { employee.update(emp_code: "002", name: "Tom") }
 
       before do
         ignore_columns_ = ignore_columns
@@ -784,28 +784,28 @@ RSpec.describe ActiveRecord::Bitemporal do
 
         # It did not work.
         # it { is_expected.to change(&now).from(have_attributes(emp_code: "001", name: "Jane")).to(have_attributes(emp_code: "002", name: nil)) }
-        it { is_expected.to change { now.call.name }.from("Jane").to(nil) }
-        it { is_expected.to change { now.call.emp_code }.from("001").to("002") }
-        it { is_expected.to change(&old).from(nil).to(have_attributes(emp_code: "001", name: "Jane")) }
+        it { expect { subject }.to change { now.call.name }.from("Jane").to(nil) }
+        it { expect { subject }.to change { now.call.emp_code }.from("001").to("002") }
+        it { expect { subject }.to change(&old).from(nil).to(have_attributes(emp_code: "001", name: "Jane")) }
       end
 
       context "return to String" do
         let(:ignore_columns) { ["name"] }
 
-        it { is_expected.to change { now.call.name }.from("Jane").to(nil) }
-        it { is_expected.to change { now.call.emp_code }.from("001").to("002") }
-        it { is_expected.to change(&old).from(nil).to(have_attributes(emp_code: "001", name: "Jane")) }
+        it { expect { subject }.to change { now.call.name }.from("Jane").to(nil) }
+        it { expect { subject }.to change { now.call.emp_code }.from("001").to("002") }
+        it { expect { subject }.to change(&old).from(nil).to(have_attributes(emp_code: "001", name: "Jane")) }
       end
     end
 
     describe "changed `valid_from` columns" do
       let(:employee) { Employee.create(name: "Jane", emp_code: "001") }
-      subject { -> { employee.update(name: "Tom") } }
-      it { is_expected.to change(employee, :name).from("Jane").to("Tom") }
-      it { is_expected.to change(employee, :valid_from) }
+      subject { employee.update(name: "Tom") }
+      it { expect { subject }.to change(employee, :name).from("Jane").to("Tom") }
+      it { expect { subject }.to change(employee, :valid_from) }
       # valid_to is fixed "9999/12/31"
-      it { is_expected.not_to change(employee, :valid_to) }
-      it { is_expected.not_to change(employee, :emp_code) }
+      it { expect { subject }.not_to change(employee, :valid_to) }
+      it { expect { subject }.not_to change(employee, :emp_code) }
     end
 
     context 'when updated with valid_at in the past ' do
@@ -815,11 +815,11 @@ RSpec.describe ActiveRecord::Bitemporal do
             Employee.create(name: "Jane", emp_code: "001")
           }
         }
-        subject { -> {
+        subject {
           ActiveRecord::Bitemporal.valid_at("2019/04/01") { employee.update(name: "Tom") }
-        }}
+        }
 
-        it { is_expected.to change(employee, :valid_to).from(ActiveRecord::Bitemporal::DEFAULT_VALID_TO)
+        it { expect { subject }.to change(employee, :valid_to).from(ActiveRecord::Bitemporal::DEFAULT_VALID_TO)
                                                        .to(Time.utc(2019, 05, 01).in_time_zone) }
       end
     end
@@ -842,10 +842,10 @@ RSpec.describe ActiveRecord::Bitemporal do
       context "valid_datetime is before created time" do
         let(:employee) { Timecop.freeze("2019/1/20") { Employee.create!(name: "Jane") } }
         let(:latest_employee) { -> { Employee.ignore_valid_datetime.order(:valid_from).find(employee.id) } }
-        subject { -> { employee.valid_at("2019/1/5", &:touch) } }
+        subject { employee.valid_at("2019/1/5", &:touch) }
         before { Timecop.freeze("2019/1/10") { Employee.create!(name: "Homu") } }
         it do
-          is_expected.to change { latest_employee.call.valid_to }.from(employee.valid_to).to(employee.valid_from)
+          expect { subject }.to change { latest_employee.call.valid_to }.from(employee.valid_to).to(employee.valid_from)
         end
       end
     end
@@ -856,16 +856,16 @@ RSpec.describe ActiveRecord::Bitemporal do
         let(:company_count) { -> { Company.ignore_valid_datetime.bitemporal_for(company.id).count } }
         let(:company_transaction_to) { -> { Company.ignore_valid_datetime.within_deleted.bitemporal_for(company.id).first.transaction_to } }
         let(:valid_datetime) { company.valid_from }
-        subject { -> { company.valid_at(valid_datetime) { |c| c.update(name: "Company") } } }
+        subject { company.valid_at(valid_datetime) { |c| c.update(name: "Company") } }
 
-        it { expect(subject.call).to be_falsey }
-        it { is_expected.not_to change(&company_count) }
-        it { is_expected.not_to change(&company_transaction_to) }
+        it { expect(subject).to be_falsey }
+        it { expect { subject }.not_to change(&company_count) }
+        it { expect { subject }.not_to change(&company_transaction_to) }
 
         context "call `update!`" do
-          subject { -> { company.valid_at(valid_datetime) { |c| c.update!(name: "Company") } } }
-          it { is_expected.to raise_error(ActiveRecord::RecordInvalid) }
-          it { is_expected.to raise_error { |e|
+          subject { company.valid_at(valid_datetime) { |c| c.update!(name: "Company") } }
+          it { expect { subject }.to raise_error(ActiveRecord::RecordInvalid) }
+          it { expect { subject }.to raise_error { |e|
             expect(e.message).to eq "Validation failed: Valid from can't be greater equal than valid_to"
           } }
         end
@@ -874,10 +874,10 @@ RSpec.describe ActiveRecord::Bitemporal do
       context "update for deleted record" do
         let(:datetime) { "2020/01/01".in_time_zone }
         let(:company) { Company.create!(valid_from: "2019/02/01", valid_to: "2019/04/01") }
-        subject { -> { Timecop.freeze(datetime) { company.update!(name: "Company2") } } }
+        subject { Timecop.freeze(datetime) { company.update!(name: "Company2") } }
         before { company.destroy }
-        it { is_expected.to raise_error(ActiveRecord::RecordNotFound) }
-        it { is_expected.to raise_error { |e|
+        it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
+        it { expect { subject }.to raise_error { |e|
           expect(e.message).to eq "Update failed: Couldn't find Company with 'bitemporal_id'=#{company.bitemporal_id} and 'valid_from' < #{datetime}"
         } }
       end
@@ -913,13 +913,13 @@ RSpec.describe ActiveRecord::Bitemporal do
     let(:count) { -> { Employee.ignore_valid_datetime.within_deleted.count } }
     let(:update_attributes) { { name: "Tom" } }
 
-    subject { -> { employee.force_update { |m| m.update!(**update_attributes) } } }
+    subject { employee.force_update { |m| m.update!(**update_attributes) } }
 
-    it { is_expected.to change(&count).by(1) }
-    it { is_expected.to change(employee, :name).from("Jane").to("Tom") }
-    it { is_expected.not_to change(employee, :id) }
-    it { is_expected.to change(employee, :swapped_id).from(swapped_id).to(kind_of(Integer)) }
-    it { is_expected.to change(employee, :swapped_id_previously_was).from(nil).to(swapped_id) }
+    it { expect { subject }.to change(&count).by(1) }
+    it { expect { subject }.to change(employee, :name).from("Jane").to("Tom") }
+    it { expect { subject }.not_to change(employee, :id) }
+    it { expect { subject }.to change(employee, :swapped_id).from(swapped_id).to(kind_of(Integer)) }
+    it { expect { subject }.to change(employee, :swapped_id_previously_was).from(nil).to(swapped_id) }
 
     context "with `#valid_at`" do
       let!(:employee) { Timecop.freeze("2019/1/1") { Employee.create!(name: "Jane") } }
@@ -968,7 +968,7 @@ RSpec.describe ActiveRecord::Bitemporal do
       define_method(:employee_all) { Employee.ignore_valid_datetime.within_deleted.bitemporal_for(employee.id).order(:created_at) }
 
       it do
-        is_expected.to change { employee_all }
+        expect { subject }.to change { employee_all }
           .from(match [
             have_attributes(name: "Jane", valid_from: create_valid_from, valid_to: ActiveRecord::Bitemporal::DEFAULT_VALID_TO, deleted_at: be_blank)
           ])
@@ -982,7 +982,7 @@ RSpec.describe ActiveRecord::Bitemporal do
         let(:update_valid_from) { create_valid_from - 10.days }
 
         it do
-          is_expected.to change { employee_all }
+          expect { subject }.to change { employee_all }
             .from(match [
               have_attributes(name: "Jane", valid_from: create_valid_from, valid_to: ActiveRecord::Bitemporal::DEFAULT_VALID_TO, deleted_at: be_blank)
             ])
@@ -1019,12 +1019,12 @@ RSpec.describe ActiveRecord::Bitemporal do
     let(:latest) { -> { Employee.find(employee.id) } }
     let(:count) { -> { Employee.ignore_valid_datetime.within_deleted.count } }
 
-    subject { -> { employee.update_columns(name: "Homu") } }
+    subject { employee.update_columns(name: "Homu") }
 
-    it { is_expected.not_to change(&count) }
-    it { is_expected.to change { latest.call.name }.from("Tom").to("Homu") }
-    it { is_expected.to change { employee.reload.name }.from("Tom").to("Homu") }
-    it { is_expected.not_to change { original.call.name} }
+    it { expect { subject }.not_to change(&count) }
+    it { expect { subject }.to change { latest.call.name }.from("Tom").to("Homu") }
+    it { expect { subject }.to change { employee.reload.name }.from("Tom").to("Homu") }
+    it { expect { subject }.not_to change { original.call.name} }
   end
 
   describe "#destroy" do
@@ -1033,29 +1033,29 @@ RSpec.describe ActiveRecord::Bitemporal do
     let(:created_time) { time_current - 10.second }
     let(:updated_time) { time_current - 5.second }
     let(:destroyed_time) { time_current }
-    subject { -> { Timecop.freeze(destroyed_time) { employee.destroy } } }
+    subject { Timecop.freeze(destroyed_time) { employee.destroy } }
 
     before do
       Timecop.freeze(updated_time) { employee.update!(name: "Tom") }
       @swapped_id_before_destroy = employee.swapped_id
     end
 
-    it { is_expected.to change(Employee, :call_before_destroy_count).by(1) }
-    it { is_expected.to change(Employee, :call_after_destroy_count).by(1) }
-    it { is_expected.to change(Employee, :call_after_save_count) }
-    it { is_expected.to change(Employee, :count).by(-1) }
-    it { is_expected.to change(employee, :destroyed?).from(false).to(true) }
-    it { is_expected.not_to change(employee, :valid_from) }
-    it { is_expected.to change(employee, :valid_to).from(ActiveRecord::Bitemporal::DEFAULT_VALID_TO).to(destroyed_time) }
-    it { is_expected.to change(employee, :transaction_from).from(updated_time).to(destroyed_time) }
-    it { is_expected.not_to change(employee, :transaction_to) }
-    it { is_expected.to change { Employee.ignore_valid_datetime.within_deleted.count }.by(1) }
-    it { is_expected.to change(employee, :swapped_id).from(@swapped_id_before_destroy).to(kind_of(Integer)) }
-    it { is_expected.to change(employee, :swapped_id_previously_was).from(kind_of(Integer)).to(@swapped_id_before_destroy) }
-    it { expect(subject.call).to eq employee }
+    it { expect { subject }.to change(Employee, :call_before_destroy_count).by(1) }
+    it { expect { subject }.to change(Employee, :call_after_destroy_count).by(1) }
+    it { expect { subject }.to change(Employee, :call_after_save_count) }
+    it { expect { subject }.to change(Employee, :count).by(-1) }
+    it { expect { subject }.to change(employee, :destroyed?).from(false).to(true) }
+    it { expect { subject }.not_to change(employee, :valid_from) }
+    it { expect { subject }.to change(employee, :valid_to).from(ActiveRecord::Bitemporal::DEFAULT_VALID_TO).to(destroyed_time) }
+    it { expect { subject }.to change(employee, :transaction_from).from(updated_time).to(destroyed_time) }
+    it { expect { subject }.not_to change(employee, :transaction_to) }
+    it { expect { subject }.to change { Employee.ignore_valid_datetime.within_deleted.count }.by(1) }
+    it { expect { subject }.to change(employee, :swapped_id).from(@swapped_id_before_destroy).to(kind_of(Integer)) }
+    it { expect { subject }.to change(employee, :swapped_id_previously_was).from(kind_of(Integer)).to(@swapped_id_before_destroy) }
+    it { expect(subject).to eq employee }
 
     it do
-      subject.call
+      subject
       expect(represent_deleted).to have_attributes(
         valid_from: employee.valid_from,
         valid_to: destroyed_time,
@@ -1084,18 +1084,18 @@ RSpec.describe ActiveRecord::Bitemporal do
         self_.instance_exec { expect(e).to eq true }
       end
 
-      subject.call
+      subject
     end
 
     context "when raise exception" do
       shared_examples "return false and #destroyed? to be false" do
-        it { is_expected.not_to change(employee, :destroyed?) }
-        it { is_expected.not_to change { Employee.ignore_valid_datetime.count } }
-        it { is_expected.not_to change(employee, :swapped_id) }
-        it { is_expected.not_to change(employee, :swapped_id_previously_was) }
-        it { expect(subject.call).to eq false }
+        it { expect { subject }.not_to change(employee, :destroyed?) }
+        it { expect { subject }.not_to change { Employee.ignore_valid_datetime.count } }
+        it { expect { subject }.not_to change(employee, :swapped_id) }
+        it { expect { subject }.not_to change(employee, :swapped_id_previously_was) }
+        it { expect(subject).to eq false }
         it do
-          subject.call
+          subject
           expect(employee.reload.transaction_to).to eq ActiveRecord::Bitemporal::DEFAULT_TRANSACTION_TO
         end
       end
@@ -1112,11 +1112,11 @@ RSpec.describe ActiveRecord::Bitemporal do
         it_behaves_like "return false and #destroyed? to be false"
 
         context "with transaction" do
-          subject { -> {
+          subject {
             ActiveRecord::Base.transaction {
               Timecop.freeze(destroyed_time) { employee.destroy }
             }
-          } }
+          }
           it_behaves_like "return false and #destroyed? to be false"
         end
       end
@@ -1149,16 +1149,16 @@ RSpec.describe ActiveRecord::Bitemporal do
 
       context "`destroyed_time` is earlier than `created_time`" do
         let(:destroyed_time) { created_time - 10.second }
-        subject { -> { ActiveRecord::Bitemporal.valid_at(destroyed_time) { employee.destroy } } }
+        subject { ActiveRecord::Bitemporal.valid_at(destroyed_time) { employee.destroy } }
         it_behaves_like "return false and #destroyed? to be false"
       end
 
       context "with `destory!`" do
-        subject { -> { Timecop.freeze(destroyed_time) { employee.destroy! } } }
+        subject { Timecop.freeze(destroyed_time) { employee.destroy! } }
 
         before { allow_any_instance_of(Employee).to receive('save!').and_raise(ActiveRecord::RecordNotSaved.new("failed")) }
 
-        it { is_expected.to raise_error(ActiveRecord::RecordNotDestroyed, "Failed to destroy the record: class=ActiveRecord::RecordNotSaved, message=failed") }
+        it { expect { subject }.to raise_error(ActiveRecord::RecordNotDestroyed, "Failed to destroy the record: class=ActiveRecord::RecordNotSaved, message=failed") }
       end
     end
 
@@ -1176,7 +1176,7 @@ RSpec.describe ActiveRecord::Bitemporal do
           # After update valid_to
           self_.instance_exec { expect(valid_to).to eq destroyed_time }
         }
-        subject.call
+        subject
       end
     end
 
@@ -1190,23 +1190,23 @@ RSpec.describe ActiveRecord::Bitemporal do
     end
 
     context "with `#valid_at`" do
-      subject { -> { Timecop.freeze(destroyed_time) { employee.valid_at(destroyed_time + 1.day, &:destroy) } } }
-      it { is_expected.not_to change(employee, :valid_from) }
-      it { is_expected.to change(employee, :valid_to).from(ActiveRecord::Bitemporal::DEFAULT_VALID_TO).to(destroyed_time + 1.day) }
-      it { is_expected.to change(employee, :transaction_from).from(updated_time).to(destroyed_time) }
-      it { is_expected.not_to change(employee, :transaction_to) }
+      subject { Timecop.freeze(destroyed_time) { employee.valid_at(destroyed_time + 1.day, &:destroy) } }
+      it { expect { subject }.not_to change(employee, :valid_from) }
+      it { expect { subject }.to change(employee, :valid_to).from(ActiveRecord::Bitemporal::DEFAULT_VALID_TO).to(destroyed_time + 1.day) }
+      it { expect { subject }.to change(employee, :transaction_from).from(updated_time).to(destroyed_time) }
+      it { expect { subject }.not_to change(employee, :transaction_to) }
     end
   end
 
   describe "#touch" do
     let!(:employee) { Employee.create(name: "Jane").tap { |it| it.update!(name: "Tom") } }
     let(:employee_count) { -> { Employee.ignore_valid_datetime.bitemporal_for(employee.id).count } }
-    subject { -> { employee.touch(:archived_at) } }
+    subject { employee.touch(:archived_at) }
 
     it { expect(employee).to have_attributes(name: "Tom", id: employee.id) }
-    it { expect(subject.call).to eq true }
-    it { is_expected.to change(&employee_count).by(1) }
-    it { is_expected.to change { employee.reload.archived_at }.from(nil) }
+    it { expect(subject).to eq true }
+    it { expect { subject }.to change(&employee_count).by(1) }
+    it { expect { subject }.to change { employee.reload.archived_at }.from(nil) }
   end
 
   describe "validation" do
@@ -1278,15 +1278,13 @@ RSpec.describe ActiveRecord::Bitemporal do
     context "with raise" do
       let!(:employee) { Employee.create(name: "Jane") }
       subject {
-        -> {
-          ActiveRecord::Base.transaction do
-            employee.update(name: "Tom")
-            raise ActiveRecord::Rollback
-          end
-        }
+        ActiveRecord::Base.transaction do
+          employee.update(name: "Tom")
+          raise ActiveRecord::Rollback
+        end
       }
-      it { is_expected.not_to change { employee.reload.name } }
-      it { is_expected.not_to change { Employee.ignore_valid_datetime.count } }
+      it { expect { subject }.not_to change { employee.reload.name } }
+      it { expect { subject }.not_to change { Employee.ignore_valid_datetime.count } }
     end
   end
 
@@ -1438,8 +1436,8 @@ RSpec.describe ActiveRecord::Bitemporal do
       end
 
       context "call with_bitemporal_option" do
-        subject { -> { ActiveRecord::Bitemporal.with_bitemporal_option(valid_datetime: "2010/4/1"){} } }
-        it { is_expected.not_to change(ActiveRecord::Bitemporal, :bitemporal_option) }
+        subject { ActiveRecord::Bitemporal.with_bitemporal_option(valid_datetime: "2010/4/1"){} }
+        it { expect { subject }.not_to change(ActiveRecord::Bitemporal, :bitemporal_option) }
       end
 
       context "nested with_bitemporal_option" do
@@ -2373,21 +2371,19 @@ RSpec.describe ActiveRecord::Bitemporal do
             end
           }
         }
-        proc do
-          [
-            thread_new.call(company.id),
-            thread_new.call(company.id),
-            thread_new.call(company.id),
-            thread_new.call(company2.id),
-            thread_new.call(company2.id),
-            thread_new.call(company2.id),
-          ].each { |t| t.join(3) }
-        end
+        [
+          thread_new.call(company.id),
+          thread_new.call(company.id),
+          thread_new.call(company.id),
+          thread_new.call(company2.id),
+          thread_new.call(company2.id),
+          thread_new.call(company2.id),
+        ].each { |t| t.join(3) }
       end
-      it { is_expected.to change { Company.ignore_valid_datetime.count }.by(2) }
+      it { expect { subject }.to change { Company.ignore_valid_datetime.count }.by(2) }
       (1..10).each do
         it do
-          subject.call
+          subject
           com1, com2 = Company.ignore_valid_datetime.bitemporal_for(company.id).order(:valid_from).last(2)
           expect(com1.valid_to).not_to eq com2.valid_to
         end
@@ -2410,20 +2406,18 @@ RSpec.describe ActiveRecord::Bitemporal do
               end
             }
           }
-          proc do
-            [
-              thread_new.call(company.id),
-              thread_new.call(company.id),
-              thread_new.call(company.id),
-              thread_new.call(company2.id),
-              thread_new.call(company2.id),
-              thread_new.call(company2.id),
-            ].each { |t| t.join(3) }
-          end
+          [
+            thread_new.call(company.id),
+            thread_new.call(company.id),
+            thread_new.call(company.id),
+            thread_new.call(company2.id),
+            thread_new.call(company2.id),
+            thread_new.call(company2.id),
+          ].each { |t| t.join(3) }
         end
-        it { is_expected.to change { Company.ignore_valid_datetime.count }.by(2) }
+        it { expect { subject }.to change { Company.ignore_valid_datetime.count }.by(2) }
         it do
-          subject.call
+          subject
           com1, com2 = Company.ignore_valid_datetime.bitemporal_for(company.id).order(:valid_from).last(2)
           expect(com1.valid_to).not_to eq com2.valid_to
         end
@@ -2448,19 +2442,17 @@ RSpec.describe ActiveRecord::Bitemporal do
             end
           }
         }
-        proc do
-          [
-            thread_new.call(company.id),
-            thread_new.call(company.id),
-            thread_new.call(company.id),
-            thread_new.call(company2.id),
-            thread_new.call(company2.id),
-          ].each { |t| t.join(3) }
-        end
+        [
+          thread_new.call(company.id),
+          thread_new.call(company.id),
+          thread_new.call(company.id),
+          thread_new.call(company2.id),
+          thread_new.call(company2.id),
+        ].each { |t| t.join(3) }
       end
       (1..10).each do
         it do
-          subject.call
+          subject
           com1, com2 = Company.ignore_valid_datetime.bitemporal_for(company.id).order(:valid_from).last(2)
           expect(com1.valid_to).not_to eq com2.valid_to
         end

--- a/spec/activerecord-bitemporal/polymorphic_spec.rb
+++ b/spec/activerecord-bitemporal/polymorphic_spec.rb
@@ -55,9 +55,9 @@ RSpec.describe "Model with polymorphic option" do
     let(:picture2) { product.pictures.create(name: "Picture2") }
     let(:picture1_imageable_name) { -> { picture1.imageable.name } }
     let(:picture2_imageable_name) { -> { picture2.imageable.name } }
-    subject { -> { product.update!(name: "New") } }
+    subject { product.update!(name: "New") }
 
-    it { is_expected.to change(&picture1_imageable_name).from("Product").to("New") }
-    it { is_expected.to change(&picture2_imageable_name).from("Product").to("New") }
+    it { expect { subject }.to change(&picture1_imageable_name).from("Product").to("New") }
+    it { expect { subject }.to change(&picture2_imageable_name).from("Product").to("New") }
   end
 end

--- a/spec/activerecord-bitemporal/relation_spec.rb
+++ b/spec/activerecord-bitemporal/relation_spec.rb
@@ -34,20 +34,20 @@ RSpec.describe "Relation" do
 
     context "when creating" do
       let(:count) { -> { Employee.all.count } }
-      subject { -> { Employee.create!(name: "Homu") } }
-      it { is_expected.to change(&count).by(1) }
+      subject { Employee.create!(name: "Homu") }
+      it { expect { subject }.to change(&count).by(1) }
     end
 
     context "when updating" do
       let(:count) { -> { Employee.all.count } }
-      subject { -> { Employee.first.update(name: "Homu") } }
-      it { is_expected.not_to change(&count) }
+      subject { Employee.first.update(name: "Homu") }
+      it { expect { subject }.not_to change(&count) }
     end
 
     context "when destroying" do
       let(:count) { -> { Employee.all.count } }
-      subject { -> { Employee.first.destroy } }
-      it { is_expected.to change(&count).by(-1) }
+      subject { Employee.first.destroy }
+      it { expect { subject }.to change(&count).by(-1) }
     end
   end
 
@@ -89,15 +89,15 @@ RSpec.describe "Relation" do
     context "update `name` to `Jane`" do
       before { Employee.create!(name: "Tom") }
       let(:count) { -> { Employee.where(name: "Tom").count } }
-      subject { -> { Employee.find_by(name: "Tom").update(name: "Jane") } }
-      it { is_expected.to change(&count).by(-1) }
+      subject { Employee.find_by(name: "Tom").update(name: "Jane") }
+      it { expect { subject }.to change(&count).by(-1) }
     end
 
     context "update `name` to `Tom`" do
       before { Employee.create!(name: "Tom") }
       let(:count) { -> { Employee.where(name: "Tom").count } }
-      subject { -> { Employee.where.not(name: "Tom").first.update(name: "Tom") } }
-      it { is_expected.to change(&count).by(1) }
+      subject { Employee.where.not(name: "Tom").first.update(name: "Tom") }
+      it { expect { subject }.to change(&count).by(1) }
     end
   end
 
@@ -110,14 +110,14 @@ RSpec.describe "Relation" do
 
     context "update `name`" do
       let(:count) { -> { Employee.count } }
-      subject { -> { Employee.first.update(name: "Tom") } }
-      it { is_expected.not_to change(&count) }
+      subject { Employee.first.update(name: "Tom") }
+      it { expect { subject }.not_to change(&count) }
     end
 
     context "force_update `valid_to`" do
       let(:count) { -> { Employee.count } }
-      subject { -> { Employee.first.force_update { |it| it.update(valid_to: Time.current) } } }
-      it { is_expected.to change(&count).by(-1) }
+      subject { Employee.first.force_update { |it| it.update(valid_to: Time.current) } }
+      it { expect { subject }.to change(&count).by(-1) }
     end
   end
 

--- a/spec/activerecord-bitemporal/through_spec.rb
+++ b/spec/activerecord-bitemporal/through_spec.rb
@@ -93,17 +93,17 @@ RSpec.describe "has_xxx with through" do
     it { expect(article.user).to eq user }
 
     context "user.create" do
-      subject { -> { blog.users.create!(name: "Homu") } }
-      it { is_expected.to change { blog.users.count }.by(1) }
-      it { is_expected.to change { blog.articles.count }.by(1) }
-      it { is_expected.not_to change { user.articles.count } }
+      subject { blog.users.create!(name: "Homu") }
+      it { expect { subject }.to change { blog.users.count }.by(1) }
+      it { expect { subject }.to change { blog.articles.count }.by(1) }
+      it { expect { subject }.not_to change { user.articles.count } }
     end
 
     context "user.articles.create" do
-      subject { -> { user.articles.create!(title: "sukiyaki", blog: blog) } }
-      it { is_expected.to change { blog.users.count }.by(1) }
-      it { is_expected.to change { blog.articles.count }.by(1) }
-      it { is_expected.to change { user.articles.count }.by(1) }
+      subject { user.articles.create!(title: "sukiyaki", blog: blog) }
+      it { expect { subject }.to change { blog.users.count }.by(1) }
+      it { expect { subject }.to change { blog.articles.count }.by(1) }
+      it { expect { subject }.to change { user.articles.count }.by(1) }
     end
   end
 
@@ -113,26 +113,26 @@ RSpec.describe "has_xxx with through" do
     let!(:article) { user.articles.create!(title: "yakiniku", blog: blog).tap { |it| it.update(title: "sushi") } }
 
     context "user.update" do
-      subject { -> { user.update(name: "Kevin") } }
-      it { is_expected.not_to change { blog.users.count } }
-      it { is_expected.not_to change { blog.articles.count } }
-      it { is_expected.not_to change { user.articles.count } }
-      it { is_expected.to change { blog.users.first.name }.from("Tom").to("Kevin") }
+      subject { user.update(name: "Kevin") }
+      it { expect { subject }.not_to change { blog.users.count } }
+      it { expect { subject }.not_to change { blog.articles.count } }
+      it { expect { subject }.not_to change { user.articles.count } }
+      it { expect { subject }.to change { blog.users.first.name }.from("Tom").to("Kevin") }
 
-      it { is_expected.to change { blog.users.ignore_valid_datetime.count }.by(2) }
-      it { is_expected.not_to change { blog.articles.ignore_valid_datetime.count } }
+      it { expect { subject }.to change { blog.users.ignore_valid_datetime.count }.by(2) }
+      it { expect { subject }.not_to change { blog.articles.ignore_valid_datetime.count } }
     end
 
     context "article.update" do
-      subject { -> { article.update(title: "kaisendon") } }
-      it { is_expected.not_to change { blog.users.count } }
-      it { is_expected.not_to change { blog.articles.count } }
-      it { is_expected.not_to change { user.articles.count } }
-      it { is_expected.to change { blog.articles.first.title }.from("sushi").to("kaisendon") }
-      it { is_expected.to change { user.articles.first.title }.from("sushi").to("kaisendon") }
+      subject { article.update(title: "kaisendon") }
+      it { expect { subject }.not_to change { blog.users.count } }
+      it { expect { subject }.not_to change { blog.articles.count } }
+      it { expect { subject }.not_to change { user.articles.count } }
+      it { expect { subject }.to change { blog.articles.first.title }.from("sushi").to("kaisendon") }
+      it { expect { subject }.to change { user.articles.first.title }.from("sushi").to("kaisendon") }
 
-      it { is_expected.to change { blog.users.ignore_valid_datetime.count }.by(2) }
-      it { is_expected.to change { blog.articles.ignore_valid_datetime.count }.by(1) }
+      it { expect { subject }.to change { blog.users.ignore_valid_datetime.count }.by(2) }
+      it { expect { subject }.to change { blog.articles.ignore_valid_datetime.count }.by(1) }
     end
   end
 

--- a/spec/activerecord-bitemporal/transaction_at_spec.rb
+++ b/spec/activerecord-bitemporal/transaction_at_spec.rb
@@ -254,15 +254,15 @@ RSpec.describe "transaction_at" do
       let(:company) { Timecop.freeze(created_at) { Company.create(name: "Company1") } }
       let(:updated_at) { created_at + 1.days }
       let(:valid_datetime) { company.valid_from - 1.days }
-      subject { -> {
+      subject {
         Timecop.freeze(updated_at) {
           ActiveRecord::Bitemporal.valid_at(valid_datetime) {
             company.update(name: "Comapny2")
           }
         }
-      } }
+      }
       it do
-        is_expected.to change { Company.ignore_valid_datetime.bitemporal_for(company.id).order(:transaction_from).pluck(:transaction_from) }.to match [created_at, updated_at]
+        expect { subject }.to change { Company.ignore_valid_datetime.bitemporal_for(company.id).order(:transaction_from).pluck(:transaction_from) }.to match [created_at, updated_at]
       end
     end
   end
@@ -531,27 +531,27 @@ RSpec.describe "transaction_at" do
     end
 
     describe ".create" do
-      subject { -> { EmployeeWithUniquness.create!(name: "Tom") } }
+      subject { EmployeeWithUniquness.create!(name: "Tom") }
       context "exists destroyed model" do
         let(:employee) { EmployeeWithUniquness.create!(name: "Jane").tap { |it| it.update(name: "Tom") } }
         before do
           employee.destroy!
         end
-        it { is_expected.not_to raise_error }
+        it { expect { subject }.not_to raise_error }
       end
 
       context "exists past model" do
         before do
           EmployeeWithUniquness.create!(name: "Tom", transaction_from: "1982/12/02", transaction_to: "2001/03/24")
         end
-        it { is_expected.not_to raise_error }
+        it { expect { subject }.not_to raise_error }
       end
 
       context "exists future model" do
         before do
           EmployeeWithUniquness.create!(name: "Tom", transaction_from: Time.current + 10.days)
         end
-        it { is_expected.to raise_error ActiveRecord::RecordInvalid }
+        it { expect { subject }.to raise_error ActiveRecord::RecordInvalid }
       end
     end
 
@@ -619,31 +619,31 @@ RSpec.describe "transaction_at" do
     end
 
     context "create" do
-      subject { -> { WithoutCreatedAtDeletedAt.create!(name: "Tom") } }
-      it { is_expected.not_to raise_error }
+      subject { WithoutCreatedAtDeletedAt.create!(name: "Tom") }
+      it { expect { subject }.not_to raise_error }
 
       context "with transaction_to" do
-        subject { -> { WithoutCreatedAtDeletedAt.create!(name: "Tom", transaction_to: Time.current + 10.days) } }
-        it { is_expected.not_to raise_error }
+        subject { WithoutCreatedAtDeletedAt.create!(name: "Tom", transaction_to: Time.current + 10.days) }
+        it { expect { subject }.not_to raise_error }
       end
     end
 
     context "update" do
       let(:record) { WithoutCreatedAtDeletedAt.create!(name: "Tom") }
-      subject { -> { record.update(name: "Jane") } }
-      it { is_expected.not_to raise_error }
+      subject { record.update(name: "Jane") }
+      it { expect { subject }.not_to raise_error }
     end
 
     context "force_update" do
       let(:record) { WithoutCreatedAtDeletedAt.create!(name: "Tom") }
-      subject { -> { record.force_update { |record| record.update(name: "Jane") } } }
-      it { is_expected.not_to raise_error }
+      subject { record.force_update { |record| record.update(name: "Jane") } }
+      it { expect { subject }.not_to raise_error }
     end
 
     context "destroy" do
       let(:record) { WithoutCreatedAtDeletedAt.create!(name: "Tom") }
-      subject { -> { record.destroy! } }
-      it { is_expected.not_to raise_error }
+      subject { record.destroy! }
+      it { expect { subject }.not_to raise_error }
     end
   end
 end

--- a/spec/activerecord-bitemporal/uniqueness_spec.rb
+++ b/spec/activerecord-bitemporal/uniqueness_spec.rb
@@ -210,17 +210,17 @@ RSpec.describe ActiveRecord::Bitemporal::Uniqueness do
       end
 
       context "update to name" do
-        subject { -> { employee.update!(name: "Tom") } }
+        subject { employee.update!(name: "Tom") }
 
         context "exitst other records" do
           context "same name" do
             let!(:other) { EmployeeWithUniquness.create!(name: "Jane").tap { |m| m.update!(name: "Tom") } }
-            it { is_expected.to raise_error ActiveRecord::RecordInvalid }
+            it { expect { subject }.to raise_error ActiveRecord::RecordInvalid }
           end
           context "other name" do
             let!(:other) { EmployeeWithUniquness.create!(name: "Mami").tap { |m| m.update!(name: "Homu") }  }
-            it { is_expected.not_to raise_error }
-            it { is_expected.to change { employee.reload.name }.from("Jane").to("Tom") }
+            it { expect { subject }.not_to raise_error }
+            it { expect { subject }.to change { employee.reload.name }.from("Jane").to("Tom") }
           end
         end
 
@@ -229,12 +229,12 @@ RSpec.describe ActiveRecord::Bitemporal::Uniqueness do
           before do
             other.update!(name: "Homu")
           end
-          it { is_expected.not_to raise_error }
-          it { is_expected.to change { employee.reload.name }.from("Jane").to("Tom") }
+          it { expect { subject }.not_to raise_error }
+          it { expect { subject }.to change { employee.reload.name }.from("Jane").to("Tom") }
 
           context "with `valid_at`" do
-            subject { -> { employee.valid_at(Time.current - 1.days) { |m| m.update!(name: "Tom") } } }
-            it { is_expected.to raise_error ActiveRecord::RecordInvalid }
+            subject { employee.valid_at(Time.current - 1.days) { |m| m.update!(name: "Tom") } }
+            it { expect { subject }.to raise_error ActiveRecord::RecordInvalid }
           end
         end
 
@@ -243,12 +243,12 @@ RSpec.describe ActiveRecord::Bitemporal::Uniqueness do
           before do
             other.destroy
           end
-          it { is_expected.not_to raise_error }
-          it { is_expected.to change { employee.reload.name }.from("Jane").to("Tom") }
+          it { expect { subject }.not_to raise_error }
+          it { expect { subject }.to change { employee.reload.name }.from("Jane").to("Tom") }
 
           context "with `valid_at`" do
-            subject { -> { employee.valid_at(Time.current - 1.days) { |m| m.update!(name: "Tom") } } }
-            it { is_expected.to raise_error ActiveRecord::RecordInvalid }
+            subject { employee.valid_at(Time.current - 1.days) { |m| m.update!(name: "Tom") } }
+            it { expect { subject }.to raise_error ActiveRecord::RecordInvalid }
           end
         end
       end
@@ -261,20 +261,20 @@ RSpec.describe ActiveRecord::Bitemporal::Uniqueness do
     end
 
     describe ".create" do
-      subject { -> { EmployeeWithUniquness.create!(name: "Tom") } }
+      subject { EmployeeWithUniquness.create!(name: "Tom") }
       context "exists destroyed model" do
         let(:employee) { EmployeeWithUniquness.create!(name: "Jane").tap { |it| it.update(name: "Tom") } }
         before do
           employee.destroy!
         end
-        it { is_expected.not_to raise_error }
+        it { expect { subject }.not_to raise_error }
       end
 
       context "exists past model" do
         before do
           EmployeeWithUniquness.create!(name: "Tom", valid_from: "1982/12/02", valid_to: "2001/03/24")
         end
-        it { is_expected.not_to raise_error }
+        it { expect { subject }.not_to raise_error }
       end
     end
 


### PR DESCRIPTION
Fix for RSpec deprecated warning.
e.g.

```
The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `#<Class:0x000055bd9f501ba0>#swapped_id_previously_was`` not `expect(value).to change `#<Class:0x000055bd9f501ba0>#swapped_id_previously_was``
```