### PR TITLE
Remove database_cleaner

### DIFF
--- a/activerecord-bitemporal.gemspec
+++ b/activerecord-bitemporal.gemspec
@@ -31,6 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pg"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "pry-byebug"
-  spec.add_development_dependency "database_cleaner"
   spec.add_development_dependency "timecop"
 end

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -1325,7 +1325,7 @@ RSpec.describe ActiveRecord::Bitemporal do
     end
   end
 
-  describe "transaction" do
+  describe "transaction", use_truncation: true do
     context "with raise" do
       let!(:employee) { Employee.create(name: "Jane") }
       subject {


### PR DESCRIPTION
Removed `database_cleaner` due to the following error in Rails main.

https://app.circleci.com/pipelines/github/kufu/activerecord-bitemporal/2035/workflows/67f5d661-02d4-4999-9b31-8b378808f614/jobs/19459
```
An error occurred in a `before(:suite)` hook.
Failure/Error: DatabaseCleaner.clean_with(:truncation)

NoMethodError:
  undefined method `schema_migration' for an instance of ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
# /usr/local/bundle/gems/database_cleaner-active_record-2.1.0/lib/database_cleaner/active_record/base.rb:19:in `migration_table_name'
# /usr/local/bundle/gems/database_cleaner-active_record-2.1.0/lib/database_cleaner/active_record/base.rb:27:in `exclusion_condition'
# /usr/local/bundle/gems/database_cleaner-active_record-2.1.0/lib/database_cleaner/active_record/truncation.rb:239:in `tables_with_schema'
# /usr/local/bundle/gems/database_cleaner-active_record-2.1.0/lib/database_cleaner/active_record/truncation.rb:209:in `database_cleaner_table_cache'
# /usr/local/bundle/gems/database_cleaner-active_record-2.1.0/lib/database_cleaner/active_record/truncation.rb:38:in `tables_to_truncate'
# /usr/local/bundle/gems/database_cleaner-active_record-2.1.0/lib/database_cleaner/active_record/truncation.rb:25:in `block in clean'
# /usr/local/bundle/bundler/gems/rails-d65fec4fd2a0/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb:19:in `disable_referential_integrity'
# /usr/local/bundle/gems/database_cleaner-active_record-2.1.0/lib/database_cleaner/active_record/truncation.rb:21:in `clean'
# /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaner.rb:65:in `clean_with'
# /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:40:in `block in clean_with'
# /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:40:in `each'
# /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:40:in `clean_with'
# ./spec/spec_helper.rb:32:in `block (2 levels) in <top (required)>'
```

A PR that resolves this error already exists but has not yet been merged. (https://github.com/DatabaseCleaner/database_cleaner-active_record/pull/101) Therefore, it is unclear when a fixed version will be released.

Our use of `database_cleaner` is simple, so I removed the `database_cleaner` dependency and added a hook.
