### PR TITLE
Fix unintended valid_datetime set when `CollectionProxy#load`

### DIFF
--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -29,7 +29,6 @@ module ActiveRecord::Bitemporal::Bitemporalize
         def prepend_relation_delegate_class(mod)
           relation_delegate_class(ActiveRecord::Relation).prepend mod
           relation_delegate_class(ActiveRecord::AssociationRelation).prepend mod
-          relation_delegate_class(ActiveRecord::Associations::CollectionProxy).prepend mod
         end
       end
     end

--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -142,9 +142,19 @@ module ActiveRecord::Bitemporal
   end
 
   module CollectionProxy
-    # Delegate to ActiveRecord::Bitemporal::Relation#bitemporal_value
+    # Delegate to ActiveRecord::Bitemporal::Relation
     # @see https://github.com/rails/rails/blob/v7.1.3.4/activerecord/lib/active_record/associations/collection_proxy.rb#L1115-L1124
-    delegate :bitemporal_value, :bitemporal_value=, to: :scope
+    #
+    # In order to update the CollectionProxy state, `load` needs to be excluded.
+    # The reason for using `@association` instead of delegating this method is to preserve state such as `loaded`.
+    # @see https://github.com/rails/rails/blob/v7.1.3.4/activerecord/lib/active_record/associations/collection_proxy.rb#L44
+    #
+    # There is no need to delegate to `scope` as `ActiveRecord::Bitemporal::Relation::Finder`'s methods are delegated
+    # by `ActiveRecord::Delegation`. This is not a problem because `scoping` used in this is delegated to `scope`.
+    # @see https://github.com/rails/rails/blob/v7.1.3.4/activerecord/lib/active_record/relation/delegation.rb#L117
+    delegate :bitemporal_value, :bitemporal_value=, :valid_datetime, :valid_date,
+             :transaction_datetime, :bitemporal_option, :bitemporal_option_merge!,
+             :build_arel, :primary_key, to: :scope
   end
 
   module Scope

--- a/spec/activerecord-bitemporal/association_spec.rb
+++ b/spec/activerecord-bitemporal/association_spec.rb
@@ -168,8 +168,10 @@ RSpec.describe "Association" do
       let!(:mado) { company.employees.create(name: "Mado") }
       let!(:tom) { company.employees.create(name: "Tom") }
       before do
+        mado.update(name: "Mado2")
         company.employees.create(name: "Tom").update(name: "Jane")
         @time = Time.current
+        mado.update(name: "Mado")
         company.employees.create(name: "Mami").tap { |m|
           m.update(name: "Mado")
           m.update(name: "Homu")
@@ -182,15 +184,19 @@ RSpec.describe "Association" do
       end
 
       describe ".find" do
-        it { expect(company.employees.find(mado.id)).to have_attributes(name: "Mado") }
+        it { expect(company.employees.find(mado.id)).to have_attributes(name: "Mado", valid_datetime: nil) }
         it { expect(company.employees.find(mado.id, tom.id).pluck(:name)).to contain_exactly("Mado", "Tom") }
       end
 
       describe ".find_by" do
         it { expect(company.employees.find_by(name: "Mami")).to be_nil }
-        it { expect(company.employees.find_by(name: "Mado")).to have_attributes(name: "Mado") }
+        it { expect(company.employees.find_by(name: "Mado")).to have_attributes(name: "Mado", valid_datetime: nil) }
         it { expect(company.employees.find_by(name: "Tom")).to have_attributes(name: "Tom") }
         it { expect(company.employees.find_by(name: "Jane")).to have_attributes(name: "Jane") }
+      end
+
+      describe ".find_at_time" do
+        it { expect(company.employees.find_at_time(@time, mado.id)).to have_attributes(name: "Mado2", valid_datetime: @time) }
       end
 
       describe ".where" do
@@ -215,6 +221,7 @@ RSpec.describe "Association" do
         it { expect(company.employees.valid_at(@time).where(name: "Jane").count).to eq 1 }
         it { expect(company.employees.valid_at(@time).where(name: "Tom").count).to eq 1 }
         it { expect(company.employees.valid_at(@time).where(name: "Homu").count).to eq 0 }
+        it { expect(company.employees.valid_at(@time).find_by(name: "Jane")).to have_attributes(valid_datetime: @time) }
       end
 
       describe "preload" do
@@ -233,6 +240,12 @@ RSpec.describe "Association" do
           relation = company.employees
           relation.bitemporal_value = { foo: :bar }
           expect(relation.bitemporal_value).to eq({ foo: :bar })
+        end
+      end
+
+      describe "collection proxy" do
+        it "can call all public instance methods of ActiveRecord::Bitemporal::Relation" do
+          expect(company.employees).to respond_to(*ActiveRecord::Bitemporal::Relation.public_instance_methods(false))
         end
       end
     end
@@ -259,6 +272,35 @@ RSpec.describe "Association" do
         it { expect { subject }.to change { Employee.ignore_valid_datetime.count }.by(2) }
         it { expect { subject }.to change { employee1.reload.name }.from("Tom").to("Kevin") }
         it { expect { subject }.to change { employee2.reload.name }.from("Mami").to("Mado") }
+
+        context "associatoins valid_datetime without vaild_at" do
+          subject {
+            company.reload # clear cache
+            company.employees_attributes = [
+              { id: employee1.id, name: "Kevin" },
+              { id: employee2.id, name: "Mado" }
+            ]
+            company.employees
+          }
+
+          it { expect(subject.map(&:valid_datetime)).to eq [nil, nil] }
+        end
+
+        context "associatoins valid_datetime with vaild_at" do
+          subject {
+            ActiveRecord::Bitemporal.valid_at(time_current) do
+              company.reload # clear cache
+              company.employees_attributes = [
+                { id: employee1.id, name: "Kevin" },
+                { id: employee2.id, name: "Mado" }
+              ]
+              company.employees
+            end
+          }
+          let(:time_current) { Time.current }
+
+          it { expect(subject.map(&:valid_datetime)).to eq [time_current, time_current] }
+        end
       end
     end
 
@@ -322,6 +364,51 @@ RSpec.describe "Association" do
         it { expect { subject }.to change { Employee.ignore_valid_datetime.count }.by(2) }
         it { expect { subject }.to change { employee1.reload.name }.from("Tom").to("Kevin") }
         it { expect { subject }.to change { employee2.reload.name }.from("Mami").to("Mado") }
+
+        context "associations valid_datetime without valid_at" do
+          subject {
+            company.reload # clear cache
+            company.employees_attributes = [
+              { id: employee1.id, name: "Kevin" },
+              { id: employee2.id, name: "Mado" }
+            ]
+            company.employees
+          }
+
+          it { expect(subject.map(&:valid_datetime)).to eq [nil, nil] }
+        end
+
+        context "associations valid_datetime with valid_at" do
+          subject {
+            ActiveRecord::Bitemporal.valid_at(time_current) do
+              company.reload # clear cache
+              company.employees_attributes = [
+                { id: employee1.id, name: "Kevin" },
+                { id: employee2.id, name: "Mado" }
+              ]
+              company.employees
+            end
+          }
+          let(:time_current) { Time.current }
+
+          it { expect(subject.map(&:valid_datetime)).to eq [time_current, time_current] }
+        end
+
+        context "associations valid_datetime when owner has valid_datetime" do
+          subject {
+            company_with_valid_datetime = ActiveRecord::Bitemporal.valid_at(time_current) do
+              company.class.find(company.id)
+            end
+            company_with_valid_datetime.employees_attributes = [
+              { id: employee1.id, name: "Kevin" },
+              { id: employee2.id, name: "Mado" }
+            ]
+            company_with_valid_datetime.employees
+          }
+          let(:time_current) { Time.current }
+
+          it { expect(subject.map(&:valid_datetime)).to eq [time_current, time_current] }
+        end
       end
     end
 
@@ -450,6 +537,54 @@ RSpec.describe "Association" do
 
       it { expect(employee.reload.address.employee).to be employee }
     end
+
+    describe "nested_attributes" do
+      context "with accepts_nested_attributes_for" do
+        let(:company) {
+          Class.new(CompanyWithoutBitemporal) {
+            has_one :employee, foreign_key: :company_id
+            accepts_nested_attributes_for :employee
+
+            def self.name
+              "CompanyWithoutBitemporalAcceptsNestedAttributes"
+            end
+          }.create(name: "Company")
+        }
+        let!(:employee1) { company.create_employee(name: "Jane").tap { |m| m.update(name: "Tom") } }
+
+        subject {
+          company.employee_attributes = { id: employee1.id, name: "Kevin" }
+          company.save
+        }
+
+        it { expect { subject }.not_to change { Employee.count } }
+        it { expect { subject }.to change { Employee.ignore_valid_datetime.count }.by(1) }
+        it { expect { subject }.to change { employee1.reload.name }.from("Tom").to("Kevin") }
+
+        context "association valid_datetime without valid_at" do
+          subject {
+            company.reload # clear cache
+            company.employee_attributes = { id: employee1.id, name: "Kevin" }
+            company.employee
+          }
+
+          it { expect(subject.valid_datetime).to be_nil }
+        end
+
+        context "association valid_datetime with valid_at" do
+          subject {
+            ActiveRecord::Bitemporal.valid_at(time_current) do
+              company.reload # clear cache
+              company.employee_attributes = { id: employee1.id, name: "Kevin" }
+              company.employee
+            end
+          }
+          let(:time_current) { Time.current }
+
+          it { expect(subject.valid_datetime).to eq time_current }
+        end
+      end
+    end
   end
 
   describe "non BTDM has many non BTDM" do
@@ -492,6 +627,67 @@ RSpec.describe "Association" do
       end
 
       it { expect(employee.reload.address.employee).to be employee }
+    end
+
+    describe "nested_attributes" do
+      context "with accepts_nested_attributes_for" do
+        let(:company) {
+          Class.new(Company) {
+            has_one :employee, foreign_key: :company_id
+            accepts_nested_attributes_for :employee
+
+            def self.name
+              "CompanyAcceptsNestedAttributes"
+            end
+          }.create(name: "Company")
+        }
+        let!(:employee1) { company.create_employee(name: "Jane").tap { |m| m.update(name: "Tom") } }
+
+        subject {
+          company.employee_attributes = { id: employee1.id, name: "Kevin" }
+          company.save
+        }
+
+        it { expect { subject }.not_to change { Employee.count } }
+        it { expect { subject }.to change { Employee.ignore_valid_datetime.count }.by(1) }
+        it { expect { subject }.to change { employee1.reload.name }.from("Tom").to("Kevin") }
+
+        context "association valid_datetime without valid_at" do
+          subject {
+            company.reload # clear cache
+            company.employee_attributes = { id: employee1.id, name: "Kevin" }
+            company.employee
+          }
+
+          it { expect(subject.valid_datetime).to be_nil }
+        end
+
+        context "association valid_datetime with valid_at" do
+          subject {
+            ActiveRecord::Bitemporal.valid_at(time_current) do
+              company.reload # clear cache
+              company.employee_attributes = { id: employee1.id, name: "Kevin" }
+              company.employee
+            end
+          }
+          let(:time_current) { Time.current }
+
+          it { expect(subject.valid_datetime).to eq time_current }
+        end
+
+        context "association valid_datetime when owner has valid_datetime" do
+          subject {
+            company_with_valid_datetime = ActiveRecord::Bitemporal.valid_at(time_current) do
+              company.class.find(company.id)
+            end
+            company_with_valid_datetime.employee_attributes = { id: employee1.id, name: "Kevin" }
+            company_with_valid_datetime.employee
+          }
+          let(:time_current) { Time.current }
+
+          it { expect(subject.valid_datetime).to eq time_current }
+        end
+      end
     end
   end
 end

--- a/spec/activerecord-bitemporal/relation_spec.rb
+++ b/spec/activerecord-bitemporal/relation_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe "Relation" do
       context "`ActiveRecord_Associations_CollectionProxy`" do
         let(:klass) { Employee.const_get(:ActiveRecord_Associations_CollectionProxy) }
 
-        it { is_expected.to include ActiveRecord::Bitemporal::Relation }
         it { is_expected.to include ActiveRecord::Bitemporal::CollectionProxy }
       end
     end


### PR DESCRIPTION
This PR fixes unintended `valid_datetime` set when `CollectionProxy#load`.

Before the changes

```rb
company.employees_attributes = [
  { id: employee1.id, name: "Kevin" },
  { id: employee2.id, name: "Mado" }
]
company.employees.first.valid_datetie #=> 2024-06-16 17:21:09.247036709 +0900
```

After the changes

```rb
company.employees_attributes = [
  { id: employee1.id, name: "Kevin" },
  { id: employee2.id, name: "Mado" }
]
company.employees.first.valid_datetie #=> nil
```

At first I thought it was a `assign_nested_attributes_for_collection_association` problem and fixed it. (#167)
However, this change left the problem of using `load` unresolved.
As noted in #168, the problem was that the `ActiveRecord::Bitemporal::Relation#load` was called twice. The `bitemporal_option` set in the first call is reflected in the nested call, and finally the `valid_datetime` is set in the instance.

`ActiveRecord::Associations::CollectionProxy` is designed to delegate most of the implementation to the `@association` or `scope` and has no logic of its own.
https://github.com/rails/rails/blob/v7.1.3.4/activerecord/lib/active_record/associations/collection_proxy.rb#L1124

Therefore, we stopped prepending `ActiveRecord::Bitemporal::Relation` and changed to delegate methods other than `load`. The reason for excluding `load` is to update the state of `loaded` etc. by calling the `@association`'s method.

This `load` method is `ActiveRecord::Relation#load`.
https://github.com/rails/rails/blob/v7.1.3.4/activerecord/lib/active_record/relation.rb#L740

Inside this, `exec_queries` is called. `exec_queries` is `ActiveRecord::Associations::CollectionProxy#exec_queries`.
https://github.com/rails/rails/blob/v7.1.3.4/activerecord/lib/active_record/associations/collection_proxy.rb#L1145

`exec_queries` calls `load_target`. Then `load_target` calls `@association`'s `load_target`.
https://github.com/rails/rails/blob/v7.1.3.4/activerecord/lib/active_record/associations/collection_proxy.rb#L44

Calling the `@association`'s method will update the state of `loaded`, etc. Therefore, the `load` method had to be excluded. If the `load` method is delegated to `scope`, the `@association` state will no longer be updated, and as a result `CollectionProxy#loaded?` will not return `true`.


`Finder` methods can be called by `ActiveRecord::Delegation`. This is not a problem because `scoping` used in this is delegated to `scope` to set where condition.
https://github.com/rails/rails/blob/v7.1.3.4/activerecord/lib/active_record/relation/delegation.rb#L117

---

Note that this change causes `ActiveRecord::Associations::CollectionAssociation#find` to be called.
https://github.com/rails/rails/blob/v7.1.3.4/activerecord/lib/active_record/associations/collection_association.rb#L92

`ActiveRecord::Bitemporal::Relation::Finder#find` was calling `spawn`, so the query was executed every time.
https://github.com/kufu/activerecord-bitemporal/blob/v5.1.0/lib/activerecord-bitemporal/bitemporal.rb#L130

However, in the case of `ActiveRecord::Associations::CollectionAssociation#find`, the query may not be executed if there is a cache. The changed behavior is closer to the original behavior of Active Record and will not be a problem in many cases.
