### PR TITLE
`Or` node changed to `Nary` in Rails 7.2

### DIFF
--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -27,6 +27,10 @@ module ActiveRecord::Bitemporal
   end
 
   module Relation
+    # see: https://github.com/rails/rails/pull/51492
+    NARY_NODE = ActiveRecord.gem_version >= Gem::Version.new("7.2.0") ? Arel::Nodes::Nary : Arel::Nodes::And
+    private_constant :NARY_NODE
+
     using Module.new {
       refine ActiveRecord::Relation::WhereClause do
         using Module.new {
@@ -56,7 +60,7 @@ module ActiveRecord::Bitemporal
                 case node
                 when Arel::Nodes::LessThan, Arel::Nodes::LessThanOrEqual, Arel::Nodes::GreaterThan, Arel::Nodes::GreaterThanOrEqual
                   y << node if node && node.left.respond_to?(:relation)
-                when Arel::Nodes::And
+                when NARY_NODE
                   each_operatable_node(node.children) { |node| y << node }
                 when Arel::Nodes::Binary
                   each_operatable_node(node.left) { |node| y << node }


### PR DESCRIPTION
In https://github.com/rails/rails/pull/51492 the `Or` node changed from `Binary` to `Nary` as well as `And`.
This PR changed to treat `Or` as `Nary` since Rails 7.2.

For example, this test fails:
https://github.com/kufu/activerecord-bitemporal/blob/010d79d42418eca0f42ab090070964306dda8a5c/spec/activerecord-bitemporal/bitemporal_scope_spec.rb#L1170
```ruby
  1) ActiveRecord::Bitemporal::Scope bitemporal_scope association .joins with .or and without Time freeze is expected to match /"articles"."transaction_from" <= \$1/
     Failure/Error: it { is_expected.to match %r/"articles"."transaction_from" <= \$1/ }
     
       expected "SELECT \"blogs\".* FROM \"blogs\" INNER JOIN \"articles\" ON \"articles\".\"blog_id\" = \"blogs\".\"...blogs\".\"transaction_to\" > $6 AND \"blogs\".\"valid_from\" <= $7 AND \"blogs\".\"valid_to\" > $8)" to match /"articles"."transaction_from" <= \$1/
       Diff:
       @@ -1 +1 @@
       -/"articles"."transaction_from" <= \$1/
       +"SELECT \"blogs\".* FROM \"blogs\" INNER JOIN \"articles\" ON \"articles\".\"blog_id\" = \"blogs\".\"bitemporal_id\" WHERE (\"blogs\".\"transaction_from\" <= $1 AND \"blogs\".\"transaction_to\" > $2 AND \"blogs\".\"valid_from\" <= $3 AND \"blogs\".\"valid_to\" > $4 OR \"blogs\".\"transaction_from\" <= $5 AND \"blogs\".\"transaction_to\" > $6 AND \"blogs\".\"valid_from\" <= $7 AND \"blogs\".\"valid_to\" > $8)"
       
     # ./spec/activerecord-bitemporal/bitemporal_scope_spec.rb:1170:in `block (6 levels) in <top (required)>'
     # ./spec/activerecord-bitemporal/bitemporal_scope_spec.rb:108:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:38:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:37:in `block (2 levels) in <top (required)>'
```