### PR TITLE
Fix Relation#load to return self instead of an Array

### DIFF
--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -204,6 +204,8 @@ module ActiveRecord
           record.send(:bitemporal_option_storage)[:valid_datetime] = valid_datetime_ if valid_datetime_
           record.send(:bitemporal_option_storage)[:transaction_datetime] = transaction_datetime_ if transaction_datetime_
         end
+
+        records
       end
 
       # Use original primary_key for Active Record 8.0+ as much as possible

--- a/lib/activerecord-bitemporal/bitemporal.rb
+++ b/lib/activerecord-bitemporal/bitemporal.rb
@@ -184,9 +184,9 @@ module ActiveRecord
         return super if loaded?
 
         # このタイミングで先読みしているアソシエーションが読み込まれるので時間を固定
-        records = ActiveRecord::Bitemporal.with_bitemporal_option(**bitemporal_option) { super }
+        relation = ActiveRecord::Bitemporal.with_bitemporal_option(**bitemporal_option) { super }
 
-        return records if records.empty?
+        return relation if relation.empty?
 
         valid_datetime_ = valid_datetime
         if ActiveRecord::Bitemporal.valid_datetime.nil? && (bitemporal_value[:with_valid_datetime].nil? || bitemporal_value[:with_valid_datetime] == :default_scope || valid_datetime_.nil?)
@@ -198,14 +198,14 @@ module ActiveRecord
           transaction_datetime_ = nil
         end
 
-        return records if valid_datetime_.nil? && transaction_datetime_.nil?
+        return relation if valid_datetime_.nil? && transaction_datetime_.nil?
 
-        records.each do |record|
+        relation.each do |record|
           record.send(:bitemporal_option_storage)[:valid_datetime] = valid_datetime_ if valid_datetime_
           record.send(:bitemporal_option_storage)[:transaction_datetime] = transaction_datetime_ if transaction_datetime_
         end
 
-        records
+        relation
       end
 
       # Use original primary_key for Active Record 8.0+ as much as possible

--- a/spec/activerecord-bitemporal/relation/load_spec.rb
+++ b/spec/activerecord-bitemporal/relation/load_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ActiveRecord::Bitemporal::Relation do
+  describe "#load" do
+    let!(:employees) { Employee.create!([{ name: "Jane" }, { name: "Tom" }]) }
+
+    context "on relation" do
+      it "returns self" do
+        relation = Employee.all
+        expect(relation.load).to equal relation
+      end
+    end
+
+    context "on loaded relation" do
+      it "returns self" do
+        relation = Employee.all.load
+        expect(relation.load).to equal relation
+      end
+    end
+
+    context "with valid_at" do
+      it "returns self" do
+        relation = Employee.valid_at(Time.current)
+        expect(relation.load).to equal relation
+      end
+    end
+
+    context "with transaction_at" do
+      it "returns self" do
+        relation = Employee.transaction_at(Time.current)
+        expect(relation.load).to equal relation
+      end
+    end
+
+    context "on empty relation" do
+      it "returns self" do
+        relation = Employee.where(name: "Not Found").valid_at(Time.current)
+        expect(relation.load).to equal relation
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

ActiveRecord::Relation#load is expected to return the relation itself (self), not the records:

https://github.com/rails/rails/blob/v8.1.3/activerecord/lib/active_record/relation.rb#L1193-L1206

```
# Causes the records to be loaded from the database if they have not
# been loaded already. You can use this if for some reason you need
# to explicitly load some records before actually using them. The
# return value is the relation itself, not the records.
#
#   Post.where(published: true).load # => #<ActiveRecord::Relation>
def load(&block)
  if !loaded? || scheduled?
    @records = exec_queries(&block)
    @loaded = true
  end

  self
end

Employee.all.load                     #=> Employee::ActiveRecord_Relation
Employee.valid_at(Time.current).load  #=> Array
```

However, the bitemporal override of #load ended with records.each. Since Relation#each is delegated to records (the loaded Array) by ActiveRecord::Delegation, records.each returns the Array — which leaked out as the return value of #load when valid_datetime or transaction_datetime is set:

https://github.com/rails/rails/blob/v8.1.3/activerecord/lib/active_record/relation/delegation.rb#L100-L103
```
delegate :to_xml, :encode_with, :length, :each, :join, :intersect?,
         :[], :&, :|, :+, :-, :sample, :reverse, :rotate, :compact, :in_groups, :in_groups_of,
         :to_sentence, :to_fs, :to_formatted_s, :as_json,
         :shuffle, :split, :slice, :index, :rindex, to: :records
```

## Fix

Return records (the relation returned by super) at the end of #load, matching Active Record's contract that load returns self.

🤖 Generated with Claude Code