### PR TITLE
Prevent where clauses from ignored by `ignore_valid_datetime`

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -533,7 +533,7 @@ module ActiveRecord
         # 有効なレコードがない場合
         else
           # 一番近い未来にある Instance を取ってきて、その valid_from を valid_to に入れる
-          nearest_instance = self.class.where(bitemporal_id: bitemporal_id).valid_from_gt(target_datetime).ignore_valid_datetime.order(valid_from: :asc).first
+          nearest_instance = self.class.where(bitemporal_id: bitemporal_id).ignore_valid_datetime.valid_from_gt(target_datetime).order(valid_from: :asc).first
           if nearest_instance.nil?
             message = "Update failed: Couldn't find #{self.class} with 'bitemporal_id'=#{self.bitemporal_id} and 'valid_from' < #{target_datetime}"
             raise ActiveRecord::RecordNotFound.new(message, self.class, "bitemporal_id", self.bitemporal_id)

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -393,6 +393,7 @@ module ActiveRecord
       rescue => e
         @destroyed = false
         @_association_destroy_exception = ActiveRecord::RecordNotDestroyed.new("Failed to destroy the record: class=#{e.class}, message=#{e.message}", self)
+        @_association_destroy_exception.set_backtrace(e.backtrace)
         false
       end
 

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -872,9 +872,9 @@ RSpec.describe ActiveRecord::Bitemporal do
 
       context "update for deleted record" do
         let(:datetime) { "2020/01/01".in_time_zone }
-        let(:company) { Company.create!(valid_from: "2019/02/01", valid_to: "2019/04/01") }
+        let(:company) { Company.create!(valid_from: "2019/02/01", transaction_from: "2019/02/01") }
         subject { Timecop.freeze(datetime) { company.update!(name: "Company2") } }
-        before { company.destroy }
+        before { Timecop.freeze(datetime - 1.day) { Company.find(company.id).destroy! } }
         it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
         it { expect { subject }.to raise_error { |e|
           expect(e.message).to eq "Update failed: Couldn't find Company with 'bitemporal_id'=#{company.bitemporal_id} and 'valid_from' < #{datetime}"


### PR DESCRIPTION
The `ignore_valid_datetime` overrides the previously added `valid_from_gt(target_datetime)`, so the intended query could not be issued.

```ruby
self.class.where(bitemporal_id: bitemporal_id).valid_from_gt(target_datetime).ignore_valid_datetime.order(valid_from: :asc).to_sql
# => "SELECT \"companies\".* FROM \"companies\" WHERE \"companies\".\"transaction_from\" <= '2020-01-01 00:00:00' AND \"companies\".\"transaction_to\" > '2020-01-01 00:00:00' AND \"companies\".\"bitemporal_id\" = 1 ORDER BY \"companies\".\"valid_from\" ASC"

self.class.where(bitemporal_id: bitemporal_id).ignore_valid_datetime.valid_from_gt(target_datetime).order(valid_from: :asc).to_sql
# => "SELECT \"companies\".* FROM \"companies\" WHERE \"companies\".\"transaction_from\" <= '2020-01-01 00:00:00' AND \"companies\".\"transaction_to\" > '2020-01-01 00:00:00' AND \"companies\".\"bitemporal_id\" = 1 AND \"companies\".\"valid_from\" > '2020-01-01 00:00:00' ORDER BY \"companies\".\"valid_from\" ASC"
```

The specs that could detect this issue were broken and have been fixed as well.
The details are listed below:

- `company.destroy` in a before block always failed because the initial company's `valid_to` was in the past relative
  to the operation time.
- The initial company's `transaction_from` was in the future relative to the operation time.