### PR TITLE
Bump up version to v4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 4.3.0
+
+### Added
+
+- [Add `previously_force_updated?` #142](https://github.com/kufu/activerecord-bitemporal/pull/142)
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Chores
+
+- [Remove unneeded spec for Rails 5.x #143](https://github.com/kufu/activerecord-bitemporal/pull/143)
+
 ## 4.2.0
 
 ### Added

--- a/lib/activerecord-bitemporal/version.rb
+++ b/lib/activerecord-bitemporal/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   module Bitemporal
-    VERSION = "4.2.0"
+    VERSION = "4.3.0"
   end
 end


### PR DESCRIPTION
## 4.3.0

### Added

- [Add `previously_force_updated?` #142](https://github.com/kufu/activerecord-bitemporal/pull/142)

### Changed

### Deprecated

### Removed

### Fixed

### Chores

- [Remove unneeded spec for Rails 5.x #143](https://github.com/kufu/activerecord-bitemporal/pull/143)
