### PR TITLE
Increase Dependabot cooldown to 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,4 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 3
+      default-days: 7


### PR DESCRIPTION
## Summary

- Increase Dependabot cooldown from 3 days to 7 days

## Why

As a mitigation against supply chain attacks, extending the cooldown period gives the community more time to detect and report compromised packages before they are automatically proposed for an update in this repository.

## Changes

- Updated `default-days` from `3` to `7` in `.github/dependabot.yml`