### PR TITLE
Bump up version to v5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 5.0.1
+
+- [Fix a typo #157](https://github.com/kufu/activerecord-bitemporal/pull/157)
+- [Remove unneeded unscope values #159](https://github.com/kufu/activerecord-bitemporal/pull/159)
+- [Remove unused `without_ignore` option #160](https://github.com/kufu/activerecord-bitemporal/pull/160)
+- [update auto assign #161](https://github.com/kufu/activerecord-bitemporal/pull/161)
+
 ## 5.0.0
 
 ### Breaking Changed

--- a/lib/activerecord-bitemporal/version.rb
+++ b/lib/activerecord-bitemporal/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   module Bitemporal
-    VERSION = "5.0.0"
+    VERSION = "5.0.1"
   end
 end


### PR DESCRIPTION
## 5.0.1

- [Fix a typo #157](https://github.com/kufu/activerecord-bitemporal/pull/157)
- [Remove unneeded unscope values #159](https://github.com/kufu/activerecord-bitemporal/pull/159)
- [Remove unused `without_ignore` option #160](https://github.com/kufu/activerecord-bitemporal/pull/160)
- [update auto assign #161](https://github.com/kufu/activerecord-bitemporal/pull/161)