### PR TITLE
Add explicit activesupport dependency

### DIFF
--- a/activerecord-bitemporal.gemspec
+++ b/activerecord-bitemporal.gemspec
@@ -23,7 +23,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 7.0"
+  rails_requirements = ">= 7.0"
+  spec.add_dependency "activerecord", rails_requirements
+  spec.add_dependency "activesupport", rails_requirements
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
This PR adds explicit activesupport dependency.

Previously, this gem relied on activesupport that was implicitly included through the activerecord dependency.

Since we directly require "active_support/core_ext/time/calculations" and use `ActiveSupport::Concern` and `ActiveSupport::CurrentAttributes`, we should declare an explicit dependency.

While it's unlikely that activesupport will be removed from activerecord's dependencies, we should have an explicit dependency since this gem uses it directly.