### PR TITLE
Use bitemporal_id as primary key for Rails 8+ excluding/without 

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -160,7 +160,8 @@ module ActiveRecord
       if ActiveRecord.version >= Gem::Version.new("8.0.0")
         use_bitemporal_id_as_primary_key :ids
 
-        # Ensure that AR::Batches (https://github.com/rails/rails/blob/v8.0.4/activerecord/lib/active_record/relation/batches.rb)
+        # Ensure that AR::Batches
+        # (https://github.com/rails/rails/blob/v8.0.5/activerecord/lib/active_record/relation/batches.rb)
         # works with `bitemporal_id` as the primary key in Rails 8+.
         use_bitemporal_id_as_primary_key :find_each
         use_bitemporal_id_as_primary_key :find_in_batches

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -165,6 +165,12 @@ module ActiveRecord
         use_bitemporal_id_as_primary_key :find_each
         use_bitemporal_id_as_primary_key :find_in_batches
         use_bitemporal_id_as_primary_key :in_batches
+
+        # Ensure that `#excluding` and `#without`
+        # (https://github.com/rails/rails/blob/v8.0.5/activerecord/lib/active_record/relation/query_methods.rb#L1548-L1591)
+        # work with `bitemporal_id` as the primary key in Rails 8+.
+        use_bitemporal_id_as_primary_key :excluding
+        use_bitemporal_id_as_primary_key :without
       end
 
       def build_arel(*)

--- a/spec/activerecord-bitemporal/relation/excluding_spec.rb
+++ b/spec/activerecord-bitemporal/relation/excluding_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe "#excluding (#without)" do
+  def create_employees_with_history
+    Employee
+      .create!([{ name: "Jane" }, { name: "Tom" }, { name: "Bob" }])
+      .each { |e| e.update!(updated_at: Time.current) }
+  end
+
+  describe "#excluding" do
+    context "with record objects" do
+      let!(:employees) { create_employees_with_history }
+
+      it "excludes the specified record by bitemporal_id" do
+        excluded = employees[0]
+        result = Employee.excluding(excluded)
+        expect(result).to match_array [employees[1], employees[2]]
+        expect(result).not_to include(excluded)
+      end
+
+      it "excludes multiple records by bitemporal_id" do
+        result = Employee.excluding(employees[0], employees[1])
+        expect(result).to match_array [employees[2]]
+      end
+    end
+
+    context "with a Relation" do
+      let!(:employees) { create_employees_with_history }
+
+      it "excludes records from the relation" do
+        excluded_relation = Employee.where(name: "Jane")
+        result = Employee.excluding(excluded_relation)
+        expect(result).to match_array [employees[1], employees[2]]
+      end
+    end
+
+    context "on association" do
+      let!(:company) {
+        Company
+          .create!(name: "Company")
+          .tap { |c| c.employees << create_employees_with_history }
+      }
+
+      it "excludes the specified record" do
+        employees = company.employees.to_a
+        result = company.employees.excluding(employees[0])
+        expect(result).to match_array [employees[1], employees[2]]
+      end
+    end
+  end
+
+  describe "#without" do
+    let!(:employees) { create_employees_with_history }
+
+    it "is an alias for excluding" do
+      excluded = employees[0]
+      result = Employee.without(excluded)
+      expect(result).to match_array [employees[1], employees[2]]
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes the same problem as #251, but for AR::QueryMethods#excluding and #without.

- https://api.rubyonrails.org/v8.0.5/classes/ActiveRecord/QueryMethods.html#method-i-excluding
- https://github.com/rails/rails/blob/v8.0.5/activerecord/lib/active_record/relation/query_methods.rb#L1548-L1591

> `excluding` / `without` internally calls `predicate_builder[primary_key, records]`
> to build a NOT IN clause. Without the primary_key override, this generates
> `WHERE id NOT IN (...)` instead of `WHERE bitemporal_id NOT IN (...)`,
> causing incorrect record exclusion for bitemporal models with history.
> 
> This is the same class of issue fixed in PR https://github.com/kufu/activerecord-bitemporal/pull/251 for AR::Batches.