### PR TITLE
Add some files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .bundle/
+.rspec_status
+Gemfile.lock
 gemfiles/*.gemfile.lock


### PR DESCRIPTION
This PR is adds some files to `.gitignore`.

* `.rspec_status`
  * This file is defined in [spec_helper](https://github.com/kufu/activerecord-bitemporal/blob/ed610e458c58cc494287c810823ff276f6f93e50/spec/spec_helper.rb#L14)
* `Gemfile.lock`
  * Follow up #126