### PR TITLE
Add Persistence#bitemporal_at and ActiveRecord::Bitemporal.bitemporal_at

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -92,6 +92,14 @@ module ActiveRecord
           with_bitemporal_option(ignore_transaction_datetime: true, transaction_datetime: nil, &block)
         end
 
+        def bitemporal_at(datetime, &block)
+          transaction_at(datetime) { valid_at(datetime, &block) }
+        end
+
+        def bitemporal_at!(datetime, &block)
+          transaction_at!(datetime) { valid_at!(datetime, &block) }
+        end
+
         def merge_by(option)
           option_ = option.dup
           if bitemporal_option_storage[:force_valid_datetime]
@@ -226,6 +234,10 @@ module ActiveRecord
 
         def transaction_at(datetime, &block)
           with_bitemporal_option(transaction_datetime: datetime, &block)
+        end
+
+        def bitemporal_at(datetime, &block)
+          transaction_at(datetime) { valid_at(datetime, &block) }
         end
 
         def bitemporal_option_merge_with_association!(other)

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -2402,7 +2402,7 @@ RSpec.describe ActiveRecord::Bitemporal do
       context "relation object" do
         # TODO: Cannot overwrite valid_datetime/transaction_datetime with bitemporal_at
         xit do
-            Company.bitemporal_at("2019/1/1").tap { |m|
+          Company.bitemporal_at("2019/1/1").tap { |m|
             expect(m.transaction_datetime).to eq "2019/1/1"
             result = ActiveRecord::Bitemporal.bitemporal_at!("2019/2/2") {
               expect(m.valid_datetime).to eq "2019/2/2"


### PR DESCRIPTION
This PR introduces `Persistence#bitemporal_at` and `ActiveRecord::Bitemporal.bitemporal_at`, which help you set a valid time and a transaction time at the same time.

This is inspired by the already existing `bitemporal_at` scope and improves the consistency of the interface:

```ruby
users = User.bitemporal_at("2024/01/01")
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."transaction_from" <= '2024-01-01 00:00:00'
#       AND "users"."transaction_to"   >  '2024-01-01 00:00:00'
#       AND "users"."valid_from"       <= '2024-01-01 00:00:00'
#       AND "users"."valid_to"         >  '2024-01-01 00:00:00'

user = users.first
user.bitemporal_at("2024/01/02") { _1.reload }
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."transaction_from" <= '2024-01-02 00:00:00'
#       AND "users"."transaction_to"   >  '2024-01-02 00:00:00'
#       AND "users"."valid_from"       <= '2024-01-02 00:00:00'
#       AND "users"."valid_to"         >  '2024-01-02 00:00:00'

ActiveRecord::Bitemporal.bitemporal_at("2024/01/03") { User.all }
# => SELECT "users".*
#      FROM "users"
#     WHERE "users"."transaction_from" <= '2024-01-03 00:00:00'
#       AND "users"."transaction_to"   >  '2024-01-03 00:00:00'
#       AND "users"."valid_from"       <= '2024-01-03 00:00:00'
#       AND "users"."valid_to"         >  '2024-01-03 00:00:00'
```