### PR TITLE
Improve ValidDatetimeRangeError message with better grammar and context

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -493,7 +493,10 @@ module ActiveRecord
           # 以前の履歴データは valid_to を詰めて保存
           before_instance[valid_to_key] = target_datetime
           if before_instance.valid_from_cannot_be_greater_equal_than_valid_to
-            raise ValidDatetimeRangeError.new("#{valid_from_key} #{before_instance[valid_from_key]} can't be greater equal than #{valid_to_key} #{before_instance[valid_to_key]}")
+            message = "#{valid_from_key} #{before_instance[valid_from_key]} can't be " \
+                      "greater than or equal to #{valid_to_key} #{before_instance[valid_to_key]} " \
+                      "for #{self.class} with bitemporal_id=#{bitemporal_id}"
+            raise ValidDatetimeRangeError.new(message)
           end
           before_instance.transaction_from = current_time
 
@@ -501,7 +504,10 @@ module ActiveRecord
           after_instance[valid_from_key] = target_datetime
           after_instance[valid_to_key] = current_valid_record[valid_to_key]
           if after_instance.valid_from_cannot_be_greater_equal_than_valid_to
-            raise ValidDatetimeRangeError.new("#{valid_from_key} #{after_instance[valid_from_key]} can't be greater equal than #{valid_to_key} #{after_instance[valid_to_key]}")
+            message = "#{valid_from_key} #{after_instance[valid_from_key]} can't be " \
+                      "greater than or equal to #{valid_to_key} #{after_instance[valid_to_key]} " \
+                      "for #{self.class} with bitemporal_id=#{bitemporal_id}"
+            raise ValidDatetimeRangeError.new(message)
           end
           after_instance.transaction_from = current_time
 

--- a/spec/activerecord-bitemporal/applied_valid_time_column_name_spec.rb
+++ b/spec/activerecord-bitemporal/applied_valid_time_column_name_spec.rb
@@ -139,7 +139,8 @@ RSpec.describe ActiveRecord::Bitemporal, "applied valid time column name" do
           it { expect { subject }.to raise_error(ActiveRecord::Bitemporal::ValidDatetimeRangeError) }
           it {
             expect { subject }.to raise_error do |e|
-              expect(e.message).to eq "valid_date_from #{company.valid_date_from} can't be greater equal than valid_date_to #{valid_datetime}"
+              expect(e.message).to eq "valid_date_from #{company.valid_date_from} can't be greater than or equal to valid_date_to #{valid_datetime} " \
+                                      "for ColumnNameAppliedCompany with bitemporal_id=#{company.bitemporal_id}"
             end
           }
         end

--- a/spec/activerecord-bitemporal/bitemporal_spec.rb
+++ b/spec/activerecord-bitemporal/bitemporal_spec.rb
@@ -865,7 +865,8 @@ RSpec.describe ActiveRecord::Bitemporal do
           subject { company.valid_at(valid_datetime) { |c| c.update!(name: "Company") } }
           it { expect { subject }.to raise_error(ActiveRecord::Bitemporal::ValidDatetimeRangeError) }
           it { expect { subject }.to raise_error { |e|
-            expect(e.message).to eq "valid_from #{company.valid_from} can't be greater equal than valid_to #{valid_datetime}"
+            expect(e.message).to eq "valid_from #{company.valid_from} can't be greater than or equal to valid_to #{valid_datetime} " \
+                                    "for Company with bitemporal_id=#{company.bitemporal_id}"
           } }
         end
       end

--- a/spec/activerecord-bitemporal/date_type_valid_time_spec.rb
+++ b/spec/activerecord-bitemporal/date_type_valid_time_spec.rb
@@ -517,7 +517,8 @@ RSpec.describe ActiveRecord::Bitemporal, 'date type valid time' do
           it { expect { subject }.to raise_error(ActiveRecord::Bitemporal::ValidDatetimeRangeError) }
           it {
             expect { subject }.to raise_error do |e|
-              expect(e.message).to eq "valid_from #{department.valid_from} can't be greater equal than valid_to #{valid_datetime}"
+              expect(e.message).to eq "valid_from #{department.valid_from} can't be greater than or equal to valid_to #{valid_datetime} " \
+                                      "for Department with bitemporal_id=#{department.bitemporal_id}"
             end
           }
         end


### PR DESCRIPTION
This PR enhances error messages from https://github.com/kufu/activerecord-bitemporal/pull/136.

Improvements:
- Change "greater equal than" to "greater than or equal to" for clarity
- Add class name and bitemporal_id to error message for better debugging