### PR TITLE
Change not to create history when destroying with `force_update`

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -346,17 +346,20 @@ module ActiveRecord
           _run_destroy_callbacks {
             @destroyed = update_transaction_to(operated_at)
 
-            # 削除時の状態を履歴レコードとして保存する
-            duplicated_instance.valid_to = target_datetime
-            duplicated_instance.transaction_from = operated_at
-            duplicated_instance.save_without_bitemporal_callbacks!(validate: false)
-            if @destroyed
-              @_swapped_id_previously_was = swapped_id
-              @_swapped_id = duplicated_instance.swapped_id
-              self.valid_from = duplicated_instance.valid_from
-              self.valid_to = duplicated_instance.valid_to
-              self.transaction_from = duplicated_instance.transaction_from
-              self.transaction_to = duplicated_instance.transaction_to
+            # force_update の場合は削除時の状態の履歴を残さない
+            unless force_update?
+              # 削除時の状態を履歴レコードとして保存する
+              duplicated_instance.valid_to = target_datetime
+              duplicated_instance.transaction_from = operated_at
+              duplicated_instance.save_without_bitemporal_callbacks!(validate: false)
+              if @destroyed
+                @_swapped_id_previously_was = swapped_id
+                @_swapped_id = duplicated_instance.swapped_id
+                self.valid_from = duplicated_instance.valid_from
+                self.valid_to = duplicated_instance.valid_to
+                self.transaction_from = duplicated_instance.transaction_from
+                self.transaction_to = duplicated_instance.transaction_to
+              end
             end
           }
           raise ActiveRecord::RecordInvalid unless @destroyed


### PR DESCRIPTION
This PR changes the `destroy` behavior on `force_update`. Previously, when destroying, the state before destruction was added as history.

```ruby
employee = Employee.create!
employee.destroy!

puts ActiveRecord::Bitemporal::Visualizer.visualize(employee)

# transaction_datetime    | valid_datetime
#                         | 2023-06-27 16:23:24.487
#                         |                   | 2023-06-27 16:23:52.387
#                         |                   |                   | 9999-12-31 09:00:00.000
# 2023-06-27 16:23:24.487 +---------------------------------------+
#                         |                                       |
#                         |                                       |
#                         |                                       |
#                         |                                       |
# 2023-06-27 16:23:52.387 +-------------------+-------------------+
#                         |*******************|
#                         |*******************|
#                         |*******************|
#                         |*******************|
# 9999-12-31 09:00:00.000 +-------------------+
```

After this change, destruction performed within `force_update` will no longer create history.

```ruby
employee = Employee.create!
employee.force_update { employee.destroy! }

puts ActiveRecord::Bitemporal::Visualizer.visualize(employee)

# transaction_datetime    | valid_datetime
#                         | 2023-06-27 08:42:13.857
#                         |                                       | 9999-12-31 00:00:00.000
# 2023-06-27 08:42:13.857 +---------------------------------------+
#                         |***************************************|
#                         |***************************************|
#                         |***************************************|
#                         |***************************************|
#                         |***************************************|
#                         |***************************************|
#                         |***************************************|
#                         |***************************************|
#                         |***************************************|
# 2023-06-27 08:42:26.857 +---------------------------------------+
```

This is an application of `force_update`'s "operate without saving history" property to destruction.

This is useful for destruction without history if you accidentally creates a record. This is equivalent to `update_columns(transaction_to: Time.current)`, but is implemented as an Active Record interface to benefit from standard mechanisms such as callbacks.