### PR TITLE
Allow passing operated_at to destroy

### DIFF
--- a/lib/activerecord-bitemporal/callbacks.rb
+++ b/lib/activerecord-bitemporal/callbacks.rb
@@ -10,7 +10,7 @@ module ActiveRecord::Bitemporal
       define_model_callbacks :bitemporal_destroy
     end
 
-    def destroy
+    def destroy(...)
       perform_bitemporal_callbacks? ? run_callbacks(:bitemporal_destroy) { super } : super
     end
 

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -1196,6 +1196,14 @@ RSpec.describe ActiveRecord::Bitemporal do
       it { expect { subject }.to change(employee, :transaction_from).from(updated_time).to(destroyed_time) }
       it { expect { subject }.not_to change(employee, :transaction_to) }
     end
+
+    context "with operated_at" do
+      subject { employee.destroy(operated_at: destroyed_time) }
+      it { expect { subject }.not_to change(employee, :valid_from) }
+      it { expect { subject }.to change(employee, :valid_to).from(ActiveRecord::Bitemporal::DEFAULT_VALID_TO).to(destroyed_time) }
+      it { expect { subject }.to change(employee, :transaction_from).from(updated_time).to(destroyed_time) }
+      it { expect { subject }.not_to change(employee, :transaction_to) }
+    end
   end
 
   describe "#touch" do


### PR DESCRIPTION
Closes https://github.com/kufu/activerecord-bitemporal/pull/137

This PR has the same motivation as #137, but a different solution. Extend the `destroy`'s interface to allow passing an `operated_at`.

```ruby
current_time = Time.current
company.destroy(operated_at: current_time)
employee.destroy(operated_at: current_time)
```

Note that this solution only solves the issue for `destroy`. There is no way to match transaction times across different models in other scenarios. But for our use case this is enough for now.

Ultimately, we may need a generic API like `freeze_transaction_datetime`, but we should be careful when designing an interface that allows you to change the transaction time.