### PR TITLE
Add a note to the README that PostgreSQL is required to run the tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,7 +711,7 @@ Employee.where(bitemporal_id: employee.bitemporal_id)
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. And start PostgreSQL on port 5432. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 


### PR DESCRIPTION
As described in the README, running the tests resulted in the following error. After starting PostgreSQL locally, the tests ran as expected, so I updated the README to mention that PostgreSQL is required.

```
An error occurred while loading ./spec/activerecord-bitemporal/association_spec.rb.
Failure/Error: connection = ActiveRecord::Base.connection

ActiveRecord::ConnectionNotEstablished:
  connection to server at "::1", port 5432 failed: Connection refused
  	Is the server running on that host and accepting TCP/IP connections?
  connection to server at "127.0.0.1", port 5432 failed: Connection refused
  	Is the server running on that host and accepting TCP/IP connections?
# ./spec/spec_helper.rb:20:in 'block in <top (required)>'
# ./spec/spec_helper.rb:12:in '<top (required)>'
# ./spec/activerecord-bitemporal/association_spec.rb:3:in '<top (required)>'
# ------------------
# --- Caused by: ---
# PG::ConnectionBad:
#   connection to server at "::1", port 5432 failed: Connection refused
#   	Is the server running on that host and accepting TCP/IP connections?
#   connection to server at "127.0.0.1", port 5432 failed: Connection refused
#   	Is the server running on that host and accepting TCP/IP connections?
#   ./spec/spec_helper.rb:20:in 'block in <top (required)>'
```