### PR TITLE
Remove unneeded unscope values

### DIFF
--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -355,11 +355,6 @@ module ActiveRecord::Bitemporal
             relation.bitemporal_value[:with_transaction_datetime] = :default_scope
           end
 
-          # Calling scope was slow, so don't call scope
-          relation.unscope_values += [
-            { where: "#{table.name}.transaction_from" },
-            { where: "#{table.name}.transaction_to" }
-          ]
           relation = relation
             ._transaction_from_lteq(transaction_datetime || datetime, without_ignore: true)
             ._transaction_to_gt(transaction_datetime || datetime, without_ignore: true)
@@ -375,10 +370,6 @@ module ActiveRecord::Bitemporal
             relation.bitemporal_value[:with_valid_datetime] = :default_scope
           end
 
-          relation.unscope_values += [
-            { where: "#{table.name}.valid_from" },
-            { where: "#{table.name}.valid_to" }
-          ]
           relation = relation
             ._valid_from_lteq(valid_datetime || datetime, without_ignore: true)
             ._valid_to_gt(valid_datetime || datetime, without_ignore: true)


### PR DESCRIPTION
Unscope values in the `bitemporal_default_scope` were introduced in [this commit](https://github.com/kufu/activerecord-bitemporal/commit/c2cea8be637732930eda03221fdf86288a1fec70).

Since it is faster to build a query explicitly with a where clause than with a scope call, we hacked the [`unscope_values`](https://github.com/rails/rails/blob/8ad19d986519ee84c22a4a02368726616b41abd7/activerecord/lib/active_record/relation/query_methods.rb#L727) that Active Record uses internally and implemented overrides of valid_from/to and transaction_from/to.

However, in [the next commit](https://github.com/kufu/activerecord-bitemporal/commit/eedd2da364eb2df5236d338ed8e1e91a2333b12c), `where!` is replaced by `_valid_from_lteq` and `_valid_to_gt`, which use `rewhere`. When using `rewhere`, there is no need to override the original condition by  unscoped values, so this can simply be removed.