### PR TITLE
Suppress changes after creating with bitemporal_id

### DIFF
--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -77,11 +77,11 @@ module ActiveRecord::Bitemporal::Bitemporalize
   module InstanceMethods
     include ActiveRecord::Bitemporal::Persistence
 
-    def swap_id!(without_clear_changes_information: false)
+    def swap_id!
       @_swapped_id_previously_was = nil
       @_swapped_id = self.id
       self.id = self.send(bitemporal_id_key)
-      clear_attribute_changes([:id]) unless without_clear_changes_information
+      clear_attribute_changes([:id])
     end
 
     def swapped_id
@@ -140,7 +140,7 @@ module ActiveRecord::Bitemporal::Bitemporalize
     after_create do
       # MEMO: #update_columns is not call #_update_row (and validations, callbacks)
       update_columns(bitemporal_id_key => swapped_id) unless send(bitemporal_id_key)
-      swap_id!(without_clear_changes_information: true)
+      swap_id!
     end
 
     after_find do

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe ActiveRecord::Bitemporal do
         it {
           is_expected.to have_attributes(
             bitemporal_id: subject.id,
+            changes: be_empty,
             previous_changes: include(
               "id" => [nil, subject.swapped_id],
               "valid_from" => [nil, be_present],
@@ -42,6 +43,7 @@ RSpec.describe ActiveRecord::Bitemporal do
         it {
           is_expected.to have_attributes(
             bitemporal_id: subject.id,
+            changes: be_empty,
             previous_changes: include(
               "id" => [nil, subject.id],
               "valid_from" => [nil, be_present],


### PR DESCRIPTION
Currently, creating a record with `bitemporal_id` unintentionally has changes.

```ruby
employee = Employee.create!(bitemporal_id: "a45296d3-ee21-4d3f-9235-ba2b3e679216")
employee.swapped_id # => "f77b261b-3bf2-45e3-891f-b35a25e0787d",

employee.changes
# => {"id"=>["f77b261b-3bf2-45e3-891f-b35a25e0787d", "a45296d3-ee21-4d3f-9235-ba2b3e679216"]}
```

This can cause unintended updates in autosave.

This PR removes `without_clear_changes_information` in `swap_id!` and makes it to always clear changes. This option seems to have been introduced in #37, but I couldn't understand from the PR why this was needed. Probably not needed.

