### PR TITLE
Add validation for `valid_from == valid_datetime`

### DIFF
--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -109,6 +109,12 @@ module ActiveRecord::Bitemporal::Bitemporalize
       end
     end
 
+    def valid_from_cannot_be_equal_to_valid_datetime
+      if persisted? && changed? && !force_update? && valid_from && valid_datetime && valid_from == valid_datetime
+        errors.add(:valid_from, "can't be equal to valid_datetime")
+      end
+    end
+
     def transaction_from_cannot_be_greater_equal_than_transaction_to
       if transaction_from && transaction_to && transaction_from >= transaction_to
         errors.add(:transaction_from, "can't be greater equal than transaction_to")
@@ -157,6 +163,7 @@ module ActiveRecord::Bitemporal::Bitemporalize
     validates :transaction_from, presence: true
     validates :transaction_to, presence: true
     validate :valid_from_cannot_be_greater_equal_than_valid_to
+    validate :valid_from_cannot_be_equal_to_valid_datetime
     validate :transaction_from_cannot_be_greater_equal_than_transaction_to
 
     validates bitemporal_id_key, uniqueness: true, allow_nil: true, strict: enable_strict_by_validates_bitemporal_id


### PR DESCRIPTION
Closes https://github.com/kufu/activerecord-bitemporal/pull/136

This PR has the same motivation as https://github.com/kufu/activerecord-bitemporal/pull/136, but a different solution. Added a validation for `valid_from == valid_datetime`.

Looking at the https://github.com/kufu/activerecord-bitemporal/pull/136 from a different perspective, it's caused by the validation step being too slow. We should validate that no unintended records occur with `valid?`, not `_update_row`. The most common cause of this problem is when `valid_from == valid_datetime`, so we report validation errors up front for such records.

Note that it is not always invalid when `valid_from == valid_datetime`. For example, given `valid_datetime`, the updated instance will always be `valid_from == valid_datetime`, but it is obviously valid:

```ruby
employee = Employee.first
employee.valid_at("2023/07/01") do |e|
  e.update!(name: "Jane")

  e.valid_datetime # => 2023/07/01
  e.valid_from     # => 2023/07/01
end
```

A notable property here is that the validation conditions change depending on the state of the instance. Specifically, only if the updates create a history in valid datetime. This is complicated compared to general Active Record validation, so I'm wondering if this change should be merged from that perspective.