### PR TITLE
Fix deleted time order between associations

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -344,16 +344,17 @@ module ActiveRecord
         end || false
       end
 
-      def destroy(force_delete: false, operated_at: Time.current)
+      def destroy(force_delete: false, operated_at: nil)
         return super() if force_delete
-
-        target_datetime = valid_datetime || operated_at
-
-        duplicated_instance = self.class.find_at_time(target_datetime, self.id).dup
 
         ActiveRecord::Base.transaction(requires_new: true, joinable: false) do
           @destroyed = false
           _run_destroy_callbacks {
+            operated_at ||= Time.current
+            target_datetime = valid_datetime || operated_at
+
+            duplicated_instance = self.class.find_at_time(target_datetime, self.id).dup
+
             @destroyed = update_transaction_to(operated_at)
             @previously_force_updated = force_update?
 

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -116,8 +116,8 @@ class Employee < ActiveRecord::Base
 
   belongs_to :company, foreign_key: :company_id
 
-  has_one  :address,   foreign_key: :employee_id
-  has_one  :address_without_bitemporal,  foreign_key: :employee_id
+  has_one  :address,   foreign_key: :employee_id, dependent: :destroy
+  has_one  :address_without_bitemporal,  foreign_key: :employee_id, dependent: :destroy
 
   class <<self
     attr_accessor :call_after_save_count
@@ -147,8 +147,8 @@ end
 class EmployeeWithoutBitemporal < ActiveRecord::Base
   belongs_to :company, foreign_key: :company_id
 
-  has_one  :address,   foreign_key: :employee_id
-  has_one  :address_without_bitemporal,  foreign_key: :employee_id
+  has_one  :address,   foreign_key: :employee_id, dependent: :destroy
+  has_one  :address_without_bitemporal,  foreign_key: :employee_id, dependent: :destroy
 end
 
 


### PR DESCRIPTION
This PR fixes a strange problem with deletion times when deleting a model with a Bi-Temporal model association with `dependent: :destroy`.

Normally, when an association is deleted by `dependent: :destroy`, it is deleted before its parent by `before_destroy` callback.
https://github.com/rails/rails/blob/v7.1.3/activerecord/lib/active_record/associations/builder/association.rb#L141

However, strangely, the bitemporal gem creates a history where the parent is deleted first:

```ruby
employee = Employee.create(name: "John", address: Address.new(city: "Tokyo"))
emplpyee.destroy!

employee.valid_at(employee.address.valid_to) { |e| e.reload } # => ActiveRecord::RecordNotFound
```

Why does this happen? The cause is the timing of calculating the operation time. `ActiveRecord::Bitemporal::Persistence#destroy` is assigned the time when it is called as `operated_at`:

https://github.com/kufu/activerecord-bitemporal/blob/21420efc43ccf01cc44d4726c483cbbe9818502e/lib/activerecord-bitemporal/bitemporal.rb#L347

On the other hand, the callback fires inside the `destroy` method:

https://github.com/kufu/activerecord-bitemporal/blob/21420efc43ccf01cc44d4726c483cbbe9818502e/lib/activerecord-bitemporal/bitemporal.rb#L356

This causes the actual deletion to occur from child to parent, but the operation time is calculated from parent to child.

This PR fixes the problem by calculating the operation time inside the destroy callback.