### PR TITLE
Bump up version to v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 5.1.0
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- [Remove `joinable: false` #156](https://github.com/kufu/activerecord-bitemporal/pull/156)
+
+### Chores
+
+- [Remove database_cleaner #162](https://github.com/kufu/activerecord-bitemporal/pull/162)
+
 ## 5.0.1
 
 - [Fix a typo #157](https://github.com/kufu/activerecord-bitemporal/pull/157)

--- a/lib/activerecord-bitemporal/version.rb
+++ b/lib/activerecord-bitemporal/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   module Bitemporal
-    VERSION = "5.0.1"
+    VERSION = "5.1.0"
   end
 end


### PR DESCRIPTION
## 5.1.0

### Added

### Changed

### Deprecated

### Removed

### Fixed

- [Remove `joinable: false` #156](https://github.com/kufu/activerecord-bitemporal/pull/156)

### Chores

- [Remove database_cleaner #162](https://github.com/kufu/activerecord-bitemporal/pull/162)
