### PR TITLE
Add ActiveRecord::Bitemporal.freeze_transaction_datetime

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -73,10 +73,12 @@ module ActiveRecord
         end
 
         def transaction_at(datetime, &block)
+          raise 'already transaction_datetime is specified' if frozen_transaction_datetime.present?
           with_bitemporal_option(ignore_transaction_datetime: false, transaction_datetime: datetime, &block)
         end
 
         def transaction_at!(datetime, &block)
+          raise 'already transaction_datetime is specified' if frozen_transaction_datetime.present?
           with_bitemporal_option(ignore_transaction_datetime: false, transaction_datetime: datetime, force_transaction_datetime: true, &block)
         end
 
@@ -89,11 +91,15 @@ module ActiveRecord
         end
 
         def freeze_transaction_datetime(&block)
-          with_bitemporal_option(frozen_transaction_datetime: Time.current, &block)
+          raise 'already transaction_datetime is specified' if transaction_datetime.present?
+          with_bitemporal_option(frozen_transaction_datetime: true,
+                                 ignore_transaction_datetime: false,
+                                 transaction_datetime: Time.current, &block)
         end
 
         def frozen_transaction_datetime
-          bitemporal_option[:frozen_transaction_datetime]
+          return nil unless bitemporal_option[:frozen_transaction_datetime]
+          bitemporal_option[:transaction_datetime]
         end
 
         def merge_by(option)
@@ -229,6 +235,7 @@ module ActiveRecord
         end
 
         def transaction_at(datetime, &block)
+          raise 'already transaction_datetime is specified' if frozen_transaction_datetime.present?
           with_bitemporal_option(transaction_datetime: datetime, &block)
         end
 
@@ -251,7 +258,8 @@ module ActiveRecord
         end
 
         def frozen_transaction_datetime
-          bitemporal_option[:frozen_transaction_datetime]
+          return nil unless bitemporal_option[:frozen_transaction_datetime]
+          bitemporal_option[:transaction_datetime]
         end
       end
       include PersistenceOptionable

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -93,7 +93,7 @@ module ActiveRecord
         end
 
         def frozen_transaction_datetime
-          bitemporal_option[:frozen_transaction_datetime]&.in_time_zone
+          bitemporal_option[:frozen_transaction_datetime]
         end
 
         def merge_by(option)
@@ -251,7 +251,7 @@ module ActiveRecord
         end
 
         def frozen_transaction_datetime
-          bitemporal_option[:frozen_transaction_datetime]&.in_time_zone
+          bitemporal_option[:frozen_transaction_datetime]
         end
       end
       include PersistenceOptionable

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -106,10 +106,6 @@ module ActiveRecord
             option_.merge!(transaction_datetime: bitemporal_option_storage[:transaction_datetime])
           end
 
-          if bitemporal_option_storage[:frozen_transaction_datetime]
-            option_.merge!(frozen_transaction_datetime: bitemporal_option_storage[:frozen_transaction_datetime])
-          end
-
           bitemporal_option_storage.merge(option_)
         end
       private

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -463,7 +463,7 @@ module ActiveRecord
 
       private
 
-      def bitemporal_assign_initialize_value(valid_datetime:, transaction_datetime: nil)
+      def bitemporal_assign_initialize_value(valid_datetime:, transaction_datetime:)
         # 自身の `valid_from` を設定
         current_time = Time.current
         self.valid_from = valid_datetime || current_time if self.valid_from == ActiveRecord::Bitemporal::DEFAULT_VALID_FROM

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -549,6 +549,9 @@ module ActiveRecord
           after_instance.transaction_from = target_transaction_datetime
         end
 
+        raise ActiveRecord::RecordInvalid.new(before_instance) if before_instance&.transaction_from_cannot_be_greater_equal_than_transaction_to
+        raise ActiveRecord::RecordInvalid.new(after_instance) if after_instance.transaction_from_cannot_be_greater_equal_than_transaction_to
+
         [current_valid_record, before_instance, after_instance]
       end
     end

--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -393,6 +393,8 @@ module ActiveRecord::Bitemporal
 
       # transaction_from <= datetime && datetime < transaction_to
       scope :transaction_at, -> (datetime) {
+        raise 'already transaction_datetime is specified' if ActiveRecord::Bitemporal.frozen_transaction_datetime.present?
+
         if ActiveRecord::Bitemporal.force_transaction_datetime?
           datetime = ActiveRecord::Bitemporal.transaction_datetime
         end

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -2705,6 +2705,8 @@ RSpec.describe ActiveRecord::Bitemporal do
   describe ".freeze_transaction_datetime" do
     context 'with freeze_transaction_datetime' do
       it 'same transaction_datetime for create, update and delete operations' do
+
+        employee_for_create = nil
         employee_for_update = Employee.create!(name: "Jone")
         employee_for_destroy = Employee.create!(name: "Mami")
 
@@ -2712,27 +2714,28 @@ RSpec.describe ActiveRecord::Bitemporal do
           employee_for_create = Employee.create!(name: "Homu")
           employee_for_update.update!(name: "Bonnie")
           employee_for_destroy.destroy!
-
-          create_transaction_datetime = employee_for_create.reload.transaction_from
-
-          update_transaction_datetimes = Employee.ignore_bitemporal_datetime
-                                                 .bitemporal_for(employee_for_update.id)
-                                                 .order(:updated_at)
-
-          expect(update_transaction_datetimes).to match_array([have_attributes(transaction_to: create_transaction_datetime),
-                                                               have_attributes(transaction_from: create_transaction_datetime,
-                                                                               transaction_to: ActiveRecord::Bitemporal::DEFAULT_TRANSACTION_TO),
-                                                               have_attributes(transaction_from: create_transaction_datetime,
-                                                                               transaction_to: ActiveRecord::Bitemporal::DEFAULT_TRANSACTION_TO)])
-
-          destroy_transaction_datetimes = Employee.ignore_bitemporal_datetime
-                                                  .bitemporal_for(employee_for_destroy.id)
-                                                  .order(:updated_at)
-
-          expect(destroy_transaction_datetimes).to match_array([have_attributes(transaction_to: create_transaction_datetime),
-                                                                have_attributes(transaction_from: create_transaction_datetime,
-                                                                                transaction_to: ActiveRecord::Bitemporal::DEFAULT_TRANSACTION_TO)])
         end
+
+        create_transaction_datetime = employee_for_create.reload.transaction_from
+
+        update_transaction_datetimes = Employee.ignore_bitemporal_datetime
+                                               .bitemporal_for(employee_for_update.id)
+                                               .order(:updated_at)
+
+        expect(update_transaction_datetimes).to match_array([have_attributes(transaction_to: create_transaction_datetime),
+                                                             have_attributes(transaction_from: create_transaction_datetime,
+                                                                             transaction_to: ActiveRecord::Bitemporal::DEFAULT_TRANSACTION_TO),
+                                                             have_attributes(transaction_from: create_transaction_datetime,
+                                                                             transaction_to: ActiveRecord::Bitemporal::DEFAULT_TRANSACTION_TO)])
+
+        destroy_transaction_datetimes = Employee.ignore_bitemporal_datetime
+                                                .bitemporal_for(employee_for_destroy.id)
+                                                .order(:updated_at)
+
+        expect(destroy_transaction_datetimes).to match_array([have_attributes(transaction_to: create_transaction_datetime),
+                                                              have_attributes(transaction_from: create_transaction_datetime,
+                                                                              transaction_to: ActiveRecord::Bitemporal::DEFAULT_TRANSACTION_TO)])
+
       end
     end
 


### PR DESCRIPTION
## Summary
When changing multiple records in one operation, I want to see the `transaction_datetime` of multiple models and get the values ​​before and after the change.

At that time, especially when multiple models, such as models with associations, and create, update, and delete operations are mixed
It is difficult to specify "single operation" because `transaction_datetime` is calculated separately.

Therefore, I implemented a function to fix the `transaction_datetime` during operation.

## Execution sample
```ruby
ActiveRecord::Bitemporal.freeze_transaction_datetime do
  employee_for_create = Employee.create!(name: "Homu")
  employee_for_update.update!(name: "Bonnie")
  # transaction_datetime is fixed 
  # employee_for_create.transaction_from == employee_for_update.transaction_from
  employee_for_destroy.destroy! 
  # transaction_datetime is fixed 
  # employee_for_create.transaction_from == employee_for_destroy.transaction_from
end
```

The reason I made it a different method from the existing `ActiveRecord::Bitemporal.transaction_at` is because I thought it would be better if it could be fixed at the time instead of being specified at an arbitrary time.