### PR TITLE
Delegate CollectionProxy#bitemporal_value to Relation

### DIFF
--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -58,6 +58,7 @@ module ActiveRecord::Bitemporal::Bitemporalize
     def inherited(klass)
       super
       klass.prepend_relation_delegate_class ActiveRecord::Bitemporal::Relation
+      klass.relation_delegate_class(ActiveRecord::Associations::CollectionProxy).prepend ActiveRecord::Bitemporal::CollectionProxy
       if relation_delegate_class(ActiveRecord::Relation).ancestors.include? ActiveRecord::Bitemporal::Relation::MergeWithExceptBitemporalDefaultScope
         klass.relation_delegate_class(ActiveRecord::Relation).prepend ActiveRecord::Bitemporal::Relation::MergeWithExceptBitemporalDefaultScope
       end
@@ -169,6 +170,7 @@ module ActiveRecord::Bitemporal::Bitemporalize
     validates bitemporal_id_key, uniqueness: true, allow_nil: true, strict: enable_strict_by_validates_bitemporal_id
 
     prepend_relation_delegate_class ActiveRecord::Bitemporal::Relation
+    relation_delegate_class(ActiveRecord::Associations::CollectionProxy).prepend ActiveRecord::Bitemporal::CollectionProxy
   end
 end
 

--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -141,6 +141,12 @@ module ActiveRecord::Bitemporal
     end
   end
 
+  module CollectionProxy
+    # Delegate to ActiveRecord::Bitemporal::Relation#bitemporal_value
+    # @see https://github.com/rails/rails/blob/v7.1.3.4/activerecord/lib/active_record/associations/collection_proxy.rb#L1115-L1124
+    delegate :bitemporal_value, :bitemporal_value=, to: :scope
+  end
+
   module Scope
     extend ActiveSupport::Concern
 

--- a/spec/activerecord-bitemporal/association_spec.rb
+++ b/spec/activerecord-bitemporal/association_spec.rb
@@ -226,6 +226,15 @@ RSpec.describe "Association" do
         it { expect(CompanyWithoutBitemporal.includes(:employees).where(employees: { name: "Jane" }).count).to eq 2 }
         it { expect(CompanyWithoutBitemporal.joins(:employees).where(employees: { name: "Jane" }).count).to eq 3 }
       end
+
+      describe "#bitemporal_value" do
+        it { expect(company.employees.bitemporal_value).to eq({ with_valid_datetime: :default_scope, with_transaction_datetime: :default_scope }) }
+        it do
+          relation = company.employees
+          relation.bitemporal_value = { foo: :bar }
+          expect(relation.bitemporal_value).to eq({ foo: :bar })
+        end
+      end
     end
 
     describe "nested_attributes" do

--- a/spec/activerecord-bitemporal/relation_spec.rb
+++ b/spec/activerecord-bitemporal/relation_spec.rb
@@ -11,6 +11,13 @@ RSpec.describe "Relation" do
         let(:klass) { Employee.const_get(:ActiveRecord_Relation) }
         it { is_expected.to include ActiveRecord::Bitemporal::Relation }
       end
+
+      context "`ActiveRecord_Associations_CollectionProxy`" do
+        let(:klass) { Employee.const_get(:ActiveRecord_Associations_CollectionProxy) }
+
+        it { is_expected.to include ActiveRecord::Bitemporal::Relation }
+        it { is_expected.to include ActiveRecord::Bitemporal::CollectionProxy }
+      end
     end
   end
 


### PR DESCRIPTION
This PR adds `ActiveRecord::Bitemporal::CollectionProxy` and prepends it to `ActiveRecord::Associations::CollectionProxy`. This fixes the issue where `company.employees.bitemporal_value` is empty.

```ruby
# before
company.employees.bitemporal_value # => {}

# after
company.employees.bitemporal_value # => { with_valid_datetime: :default_scope, with_transaction_datetime: :default_scope }
```

The cause of the issue is that the `bitemporal_value` method is not delegated to `ActiveRecord::Relation`.

The `bitemporal_value` is defined in `ActiveRecord::Bitemporal::Relation` and is prepended to `ActiveRecord::Relation`, `ActiveRecord::AssociationRelation`, and `ActiveRecord::Associations::CollectionProxy` (To be precise, those delegate  classes):

https://github.com/kufu/activerecord-bitemporal/blob/0211fdd7d074586f0a830c9d629fba0b04b98afc/lib/activerecord-bitemporal/scope.rb#L135-L137
https://github.com/kufu/activerecord-bitemporal/blob/0211fdd7d074586f0a830c9d629fba0b04b98afc/lib/activerecord-bitemporal.rb#L171
https://github.com/kufu/activerecord-bitemporal/blob/0211fdd7d074586f0a830c9d629fba0b04b98afc/lib/activerecord-bitemporal.rb#L60

The `@values` is defined in `ActiveRecord::Relation`, and this variable contains metadata for building a query such as `where_clauses`:

https://github.com/rails/rails/blob/v7.1.3.4/activerecord/lib/active_record/relation.rb#L31

```ruby
Employee.all.values.keys
# => [:where, :bitemporal_value, :unscope]
```

This patch makes the `bitemporal_value` available in many cases just like any other query metadata, but this doesn't work with `ActiveRecord::Associations::CollectionProxy`.

The `ActiveRecord::Associations::CollectionProxy` is an association class referenced in a `has_many` association like `company.employees`, and acts like a proxy for the `ActiveRecord::Relation`:

https://github.com/rails/rails/blob/v7.1.3.4/activerecord/lib/active_record/associations/collection_association.rb#L39

Therefore, access to the metadata present in `ActiveRecord::Relation`, such as `where_clause` and `values`, is delegated to the `scope`:

https://github.com/rails/rails/blob/v7.1.3.4/activerecord/lib/active_record/associations/collection_proxy.rb#L1115-L1124

However, the `bitemporal_value` is not included in this delegation list, so instead of `ActiveRecord::Relation#bitemporal_value` you were getting `ActiveRecord::Associations::CollectionProxy#bitemporal_value`, which always gave you empty.

This PR solves this issue by introducing `ActiveRecord::Bitemporal::CollectionProxy` and delegating the `bitemporal_value` to the `scope`.

---

Please note that this issue will likely not affect general usage. This fix only changes behavior in very specific cases, and in most cases you will not need to worry about it. The impact of the issue of not delegating in `CollectionProxy` is as follows:

- `CollectionProxy#valid_datetime` is not affected
  - https://github.com/kufu/activerecord-bitemporal/blob/0211fdd7d074586f0a830c9d629fba0b04b98afc/lib/activerecord-bitemporal/scope.rb#L116
  - The `bitemporal_clause` calls the `where_clause`, which is delegated to `Relation`.
  - Similarly for `valid_date` and `transaction_datetime`
- `CollectionProxy#bitemporal_option` is affected, but no-op
  - https://github.com/kufu/activerecord-bitemporal/blob/0211fdd7d074586f0a830c9d629fba0b04b98afc/lib/activerecord-bitemporal/scope.rb#L128
  - Previously, it did not include the values ​​contained in the `bitemporal_value`. This includes `with_valid_datetime` and `with_transaction_datetime`.
    - These values ​​are used to determine whether to set `valid_datetime` on instances loaded with `Relation#load`.
    - https://github.com/kufu/activerecord-bitemporal/blob/0211fdd7d074586f0a830c9d629fba0b04b98afc/lib/activerecord-bitemporal/bitemporal.rb#L165-L168
    - The above only refers to the values ​​of the `bitemporal_value`, these values ​​are not used as `bitemporal_option`, so this difference has no effect on behavior.
- `CollectionProxy#bitemporal_value` is affected, but no-op
  - https://github.com/kufu/activerecord-bitemporal/blob/0211fdd7d074586f0a830c9d629fba0b04b98afc/lib/activerecord-bitemporal/scope.rb#L136
  - Affects the behavior of whether or not `valid_datetime` is set to the instances when `CollectionProxy#load` is performed. However, in most cases the final evaluation result of the conditional expression will not change.
    - Without `valid_at`
      - Previously, the `bitemporal_value[:with_valid_datetime].nil?` was true. Now, the `bitemporal_value[:with_valid_datetime] == :default_scope` is true.
    - With `ActiveRecord::Bitemporal.valid_at`
      - `ActiveRecord::Bitemporal.valid_datetime.nil?` is always false.
    - With `company.employess.valid_at`
      - Through the scope, the `CollectionProxy` is converted into an `AssociationRelation`.
        - `company.employess.class` => `Employee::ActiveRecord_Associations_CollectionProxy`
        - `company.employess.valid_at(Time.current).class` => `Employee::ActiveRecord_AssociationRelation`
      - As a result, the `bitemporal_value` can be obtained successfully.
    - With `company.valid_at { _1.employess }`
      - Previously, the `bitemporal_value[:with_valid_datetime]` was nil, but now it is true. This is the only path where the result of the conditional expression is reversed.
      - However, since `ActiveRecord::Bitemporal::Relation#load` is called twice (`CollectionProxy#load`, `Relation#load`), the `bitemporal_option` set in the first call is reflected in the nested call, and finally the `valid_datetime` is set in the instance. This does not affect the final behavior.

---

You might be wondering if similar considerations should be given to `ActiveRecord::Associations::AssociationRelation`.

https://github.com/rails/rails/blob/v7.1.3.4/activerecord/lib/active_record/association_relation.rb

However, `AssociationRelation` does not delegate, but rather propagates query metadata by merging relations. When merging relations, `ActiveRecord::Bitemporal::Patches::Merger` merges the `bitemporal_value`, so the `bitemporal_value` is correctly reflected in the `AssociationRelation`:

https://github.com/rails/rails/blob/v7.1.3.4/activerecord/lib/active_record/associations/association.rb#L282
https://github.com/rails/rails/blob/v7.1.3.4/activerecord/lib/active_record/relation/merger.rb#L60
https://github.com/kufu/activerecord-bitemporal/blob/0211fdd7d074586f0a830c9d629fba0b04b98afc/lib/activerecord-bitemporal/patches.rb#L123-L130