### PR TITLE
Replace `default` overrides from `load_schema!` to `attribute`

### DIFF
--- a/lib/activerecord-bitemporal.rb
+++ b/lib/activerecord-bitemporal.rb
@@ -37,13 +37,6 @@ module ActiveRecord::Bitemporal::Bitemporalize
   module ClassMethods
     include ActiveRecord::Bitemporal::Relation::Finder
 
-    DEFAULT_ATTRIBUTES = {
-      valid_from:       ActiveRecord::Bitemporal::DEFAULT_VALID_FROM,
-      valid_to:         ActiveRecord::Bitemporal::DEFAULT_VALID_TO,
-      transaction_from: ActiveRecord::Bitemporal::DEFAULT_TRANSACTION_FROM,
-      transaction_to:   ActiveRecord::Bitemporal::DEFAULT_TRANSACTION_TO
-    }.freeze
-
     def bitemporal_id_key
       'bitemporal_id'
     end
@@ -60,16 +53,6 @@ module ActiveRecord::Bitemporal::Bitemporalize
       klass.relation_delegate_class(ActiveRecord::Associations::CollectionProxy).prepend ActiveRecord::Bitemporal::CollectionProxy
       if relation_delegate_class(ActiveRecord::Relation).ancestors.include? ActiveRecord::Bitemporal::Relation::MergeWithExceptBitemporalDefaultScope
         klass.relation_delegate_class(ActiveRecord::Relation).prepend ActiveRecord::Bitemporal::Relation::MergeWithExceptBitemporalDefaultScope
-      end
-    end
-
-  private
-    def load_schema!
-      super
-
-      DEFAULT_ATTRIBUTES.each do |name, default_value|
-        type = type_for_attribute(name)
-        define_attribute(name.to_s, type, default: default_value)
       end
     end
   end
@@ -152,6 +135,11 @@ module ActiveRecord::Bitemporal::Bitemporalize
       self.swap_id! if self.send(bitemporal_id_key).present?
       @previously_force_updated = false
     end
+
+    attribute :valid_from, default: ActiveRecord::Bitemporal::DEFAULT_VALID_FROM
+    attribute :valid_to, default: ActiveRecord::Bitemporal::DEFAULT_VALID_TO
+    attribute :transaction_from, default: ActiveRecord::Bitemporal::DEFAULT_TRANSACTION_FROM
+    attribute :transaction_to, default: ActiveRecord::Bitemporal::DEFAULT_TRANSACTION_TO
 
     # Callback hook to `validates :xxx, uniqueness: true`
     const_set(:UniquenessValidator, Class.new(ActiveRecord::Validations::UniquenessValidator) {


### PR DESCRIPTION
This PR fixes overwriting with `load_schema!` will not work from Rails 7.2.
see: https://github.com/rails/rails/commit/e0a55b038f7f2f50d1467876558be183be6cedaa

The `load_schema!` method is now called inside the `_default_attributes` method due to the https://github.com/rails/rails/commit/e0a55b038f7f2f50d1467876558be183be6cedaa change.
https://github.com/rails/rails/blob/v7.2.0.beta3/activerecord/lib/active_record/attributes.rb#L240-L252

The backtrace at that time is below.

```
=>#0	ActiveRecord::Bitemporal::Bitemporalize::ClassMethods#load_schema! at ~/github/activerecord-bitemporal/lib/activerecord-bitemporal.rb:69
  #1	block in load_schema at ~/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/activerecord-7.2.0.beta3/lib/active_record/model_schema.rb:539
  #2	[C] Monitor#synchronize at ~/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/activerecord-7.2.0.beta3/lib/active_record/model_schema.rb:536
  #3	ActiveRecord::ModelSchema::ClassMethods#load_schema at ~/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/activerecord-7.2.0.beta3/lib/active_record/model_schema.rb:536
  #4	ActiveRecord::ModelSchema::ClassMethods#columns_hash at ~/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/activerecord-7.2.0.beta3/lib/active_record/model_schema.rb:429
  #5	block {|connection=#<ActiveRecord::ConnectionAdapters::Postg...|} in _default_attributes at ~/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/activerecord-7.2.0.beta3/lib/active_record/attributes.rb:243
  #6	ActiveRecord::ConnectionAdapters::ConnectionPool#with_connection(prevent_permanent_checkout=false) at ~/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/activerecord-7.2.0.beta3/lib/active_record/connection_adapters/abstract/connection_pool.rb:407
  #7	ActiveRecord::ConnectionHandling#with_connection(prevent_permanent_checkout=false, block=#<Proc:0x00007c5ceb31b680 /home/...) at ~/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/activerecord-7.2.0.beta3/lib/active_record/connection_handling.rb:296
  #8	ActiveRecord::Attributes::ClassMethods#_default_attributes at ~/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/activerecord-7.2.0.beta3/lib/active_record/attributes.rb:242
  #9	ActiveModel::AttributeRegistration::ClassMethods#attribute_types at ~/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/activemodel-7.2.0.beta3/lib/active_model/attribute_registration.rb:38
  #10	ActiveRecord::AttributeMethods::ClassMethods#_has_attribute?(attr_name="type") at ~/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/activerecord-7.2.0.beta3/lib/active_record/attribute_methods.rb:260
  #11	ActiveRecord::Inheritance::ClassMethods#new(attributes={:name=>"Mami"}, block=nil) at ~/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/activerecord-7.2.0.beta3/lib/active_record/inheritance.rb:61
  #12	ActiveRecord::Persistence::ClassMethods#create!(attributes={:name=>"Mami"}, block=nil) at ~/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/activerecord-7.2.0.beta3/lib/active_record/persistence.rb:54
```

Therefore, default set inside `_default_attributes` were no longer reflected in `@default_attributes`. Because the new `ActiveModel::AttributeSet` object will be set to `@default_attributes`.

The `load_schema!` method was overridden to handle precision correctly. (#57)
However, this behavior has been fixed to be handled by unspecifying the type in the `attribute` method. (https://github.com/rails/rails/pull/39830)
