### PR TITLE
Add Ruby 3.4 and remove Ruby 3.0 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '3.0'
           - '3.1'
           - '3.2'
           - '3.3'
+          - '3.4'
         gemfile:
           - rails_6.1
           - rails_7.0
@@ -27,6 +27,8 @@ jobs:
           - ruby-version: '3.2'
             gemfile: rails_6.1
           - ruby-version: '3.3'
+            gemfile: rails_6.1
+          - ruby-version: '3.4'
             gemfile: rails_6.1
     services:
       postgres:

--- a/Appraisals
+++ b/Appraisals
@@ -6,6 +6,11 @@ end
 
 appraise "rails-7.0" do
   gem "rails", "~> 7.0.1"
+
+  # for Ruby 3.4
+  gem "base64"
+  gem "bigdecimal"
+  gem "mutex_m"
 end
 
 appraise "rails-7.1" do

--- a/activerecord-bitemporal.gemspec
+++ b/activerecord-bitemporal.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Enable ActiveRecord models to be handled as BiTemporal Data Model.}
   spec.homepage      = "https://github.com/kufu/activerecord-bitemporal"
   spec.license       = "Apache 2.0"
-  spec.required_ruby_version = ">= 3.0"
+  spec.required_ruby_version = ">= 3.1"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -4,5 +4,8 @@ source "https://rubygems.org"
 
 gem "appraisal"
 gem "rails", "~> 7.0.1"
+gem "base64"
+gem "bigdecimal"
+gem "mutex_m"
 
 gemspec path: "../"


### PR DESCRIPTION
This pull request includes updates to support Ruby 3.4 across various files and configurations. The most important changes include updating the Ruby version matrix in the GitHub Actions workflow, adding necessary gems for Ruby 3.4 compatibility, and updating the required Ruby version in the gem specification.

Support for Ruby 3.4:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L18-R21): Added Ruby 3.4 to the version matrix and updated the job configurations to include Ruby 3.4. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L18-R21) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R31-R32)

Gem compatibility:

* [`Appraisals`](diffhunk://#diff-635b20966b1d2fea76ee0565254eab939d55f6d22e3c4727cf9d453f589b87a0R9-R13): Added `base64`, `bigdecimal`, and `mutex_m` gems for Ruby 3.4 compatibility under the `rails-7.0` appraisal.
* base64, bigdecimal, and mutex_m were changed to bundled gem from Ruby 3.4, so they were added as dependencies.
* see also: https://github.com/rails/rails/pull/48907

Required Ruby version:

* [`activerecord-bitemporal.gemspec`](diffhunk://#diff-fa334ae5beb3029f1c5fda49d9f30d0292e8775f3a6f1071f7ad289c21bfe925L17-R17): Updated the required Ruby version to be ">= 3.1".
