### PR TITLE
Bump up version to v5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 5.2.0
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- [Delegate CollectionProxy#bitemporal_value to Relation #168](https://github.com/kufu/activerecord-bitemporal/pull/168)
+- [Fix unintended valid_datetime set when `CollectionProxy#load` #169](https://github.com/kufu/activerecord-bitemporal/pull/169)
+
+### Chores
+
+- [Do not run CI against rails_main #166](https://github.com/kufu/activerecord-bitemporal/pull/166)
+
 ## 5.1.0
 
 ### Added

--- a/lib/activerecord-bitemporal/version.rb
+++ b/lib/activerecord-bitemporal/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   module Bitemporal
-    VERSION = "5.1.0"
+    VERSION = "5.2.0"
   end
 end


### PR DESCRIPTION
## 5.2.0

### Added

### Changed

### Deprecated

### Removed

### Fixed

- [Delegate CollectionProxy#bitemporal_value to Relation #168](https://github.com/kufu/activerecord-bitemporal/pull/168)
- [Fix unintended valid_datetime set when `CollectionProxy#load` #169](https://github.com/kufu/activerecord-bitemporal/pull/169)

### Chores

- [Do not run CI against rails_main #166](https://github.com/kufu/activerecord-bitemporal/pull/166)
