### PR TITLE
Configure dependabot cooldown period to 3 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
This PR adds cooldown configuration as a countermeasure against supply chain attacks.

- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#setting-up-a-cooldown-period-for-dependency-updates
- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-