### PR TITLE
Remove unused bitemporal clauses

### DIFF
--- a/lib/activerecord-bitemporal/scope.rb
+++ b/lib/activerecord-bitemporal/scope.rb
@@ -92,8 +92,6 @@ module ActiveRecord::Bitemporal
           transaction_from = node_hash.dig(table_name, "transaction_from", 1)
           transaction_to   = node_hash.dig(table_name, "transaction_to", 1)
           {
-            valid_from: valid_from,
-            valid_to: valid_to,
             valid_datetime: valid_from == valid_to ? valid_from : nil,
             transaction_from: transaction_from,
             transaction_to: transaction_to,


### PR DESCRIPTION
The `valid_datetime` returned by `Relation#bitemporal_clause` is propagated to child associations and affects the behavior of the bitemporal gem internals, but the `valid_from`, `valid_to` ​​do not appear to affect the behavior.