### PR TITLE
Reduce update queries if pk is uuid

### DIFF
--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -151,9 +151,9 @@ module ActiveRecord::Bitemporal::Bitemporalize
         uuid = id || SecureRandom.uuid
         assign_attributes(id: uuid, bitemporal_id_key => uuid)
 
-        block.call
+        next unless block.call
       else
-        block.call
+        next unless block.call
 
         # MEMO: #update_columns is not call #_update_row (and validations, callbacks)
         update_columns(bitemporal_id_key => swapped_id) unless send(bitemporal_id_key)

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe ActiveRecord::Bitemporal do
 
             expect(new_record).to have_attributes(
               bitemporal_id: new_record.id,
+              swapped_id: new_record.id,
               previous_changes: include(
                 "id" => [nil, new_record.id],
                 "valid_from" => [nil, be_present],

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 ActiveRecord::Schema.define(version: 1) do
+  enable_extension "pgcrypto"
+
   create_table :companies, force: true do |t|
     t.string :name
 
@@ -82,6 +84,19 @@ ActiveRecord::Schema.define(version: 1) do
 
     t.timestamps
   end
+
+  create_table :plans, force: true, id: :uuid do |t|
+    t.string :name
+    t.uuid :bitemporal_id
+
+    t.datetime :valid_from, precision: 6
+    t.datetime :valid_to, precision: 6
+    t.datetime :deleted_at, precision: 6
+    t.datetime :transaction_from, precision: 6
+    t.datetime :transaction_to, precision: 6
+
+    t.timestamps
+  end
 end
 
 class Company < ActiveRecord::Base
@@ -151,3 +166,6 @@ class AddressWithoutBitemporal < ActiveRecord::Base
   belongs_to :employee, foreign_key: :employee_id
 end
 
+class Plan < ActiveRecord::Base
+  include ActiveRecord::Bitemporal
+end


### PR DESCRIPTION
When the column of bitemporal_id_key is uuid, the uuid can be generated and specified before insertion into the DB. In this case, there is no need to update bitemporal_id_key in after_create, so the update query can be reduced by one query.

Note that for types other than uuid, it is not possible to specify the next pk before inserting it into the DB, so the current logic is maintained.