### PR TITLE
Support Docker Compose V2

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,4 +1,3 @@
-version: '2.1'
 services:
   db:
     image: postgres:latest


### PR DESCRIPTION
This pull request includes a change to the `compose.yml` file, which was renamed from `docker-compose.yml`. The version specification was removed.

Changes in file `compose.yml`:

* Renamed the file from `docker-compose.yml` to `compose.yml`.
  * By default, the preferred file to load is `compose.yml`.
* Removed the version specification line.
  * The attribute `version` is obsolete, it will be ignored

Refer to https://github.com/compose-spec/compose-spec
