### PR TITLE
Fix unintended `valid_datetime` set when using `nested_attributes`

### DIFF
--- a/lib/activerecord-bitemporal/patches.rb
+++ b/lib/activerecord-bitemporal/patches.rb
@@ -39,7 +39,7 @@ module ActiveRecord::Bitemporal
 
       def assign_nested_attributes_for_collection_association(association_name, _attributes_collection)
         # Preloading records
-        send(association_name).load if association(association_name).klass&.bi_temporal_model?
+        send(association_name).load_target if association(association_name).klass&.bi_temporal_model?
         super
         send(association_name)&.each do |target|
           next unless target.changed?


### PR DESCRIPTION
Before the changes

```rb
company.employees_attributes = [
  { id: employee1.id, name: "Kevin" },
  { id: employee2.id, name: "Mado" }
]
company.employees.first.valid_datetie #=> 2024-06-16 17:21:09.247036709 +0900
```

After the changes

```rb
company.employees_attributes = [
  { id: employee1.id, name: "Kevin" },
  { id: employee2.id, name: "Mado" }
]
company.employees.first.valid_datetie #=> nil
```