### PR TITLE
Remove unneeded spec for Rails 5.x

### DIFF
--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -2743,10 +2743,4 @@ RSpec.describe ActiveRecord::Bitemporal do
       expect { employee.reload }.to change(employee, :previously_force_updated?).from(true).to(false)
     end
   end
-
-  describe "ActiveRecord" do
-    context "[Bug fix] https://github.com/rails/rails/pull/38583 in Rails 5.x" do
-      it { expect { Employee.where(Arel.sql("name").eq("Tom")).except_bitemporal_default_scope.to_sql }.not_to raise_error }
-    end
-  end
 end


### PR DESCRIPTION
This spec is introduced in https://github.com/kufu/activerecord-bitemporal/commit/193b47e1c148b6e3ba718fc6e701843c45279de0, but https://github.com/kufu/activerecord-bitemporal/pull/122 drops support for Rails 5.x.